### PR TITLE
Added SwiftCast to tracked CDs after discussion with Ari

### DIFF
--- a/src/parser/jobs/rdm/GeneralCDDowntime.js
+++ b/src/parser/jobs/rdm/GeneralCDDowntime.js
@@ -10,5 +10,6 @@ export default class GeneralCDDowntime extends CooldownDowntime {
 		ACTIONS.ACCELERATION.id,
 		ACTIONS.CORPS_A_CORPS.id,
 		ACTIONS.DISPLACEMENT.id,
+		ACTIONS.SWIFTCAST.id,
 	]
 }


### PR DESCRIPTION
Ari informed me my understanding of SwiftCast was mistaken and that it should be used as soon as pretty much any proc slot was available, instead of only to fish for procs when no procs were available.  As such I have added it to the tracked CDs for RDMs