### PR TITLE
Glossary Terms and More Powerful Markdown

### DIFF
--- a/src/components/ui/GlossaryTerm.js
+++ b/src/components/ui/GlossaryTerm.js
@@ -1,0 +1,60 @@
+import {withI18n} from '@lingui/react'
+import PropTypes from 'prop-types'
+import React, {PureComponent} from 'react'
+import {Popup, Icon} from 'semantic-ui-react'
+import ReactMarkdown from 'react-markdown'
+
+import styles from './GlossaryTerm.module.css'
+import TERMS from 'data/GLOSSARY'
+
+class GlossaryTerm extends PureComponent {
+	static propTypes = {
+		term: PropTypes.oneOfType([
+			PropTypes.string,
+			PropTypes.shape({
+				i18n_id: PropTypes.string.isRequired,
+				text: PropTypes.string.isRequired,
+				i18n_description: PropTypes.string.isRequired,
+				description: PropTypes.string.isRequired,
+			}),
+		]).isRequired,
+		i18n: PropTypes.shape({
+			_: PropTypes.func.isRequired,
+		}).isRequired,
+		children: PropTypes.node,
+	}
+
+	render() {
+		const {i18n, children} = this.props
+		let {term} = this.props
+		if (TERMS[term]) {
+			term = TERMS[term]
+		}
+
+		const title = i18n._(term.i18n_id, {}, {defaults: term.text})
+
+		return <Popup
+			trigger={<span className={styles.term}>{children || title}</span>}
+			hoverable={term.interactive}
+			wide={term.width || 'very'}
+		>
+			<Popup.Header>
+				<Icon name="info" />
+				{ title }
+			</Popup.Header>
+			<Popup.Content>
+				<ReactMarkdown
+					source={i18n._(term.i18n_description, {}, {defaults: term.description})}
+					renderers={{
+						link: props => React.createElement('a', {
+							target: '_blank',
+							href: props.href,
+						}, props.children),
+					}}
+				/>
+			</Popup.Content>
+		</Popup>
+	}
+}
+
+export default withI18n()(GlossaryTerm)

--- a/src/components/ui/GlossaryTerm.js
+++ b/src/components/ui/GlossaryTerm.js
@@ -2,10 +2,11 @@ import {withI18n} from '@lingui/react'
 import PropTypes from 'prop-types'
 import React, {PureComponent} from 'react'
 import {Popup, Icon} from 'semantic-ui-react'
-import ReactMarkdown from 'react-markdown'
 
 import styles from './GlossaryTerm.module.css'
 import TERMS from 'data/GLOSSARY'
