### PR TITLE
Automatic Language Detection

### DIFF
--- a/src/components/I18nLoader.js
+++ b/src/components/I18nLoader.js
@@ -109,6 +109,6 @@ export class I18nLoader extends Component {
 }
 
 export default connect(state => ({
-	language: state.language,
+	language: state.language.site,
 	overlay: state.i18nOverlay,
 }))(I18nLoader)

--- a/src/components/ui/DbLink.js
+++ b/src/components/ui/DbLink.js
@@ -113,7 +113,7 @@ export class DbLink extends Component {
 }
 
 const Wrapped = connect(state => ({
-	language: state.language,
+	language: state.language.site,
 }))(DbLink)
 
 export default Wrapped

--- a/src/components/ui/I18nMenu.js
+++ b/src/components/ui/I18nMenu.js
@@ -89,6 +89,6 @@ export class I18nMenu extends Component {
 }
 
 export default connect(state => ({
-	language: state.language,
+	language: state.language.site,
 	overlay: state.i18nOverlay,
 }))(I18nMenu)

--- a/src/data/LANGUAGES.js
+++ b/src/data/LANGUAGES.js
@@ -1,3 +1,5 @@
+import {stringBefore} from 'utilities'
+
 const LANGUAGES = {
 	en: {
 		menu: {
@@ -41,6 +43,14 @@ export const LANGUAGE_ARRAY = Object.entries(LANGUAGES)
 		}
 		return val
 	})
+
+export const SHORT_LANGUAGE_MAP = Object.keys(LANGUAGES).reduce(
+	(x, key) => {
+		x[stringBefore(key, '-')] = key
+		return x
+	},
+	{}
+)
 
 export default LANGUAGES
 

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -69,6 +69,11 @@ export const setLanguage = language => ({
 	payload: language,
 })
 
+export const UPDATE_LANGUAGE = 'UPDATE_LANGUAGE'
+export const updateLanguage = () => ({
+	type: UPDATE_LANGUAGE,
+})
+
 export const TOGGLE_I18N_OVERLAY = 'TOGGLE_I18N_OVERLAY'
 export const toggleI18nOverlay = () => ({
 	type: TOGGLE_I18N_OVERLAY,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,6 +2,7 @@ import {createStore, applyMiddleware} from 'redux'
 import thunkMiddleware from 'redux-thunk'
 
 import {loadState, saveState} from './storage'
+import {updateLanguage} from './actions'
 
 import reducers from './reducers'
 
@@ -16,6 +17,10 @@ function configureStore(preloadedState) {
 
 	store.subscribe(() => {
 		saveState(store.getState())
+	})
+
+	window.addEventListener('languagechange', () => {
+		store.dispatch(updateLanguage())
 	})
 
 	return store

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -2,7 +2,7 @@ import {combineReducers} from 'redux'
 
 import * as ActionTypes from './actions'
 
-import {DEFAULT_LANGUAGE} from 'data/LANGUAGES'
+import {getUserLanguage} from 'utilities'
 
 const report = (state=null, action) => {
 	if (action.type === ActionTypes.SET_REPORT) {
@@ -22,11 +22,34 @@ const globalError = (state=null, action) => {
 	}
 }
 
-const language = (state=DEFAULT_LANGUAGE, action) => {
+const language = (state=null, action) => {
+	if (!state || typeof state !== 'object') {
+		state = {
+			site_set: false,
+			site: getUserLanguage(),
+		}
+	}
+
 	switch (action.type) {
 	case ActionTypes.SET_LANGUAGE:
-		return action.payload
+		return {
+			...state,
+			site_set: true,
+			site: action.payload,
+		}
+
+	case ActionTypes.UPDATE_LANGUAGE:
 	default:
+		if (!state.site_set || !state.site) {
+			const site = getUserLanguage()
+			if (site !== state.site) {
+				return {
+					...state,
+					site: getUserLanguage(),
+				}
+			}
+		}
+
 		return state
 	}
 }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,5 +1,5 @@
 import {matchPath} from 'react-router-dom'
-import LANGUAGES, {DEFAULT_LANGUAGE} from 'data/LANGUAGES'
+import LANGUAGES, {SHORT_LANGUAGE_MAP, DEFAULT_LANGUAGE} from 'data/LANGUAGES'
 
 export const addExtraIndex = (obj, index) => {
 	Object.keys(obj).forEach(key => {
@@ -181,15 +181,8 @@ export function getUserLanguage(languages = null) {
 
 	// In case we didn't get a match, try matching just the first part of each
 	// language. It's better than falling  back to nothing. This may be overkill.
-	const stripped = Object.keys(LANGUAGES).reduce(
-		(x, key) => {
-			x[stringBefore(key, '-')] = key
-			return x
-		},
-		{})
-
 	for (const lang of languages.map(l => stringBefore(l, '-'))) {
-		const match = stripped[lang]
+		const match = SHORT_LANGUAGE_MAP[lang]
 		if (LANGUAGES[match] && LANGUAGES[match].enable) {
 			return match
 		}

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,4 +1,5 @@
 import {matchPath} from 'react-router-dom'
+import LANGUAGES, {DEFAULT_LANGUAGE} from 'data/LANGUAGES'
 
 export const addExtraIndex = (obj, index) => {
 	Object.keys(obj).forEach(key => {
@@ -144,4 +145,55 @@ export const matchClosestHigher = _matchClosestHoF((value, baseValue) => value -
 export function formatDuration(duration) {
 	const seconds = Math.floor(duration % 60)
 	return `${Math.floor(duration / 60)}:${seconds < 10? '0' : ''}${seconds}`
+}
+
+/**
+ * Get a slice of a string up until the first instance of a sub-string.
+ * @param {String} haystack The string to slice
+ * @param {String} needle The sub-string to search for
+ * @returns {String} All of string before needle
+ */
+export function stringBefore(haystack, needle) {
+	const idx = haystack.indexOf(needle)
+	return idx === -1 ? haystack : haystack.slice(0, idx)
+}
+
+/**
+ * Iterate over a list of languages and return the first matching, enabled language.
+ * Returns the default language if none match.
+ * @param {String[]} [languages] An array of languages to check, defaults to `navigator.languages`
+ * @returns {String} Language Code
+ */
+export function getUserLanguage(languages = null) {
+	if (!languages) {
+		if (Array.isArray(navigator.languages)) {
+			languages = navigator.languages
+		} else {
+			languages = [navigator.language]
+		}
+	}
+
+	for (const lang of languages) {
+		if (LANGUAGES[lang] && LANGUAGES[lang].enable) {
+			return lang
+		}
+	}
+
+	// In case we didn't get a match, try matching just the first part of each
+	// language. It's better than falling  back to nothing. This may be overkill.
+	const stripped = Object.keys(LANGUAGES).reduce(
+		(x, key) => {
+			x[stringBefore(key, '-')] = key
+			return x
+		},
+		{})
+
+	for (const lang of languages.map(l => stringBefore(l, '-'))) {
+		const match = stripped[lang]
+		if (LANGUAGES[match] && LANGUAGES[match].enable) {
+			return match
+		}
+	}
+
+	return DEFAULT_LANGUAGE
 }


### PR DESCRIPTION
This PR sets up automatic language detection using `navigator.languages`, and it additionally updates the format for language data in the redux store so that we can hopefully do more complex things in the future. I want to eventually add a setting to let users specify their preferred game language to show actions, etc. in that rather than their site language.

This also listens for an language change events to respond to them. Probably not anything that'll happen with any sort of frequency, but it's almost effortless so we may as well.