### PR TITLE
Added Hellfrog misuse to the Ninki module and reordered functions a bit

### DIFF
--- a/src/data/ACTIONS/NIN.js
+++ b/src/data/ACTIONS/NIN.js
@@ -139,7 +139,7 @@ export default {
 		name: 'Hellfrog Medium',
 		icon: 'https://secure.xivdb.com/img/game/002000/002920.png',
 		onGcd: false,
-		cooldown: 0,
+		cooldown: 0.5, // Not strictly accurate, but it has to be >0 to display on the timeline. Hellfrog is weird.
 	},
 
 	BHAVACAKRA: {

--- a/src/parser/jobs/nin/todo.txt
+++ b/src/parser/jobs/nin/todo.txt
@@ -1,12 +1,10 @@
 LOW HANGING FRUIT:
-SF clipping, Slashing falling off - This one sounds relatively easy.
 Trick not on CD
 
 NEEDS RESEARCH:
 TCJ not counting against uptime
 Ninjustsu usage on CD
 GCD loss
-Wrong Ninki Usage
 
 IMPROVEMENTS ON EXISTING MODULES:
 TrickAttackWindow.js - use enemies module for debuff tracking rather than the current timer implementation


### PR DESCRIPTION
Update to the Ninki module - it now yells at you for using Hellfrog on single targets when you have Bhava and/or TCJ available for use. 1-2 uses is flagged as minor, since there are some legitimate excuses (e.g. lots of movement for mechanics so you can't pop TCJ).