+
+import TransMarkdown from './TransMarkdown'
 
 class GlossaryTerm extends PureComponent {
 	static propTypes = {
@@ -43,14 +44,10 @@ class GlossaryTerm extends PureComponent {
 				{ title }
 			</Popup.Header>
 			<Popup.Content>
-				<ReactMarkdown
-					source={i18n._(term.i18n_description, {}, {defaults: term.description})}
-					renderers={{
-						link: props => React.createElement('a', {
-							target: '_blank',
-							href: props.href,
-						}, props.children),
-					}}
+				<TransMarkdown
+					id={term.i18n_description}
+					source={term.description}
+					linkTarget="_blank"
 				/>
 			</Popup.Content>
 		</Popup>

--- a/src/components/ui/GlossaryTerm.module.css
+++ b/src/components/ui/GlossaryTerm.module.css
@@ -1,0 +1,3 @@
+.term {
+	border-bottom: 1px dotted;
+}

--- a/src/components/ui/TransMarkdown.js
+++ b/src/components/ui/TransMarkdown.js
@@ -1,21 +1,29 @@
 import {withI18n} from '@lingui/react'
 import PropTypes from 'prop-types'
-import React, {Component} from 'react'
+import React, {PureComponent} from 'react'
 import ReactMarkdown from 'react-markdown'
 
-class TransMarkdown extends Component {
+class TransMarkdown extends PureComponent {
 	static propTypes = {
 		id: PropTypes.string.isRequired,
 		i18n: PropTypes.shape({
 			_: PropTypes.func.isRequired,
 		}).isRequired,
 		source: PropTypes.string.isRequired,
+		linkTarget: PropTypes.string,
 	}
+
 	render() {
-		const {id, i18n, source} = this.props
+		const {id, i18n, source, linkTarget} = this.props
 
 		return <ReactMarkdown
 			source={i18n._(id, {}, {defaults: source})}
+			renderers={{
+				link: props => React.createElement('a', {
+					target: linkTarget,
+					href: props.href,
+				}, props.children),
+			}}
 		/>
 	}
 }

--- a/src/components/ui/TransMarkdown.js
+++ b/src/components/ui/TransMarkdown.js
@@ -33,10 +33,6 @@ const LINK_TYPES = {
 		})
 	},
 
-	test: (href, children) => {
-		return <b>{href} ({children})</b>
-	},
-
 	status: (statusID, children) => {
 		if (STATUSES[statusID]) {
 			statusID = STATUSES[statusID].id

--- a/src/components/ui/TransMarkdown.js
+++ b/src/components/ui/TransMarkdown.js
@@ -3,6 +3,54 @@ import PropTypes from 'prop-types'
 import React, {PureComponent} from 'react'
 import ReactMarkdown from 'react-markdown'
 
+import ACTIONS from 'data/ACTIONS'
+import STATUSES from 'data/STATUSES'
+
+import GlossaryTerm from './GlossaryTerm'
+import {ActionLink, StatusLink} from './DbLink'
+
+// This line is required because eslint thinks LINK_TYPES is
+// full of React components when it's not.
+/* eslint react/display-name: 0 */
+
+const LINK_EXTRACTOR = /^~([^/]+)\/(.+)$/
+
+const LINK_TYPES = {
+	term: (term, children) => React.createElement(GlossaryTerm, {
+		term,
+	}, children),
+
+	action: (actionID, children) => {
+		if (ACTIONS[actionID]) {
+			actionID = ACTIONS[actionID].id
+		} else {
+			actionID = parseInt(actionID, 10)
+		}
+
+		return React.createElement(ActionLink, {
+			id: actionID,
+			name: children,
+		})
+	},
+
+	test: (href, children) => {
+		return <b>{href} ({children})</b>
+	},
+
+	status: (statusID, children) => {
+		if (STATUSES[statusID]) {
+			statusID = STATUSES[statusID].id
+		} else {
+			statusID = parseInt(statusID, 10)
+		}
+
+		return React.createElement(StatusLink, {
+			id: statusID,
+			name: children,
+		})
+	},
+}
+
 class TransMarkdown extends PureComponent {
 	static propTypes = {
 		id: PropTypes.string.isRequired,
@@ -10,19 +58,44 @@ class TransMarkdown extends PureComponent {
 			_: PropTypes.func.isRequired,
 		}).isRequired,
 		source: PropTypes.string.isRequired,
+		renderers: PropTypes.object,
 		linkTarget: PropTypes.string,
 	}
 
+	renderLink(data) {
+		const match = LINK_EXTRACTOR.exec(data.href)
+		if (match) {
+			const factory = LINK_TYPES[match[1]]
+			if (factory) {
+				return factory(match[2], data.isReference ? null : data.children)
+			}
+		}
+
+		return React.createElement('a', {
+			target: this.props.linkTarget,
+			href: data.href,
+		}, data.children)
+	}
+
 	render() {
-		const {id, i18n, source, linkTarget} = this.props
+		const {id, i18n, source, renderers} = this.props
 
 		return <ReactMarkdown
 			source={i18n._(id, {}, {defaults: source})}
 			renderers={{
-				link: props => React.createElement('a', {
-					target: linkTarget,
-					href: props.href,
-				}, props.children),
+				...renderers,
+				link: props => this.renderLink(props),
+
+				// This breaks reference style links in Markdown, and
+				// I'm not sure why, but I'm also almost certain no one
+				// is going to use them, while this is important for
+				// allowing people to use links to insert rich content
+				// like action links.
+				linkReference: props => this.renderLink({
+					...props,
+					isReference: true,
+					href: props.children[0],
+				}),
 			}}
 		/>
 	}

--- a/src/data/GLOSSARY.js
+++ b/src/data/GLOSSARY.js
@@ -6,7 +6,9 @@ const TERMS = {
 		text: 'proc',
 
 		i18n_description: i18nMark('core.glossary.proc-description'),
-		description: 'proc stands for programmed random occurence.',
+		description: `Proc is a term used in gaming to refer to an event (a "procedure") that is triggered under certain circumstances.
+
+For example, [~action/VERTHUNDER] has a 50% chance of triggering the status [~status/VERFIRE_READY] when cast.`,
 	},
 }
 

--- a/src/data/GLOSSARY.js
+++ b/src/data/GLOSSARY.js
@@ -1,0 +1,13 @@
+import {i18nMark} from '@lingui/react'
+
+const TERMS = {
+	PROC: {
+		i18n_id: i18nMark('core.glossary.proc'),
+		text: 'proc',
+
+		i18n_description: i18nMark('core.glossary.proc-description'),
+		description: 'proc stands for programmed random occurence.',
+	},
+}
+
+export default TERMS


### PR DESCRIPTION
This PR accomplishes two things.

1. Define a `<GlossaryTerm />` tag for defining terms that might need to be explained for users, with tooltips on hover that are formatted with markdown and support i18n.
2. Extend `<TransMarkdown />` to do special rendering for markdown links, allowing us to inject custom content such as `<GlossaryTerm />`s, `<ActionLink />`s, and `<StatusLink />`s.

The custom link renderer seems to break reference-style links in markdown, but those are probably never going to actually be used so it doesn't really matter.