### PR TITLE
Two new modules for NIN and minor cleanup

### DIFF
--- a/src/data/STATUSES/NIN.js
+++ b/src/data/STATUSES/NIN.js
@@ -4,4 +4,10 @@ export default {
 		name: 'Vulnerability Up',
 		icon: 'https://secure.xivdb.com/img/game/015000/015020.png',
 	},
+
+	DUALITY: {
+		id: 790,
+		name: 'Duality',
+		icon: 'https://secure.xivdb.com/img/game/012000/012910.png',
+	},
 }

--- a/src/parser/jobs/nin/Duality.js
+++ b/src/parser/jobs/nin/Duality.js
@@ -3,7 +3,7 @@ import React, {Fragment} from 'react'
 
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
-//import STATUSES from 'data/STATUSES'
+import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
@@ -13,16 +13,17 @@ const DUALITY_GCDS = {
 	[ACTIONS.AEOLIAN_EDGE.id]: 0,
 	[ACTIONS.SHADOW_FANG.id]: 1,
 	[ACTIONS.ARMOR_CRUSH.id]: 1,
+	[ACTIONS.THROWING_DAGGER.id]: 1,
 }
 
 export default class Duality extends Module {
 	static handle = 'duality'
 	static dependencies = [
+		'combatants',
 		'suggestions',
 	]
 
 	_badDualityUses = 0
-	_dualityActive = false
 
 	constructor(...args) {
 		super(...args)
@@ -32,12 +33,9 @@ export default class Duality extends Module {
 
 	_onCast(event) {
 		const abilityId = event.ability.guid
-		
-		if (abilityId === ACTIONS.DUALITY.id) {
-			this._dualityActive = true
-		} else if (this._dualityActive && DUALITY_GCDS.hasOwnProperty(abilityId)) {
+
+		if (this.combatants.selected.hasStatus(STATUSES.DUALITY.id) && DUALITY_GCDS.hasOwnProperty(abilityId)) {
 			this._badDualityUses += DUALITY_GCDS[abilityId] // Aeolian won't increment this, everything else will
-			this._dualityActive = false
 		}
 	}
 

--- a/src/parser/jobs/nin/Duality.js
+++ b/src/parser/jobs/nin/Duality.js
@@ -1,0 +1,58 @@
+import React, {Fragment} from 'react'
+//import {Icon, Message} from 'semantic-ui-react'
+
+import {ActionLink} from 'components/ui/DbLink'
+import ACTIONS from 'data/ACTIONS'
+//import STATUSES from 'data/STATUSES'
+import Module from 'parser/core/Module'
+import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+
+const DUALITY_GCDS = {
+	[ACTIONS.SPINNING_EDGE.id]: 1,
+	[ACTIONS.GUST_SLASH.id]: 1,
+	[ACTIONS.AEOLIAN_EDGE.id]: 0,
+	[ACTIONS.SHADOW_FANG.id]: 1,
+	[ACTIONS.ARMOR_CRUSH.id]: 1,
+}
+
+export default class Duality extends Module {
+	static handle = 'duality'
+	static dependencies = [
+		'suggestions',
+	]
+
+	_badDualityUses = 0
+	_dualityActive = false
+
+	constructor(...args) {
+		super(...args)
+		this.addHook('cast', {by: 'player'}, this._onCast)
+		this.addHook('complete', this._onComplete)
+	}
+
+	_onCast(event) {
+		const abilityId = event.ability.guid
+		
+		if (abilityId === ACTIONS.DUALITY.id) {
+			this._dualityActive = true
+		} else if (this._dualityActive && DUALITY_GCDS.hasOwnProperty(abilityId)) {
+			this._badDualityUses += DUALITY_GCDS[abilityId] // Aeolian won't increment this, everything else will
+			this._dualityActive = false
+		}
+	}
+
+	_onComplete() {
+		if (this._badDualityUses > 0) {
+			this.suggestions.add(new Suggestion({
+				icon: ACTIONS.DUALITY.icon,
+				content: <Fragment>
+					Avoid using <ActionLink {...ACTIONS.DUALITY}/> on any GCDs besides <ActionLink {...ACTIONS.AEOLIAN_EDGE}/>. The side effects of the GCD aren&apos;t duplicated, only the damage, so your highest damage combo hit is always ideal.
+				</Fragment>,
+				severity: SEVERITY.MEDIUM,
+				why: <Fragment>
+					You used Duality {this._badDualityUses} time{this._badDualityUses !== 1 && 's'} on non-optimal GCDs.
+				</Fragment>,
+			}))
+		}
+	}
+}

--- a/src/parser/jobs/nin/Ninjutsu.js
+++ b/src/parser/jobs/nin/Ninjutsu.js
@@ -39,7 +39,7 @@ export default class Ninjutsu extends Module {
 			this.suggestions.add(new Suggestion({
 				icon: ACTIONS.HYOTON.icon,
 				content: <Fragment>
-					Avoid using <ActionLink {...ACTIONS.HYOTON}/>, as it's the weakest of the mudra combinations and should typically never be used in raid content.
+					Avoid using <ActionLink {...ACTIONS.HYOTON}/>, as it&apos;s the weakest of the mudra combinations and should typically never be used in raid content.
 				</Fragment>,
 				severity: SEVERITY.MINOR,
 				why: <Fragment>

--- a/src/parser/jobs/nin/Ninjutsu.js
+++ b/src/parser/jobs/nin/Ninjutsu.js
@@ -43,7 +43,7 @@ export default class Ninjutsu extends Module {
 				</Fragment>,
 				severity: SEVERITY.MINOR,
 				why: <Fragment>
-					You cast Hyoton {this._hyotonCount} times.
+					You cast Hyoton {this._hyotonCount} time{this._hyotonCount !== 1 && 's'}.
 				</Fragment>,
 			}))
 		}
@@ -56,7 +56,7 @@ export default class Ninjutsu extends Module {
 				</Fragment>,
 				severity: SEVERITY.MEDIUM,
 				why: <Fragment>
-					You cast Rabbit Medium {this._rabbitCount} times.
+					You cast Rabbit Medium {this._rabbitCount} time{this._rabbitCount !== 1 && 's'}.
 				</Fragment>,
 			}))
 		}

--- a/src/parser/jobs/nin/Ninki.js
+++ b/src/parser/jobs/nin/Ninki.js
@@ -9,18 +9,17 @@ import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
 // Constants
 const MAX_NINKI = 100
-const SPENDER_COST = 80
 
 const NINKI_BUILDERS = {
 	[ACTIONS.MUG.id]: 30,
 	[ACTIONS.ATTACK.id]: 6,
 }
 
-const NINKI_SPENDERS = [
-	ACTIONS.HELLFROG_MEDIUM.id,
-	ACTIONS.BHAVACAKRA.id,
-	ACTIONS.TEN_CHI_JIN.id,
-]
+const NINKI_SPENDERS = {
+	[ACTIONS.HELLFROG_MEDIUM.id]: 80,
+	[ACTIONS.BHAVACAKRA.id]: 80,
+	[ACTIONS.TEN_CHI_JIN.id]: 80,
+}
 
 export default class Ninki extends Module {
 	static handle = 'ninki'
@@ -54,8 +53,8 @@ export default class Ninki extends Module {
 			this._wasteBySource.auto += this._addNinki(abilityId)
 		}
 
-		if (NINKI_SPENDERS.includes(abilityId)) {
-			this._ninki -= SPENDER_COST
+		if (NINKI_SPENDERS.hasOwnProperty(abilityId)) {
+			this._ninki -= NINKI_SPENDERS[abilityId]
 		}
 	}
 

--- a/src/parser/jobs/nin/TrickAttackWindow.js
+++ b/src/parser/jobs/nin/TrickAttackWindow.js
@@ -28,15 +28,12 @@ export default class TrickAttackWindow extends Module {
 		const abilityId = event.ability.guid
 		
 		if (abilityId === ACTIONS.TRICK_ATTACK.id) {
-			console.log(`TA at ${event.timestamp}`)
 			this._taTimestamp = event.timestamp
 		} else if (abilityId === ACTIONS.DREAM_WITHIN_A_DREAM.id) {
-			console.log(`DWaD at ${event.timestamp}`)
 			if (event.timestamp - this._taTimestamp > TA_DURATION_MILLIS) {
 				this._dwadOutsideTa++
 			}
 		} else if (abilityId === ACTIONS.ARMOR_CRUSH.id) {
-			console.log(`AC at ${event.timestamp}`)
 			if (event.timestamp - this._taTimestamp <= TA_DURATION_MILLIS) {
 				this._armorCrushInTa++
 			}

--- a/src/parser/jobs/nin/TrickAttackWindow.js
+++ b/src/parser/jobs/nin/TrickAttackWindow.js
@@ -1,0 +1,73 @@
+import React, {Fragment} from 'react'
+//import {Icon, Message} from 'semantic-ui-react'
+
+import {ActionLink} from 'components/ui/DbLink'
+import ACTIONS from 'data/ACTIONS'
+import Module from 'parser/core/Module'
+import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+
+const TA_DURATION_MILLIS = 10000
+
+export default class TrickAttackWindow extends Module {
+	static handle = 'taWindow'
+	static dependencies = [
+		'suggestions',
+	]
+
+	_taTimestamp = -10000
+	_dwadOutsideTa = 0
+	_armorCrushInTa = 0
+
+	constructor(...args) {
+		super(...args)
+		this.addHook('cast', {by: 'player'}, this._onCast)
+		this.addHook('complete', this._onComplete)
+	}
+
+	_onCast(event) {
+		const abilityId = event.ability.guid
+		
+		if (abilityId === ACTIONS.TRICK_ATTACK.id) {
+			console.log(`TA at ${event.timestamp}`)
+			this._taTimestamp = event.timestamp
+		} else if (abilityId === ACTIONS.DREAM_WITHIN_A_DREAM.id) {
+			console.log(`DWaD at ${event.timestamp}`)
+			if (event.timestamp - this._taTimestamp > TA_DURATION_MILLIS) {
+				this._dwadOutsideTa++
+			}
+		} else if (abilityId === ACTIONS.ARMOR_CRUSH.id) {
+			console.log(`AC at ${event.timestamp}`)
+			if (event.timestamp - this._taTimestamp <= TA_DURATION_MILLIS) {
+				this._armorCrushInTa++
+			}
+		}
+	}
+
+	_onComplete() {
+		if (this._dwadOutsideTa > 0) {
+			this.suggestions.add(new Suggestion({
+				icon: ACTIONS.DREAM_WITHIN_A_DREAM.icon,
+				content: <Fragment>
+					Avoid using <ActionLink {...ACTIONS.DREAM_WITHIN_A_DREAM}/> outside of Trick Attack windows. Since they&apos;re both on 60 second cooldowns, they should always be paired to maximize DPS.
+				</Fragment>,
+				severity: SEVERITY.MEDIUM,
+				why: <Fragment>
+					You used Dream Within A Dream {this._dwadOutsideTa} time{this._dwadOutsideTa !== 1 && 's'} outside of Trick Attack.
+				</Fragment>,
+			}))
+		}
+
+		if (this._armorCrushInTa > 0) {
+			this.suggestions.add(new Suggestion({
+				icon: ACTIONS.ARMOR_CRUSH.icon,
+				content: <Fragment>
+					Avoid using <ActionLink {...ACTIONS.ARMOR_CRUSH}/> during Trick Attack windows. Unless Huton would otherwise fall off, <ActionLink {...ACTIONS.AEOLIAN_EDGE}/> or <ActionLink {...ACTIONS.SHADOW_FANG}/> are always preferable for the additional damage.
+				</Fragment>,
+				severity: SEVERITY.MEDIUM,
+				why: <Fragment>
+					You used Armor Crush {this._armorCrushInTa} time{this._armorCrushInTa !== 1 && 's'} during Trick Attack.
+				</Fragment>,
+			}))
+		}
+	}
+}

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -2,9 +2,11 @@ import About from './About'
 import Ninki from './Ninki'
 import Ninjutsu from './Ninjutsu'
 import NinWeaving from './NinWeaving'
+import TrickAttackWindow from './TrickAttackWindow'
 export default [
 	About,
 	Ninki,
 	Ninjutsu,
 	NinWeaving,
+	TrickAttackWindow,
 ]

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -1,12 +1,14 @@
 import About from './About'
-import Ninki from './Ninki'
+import Duality from './Duality'
 import Ninjutsu from './Ninjutsu'
+import Ninki from './Ninki'
 import NinWeaving from './NinWeaving'
 import TrickAttackWindow from './TrickAttackWindow'
 export default [
 	About,
-	Ninki,
+	Duality,
 	Ninjutsu,
+	Ninki,
 	NinWeaving,
 	TrickAttackWindow,
 ]

--- a/src/parser/jobs/nin/todo.txt
+++ b/src/parser/jobs/nin/todo.txt
@@ -1,6 +1,4 @@
 LOW HANGING FRUIT:
-DwaD not in Trick
-AC in Trick
 Duality not on AE
 SF clipping, Slashing falling off - This one sounds relatively easy.
 Trick not on CD

--- a/src/parser/jobs/nin/todo.txt
+++ b/src/parser/jobs/nin/todo.txt
@@ -1,5 +1,4 @@
 LOW HANGING FRUIT:
-Duality not on AE
 SF clipping, Slashing falling off - This one sounds relatively easy.
 Trick not on CD
 

--- a/src/parser/jobs/nin/todo.txt
+++ b/src/parser/jobs/nin/todo.txt
@@ -7,3 +7,6 @@ TCJ not counting against uptime
 Ninjustsu usage on CD
 GCD loss
 Wrong Ninki Usage
+
+IMPROVEMENTS ON EXISTING MODULES:
+TrickAttackWindow.js - use enemies module for debuff tracking rather than the current timer implementation


### PR DESCRIPTION
This NIN update includes a module for tracking Dream Within A Dream usage outside of Trick Attack windows and Armor Crush usage in them, as well as module for tracking Duality usage on any non-Aeolian Edge GCDs. I also tidied up a couple of things here and there to keep the code as clean and consistent as possible.