### PR TITLE
Fix lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   "lint-staged": {
     "linters": {
       "src/**/*.js": [
-        "eslint --fix",
-        "git add"
+        "eslint --fix --max-warnings 0"
       ]
     }
   },


### PR DESCRIPTION
Husky currently changes your staged changes and commits whatever it feels like without any user input. It's annoying but also breaks `git add --patch` via the `git add` at the end. This PR removes the auto add and sets the commit to fail if linting doesn't pass, while still applying the fixes for the user to review. I don't know how this comment turned out so long.