### PR TITLE
More Error Context!

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ Override this function if the module absolutely _needs_ to process events before
 
 Return value should be the `events` array, with any required modifications made to it. Failing to return this will prevent the parser from parsing any events at all.
 
+##### `getErrorContext(source, error, event)`
+
+Override this function to customize the information that the module provides for automatic
+error reporting. This function is called when an error occurs in event hooks or the
+`output()` method on the faulting module as well as all modules that module depends on.
+
+`source` is either `event` or `output`
+`error` is the error that occurred
+`event` is the error that was being processed when the error occurred, if applicable
+
+If this function is not overridden or if this function returns undefined, primitive values
+will be scraped from the module and uploaded with the error report.
+
 ### Parser
 
 The core parser object, orchestrating the modules and providing meta data about the fight. All modules have access to an instance of this via `this.parser`.

--- a/src/parser/core/Module.js
+++ b/src/parser/core/Module.js
@@ -48,6 +48,21 @@ export default class Module {
 		return events
 	}
 
+
+	/**
+	 * This method is called when an error occurs, either when running
+	 * event hooks or calling {@link Module#output} in this module or
+	 * a module that depends on this module.
+	 * @param {String} source Either 'event' or 'output'
+	 * @param {Error} error The error that occurred
+	 * @param {Object} event The event that was being processed when the error occurred, if source is 'event'
+	 * @returns {Object|undefined} The data to attach to automatic error reports, or undefined to rely on primitive value detection
+	 */
+	getErrorContext(source, error, event) {
+		return
+	}
+
+
 	addHook(events, filter, cb) {
 		const mapFilterEntity = (qol, raw) => {
 			if (filter[qol]) {

--- a/src/parser/core/Parser.js
+++ b/src/parser/core/Parser.js
@@ -146,6 +146,8 @@ class Parser {
 				// Error trying to handle an event, tell sentry
 				// But first, gather some extra context
 				const tags = {
+					type: 'event',
+					event: event.type,
 					job: this.player && this.player.type,
 					module: mod,
 				}
@@ -157,33 +159,25 @@ class Parser {
 					event,
 				}
 
-				// Try gathering extra data for the event from
-				// the module with the error.
-				let extraData = undefined
+				// Gather extra data for the error report.
+				const [data, errors] = this._gatherErrorContext(mod, 'event', error, event)
+				extra.modules = data
 
-				if (typeof this.modules[mod].onError === 'function') {
-					try {
-						extraData = this.modules[mod].onError(error, event)
-					} catch (errorTwo) {
-						Raven.captureException(errorTwo, {
-							tags,
-							extra,
-						})
-					}
-				}
-
-				if (extraData === undefined) {
-					extraData = extractErrorContext(this.modules[mod])
+				for (const [m, err] of errors) {
+					Raven.captureException(err, {
+						tags: {
+							...tags,
+							module: m,
+						},
+						extra,
+					})
 				}
 
 				// Now that we have all the possible context, submit the
 				// error to Raven.
 				Raven.captureException(error, {
 					tags,
-					extra: {
-						...extra,
-						moduleData: extraData,
-					},
+					extra,
 				})
 
 				// Also cascade the error through the dependency tree
@@ -204,6 +198,51 @@ class Parser {
 				this._setModuleError(key, new DependencyCascadeError({dependency: mod}))
 			}
 		})
+	}
+
+	/**
+	 * Get error context for the named module and all of its dependencies.
+	 * @param {String} mod The name of the module with the faulting code
+	 * @param {String} source Either 'event' or 'output'
+	 * @param {Error} error The error that we're gathering context for
+	 * @param {Object} event The event that was being processed when the error occurred
+	 * @returns {[Object, Object]} The resulting data along with an object containing errors that were encountered running getErrorContext methods.
+	 */
+	_gatherErrorContext(mod, source, error, event) {
+		const output = {}
+		const errors = []
+		const visited = new Set()
+
+		const crawler = m => {
+			visited.add(m)
+
+			const constructor = this._constructors[m]
+			const module = this.modules[m]
+
+			if (typeof module.getErrorContext === 'function') {
+				try {
+					output[m] = module.getErrorContext(source, error, event)
+				} catch (error) {
+					errors.push([m, error])
+				}
+			}
+
+			if (output[m] === undefined) {
+				output[m] = extractErrorContext(module)
+			}
+
+			if (constructor && Array.isArray(constructor.dependencies)) {
+				for (const dep of constructor.dependencies) {
+					if (!visited.has(dep)) {
+						crawler(dep)
+					}
+				}
+			}
+		}
+
+		crawler(mod)
+
+		return [output, errors]
 	}
 
 	// -----
@@ -236,7 +275,45 @@ class Parser {
 				if (process.env.NODE_ENV === 'development') {
 					throw error
 				}
-				Raven.captureException(error)
+
+				// Error generating output for a module. Tell Sentry, but first,
+				// gather some extra context
+
+				const tags = {
+					type: 'output',
+					job: this.player && this.player.type,
+					module: mod,
+				}
+
+				const extra = {
+					report: this.report && this.report.code,
+					fight: this.fight && this.fight.id,
+					player: this.player && this.player.id,
+				}
+
+				// Gather extra data for the error report.
+				const [data, errors] = this._gatherErrorContext(mod, 'output', error, null)
+				extra.modules = data
+
+				for (const [m, err] of errors) {
+					Raven.captureException(err, {
+						tags: {
+							...tags,
+							module: m,
+						},
+						extra,
+					})
+				}
+
+				// Now that we have all the possible context, submit the
+				// error to Raven.
+				Raven.captureException(error, {
+					tags,
+					extra,
+				})
+
+
+				// Also add the error to the results to be displayed.
 				results.push({
 					name: module.constructor.title,
 					markup: <ErrorMessage error={error} />,


### PR DESCRIPTION
* Better name for the data gathering function
* Default no-op implementation of the function with JSDocs
* Document the function in README
* Add a couple more tags to reports
* Add all this stuff to `output()` errors as well as event hook errors.