### PR TITLE
Fix English i18n Desync

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -59,7 +59,7 @@
     ]
   },
   "core.always-cast.description": {
-    "translation": "core.always-cast.description",
+    "translation": "Make sure you're always doing something. It's often better to make small mistakes while keeping the GCD rolling than it is to perform the correct rotation slowly.",
     "defaults": "Make sure you're always doing something. It's often better to make small mistakes while keeping the GCD rolling than it is to perform the correct rotation slowly.",
     "origin": [
       [
@@ -69,7 +69,7 @@
     ]
   },
   "core.always-cast.gcd-uptime": {
-    "translation": "core.always-cast.gcd-uptime",
+    "translation": "GCD Uptime",
     "defaults": "GCD Uptime",
     "origin": [
       [
@@ -79,7 +79,7 @@
     ]
   },
   "core.always-cast.title": {
-    "translation": "core.always-cast.title",
+    "translation": "Always be casting",
     "defaults": "Always be casting",
     "origin": [
       [
@@ -306,7 +306,7 @@
     ]
   },
   "core.potions.why": {
-    "translation": "core.potions.why",
+    "translation": "Used a short potion instead of an infusion.",
     "defaults": "Used a short potion instead of an infusion.",
     "origin": [
       [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test": "react-app-rewired test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint src",
-    "extract": "rimraf locale/_build && cross-env NODE_ENV=development lingui extract",
+    "extract": "rimraf locale/_build && rimraf locale/en && lingui add-locale en && cross-env NODE_ENV=development lingui extract",
     "compile": "lingui compile"
   },
   "browserslist": {


### PR DESCRIPTION
lingui's extractor is still a bit weird, and it can cache outdated English locale strings. To fix that, this commit just changes the extract command to entirely delete and re-add the en locale.

This might need to change in the future depending on how we set up localization of actions and the like, but it should work for now.