### PR TITLE
Add url whitelisting for Sentry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,11 @@ if (NODE_ENV === 'production' && REACT_APP_RAVEN_DSN) {
 		environment: NODE_ENV,
 		release: VERSION,
 
+		whitelistUrls: [
+			// All our project's JavaScript should be loaded from /static/
+			/xivanalysis\.com\/static/,
+		],
+
 		ignoreUrls: [
 			// Browser Extensions
 			/extensions\//i,


### PR DESCRIPTION
Forgot this was an option when I was setting things up. All our JavaScript loads from `xivanalysis.com/static/ ` so we may as well just whitelist that specific path to cut out more of the junk from browser extensions and other weird situations.