### PR TITLE
Scope VS code project to /src

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,5 +3,9 @@
 		"target": "es6",
 		"module": "commonjs",
 		"baseUrl": "./src"
-	}
+	},
+
+	"include": [
+        "src/**/*"
+    ]
 }


### PR DESCRIPTION
Changed the jsconfig.json to only include /src/**/* as it's scope so auto-fill/intellisense doesn't spend years to load.