### PR TITLE
Rewrite <DbLink /> to ditch the XIVDB Tooltip JS Library

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -16,6 +16,8 @@
   "core.cooldowndowntime.ogcd-cd-metric": "",
   "core.cooldowndowntime.title": "",
   "core.cooldowndowntime.use-ogcd-cds": "",
+  "core.dblink.loading": "",
+  "core.dblink.not-found": "",
   "core.deaths.content": "",
   "core.deaths.why": "",
   "core.error.generic": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -16,6 +16,8 @@
   "core.cooldowndowntime.ogcd-cd-metric": "Always make sure to use your OGCDs when they are up but don't clip them.  {0}",
   "core.cooldowndowntime.title": "core.cooldowndowntime.title",
   "core.cooldowndowntime.use-ogcd-cds": "Use your OGCDs",
+  "core.dblink.loading": "Loading...",
+  "core.dblink.not-found": "Unable to Load",
   "core.deaths.content": "Don't die. Between downtime, lost gauge resources, and resurrection debuffs, dying is absolutely <0>crippling</0> to damage output.",
   "core.deaths.why": "{0, plural, =1 {# death} other {# deaths}}",
   "core.error.generic": "Looks like something has gone wrong. The code monkies have been notified.",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -16,6 +16,8 @@
   "core.cooldowndowntime.ogcd-cd-metric": "",
   "core.cooldowndowntime.title": "",
   "core.cooldowndowntime.use-ogcd-cds": "",
+  "core.dblink.loading": "",
+  "core.dblink.not-found": "",
   "core.deaths.content": "",
   "core.deaths.why": "",
   "core.error.generic": "",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -16,6 +16,8 @@
   "core.cooldowndowntime.ogcd-cd-metric": "",
   "core.cooldowndowntime.title": "",
   "core.cooldowndowntime.use-ogcd-cds": "",
+  "core.dblink.loading": "",
+  "core.dblink.not-found": "",
   "core.deaths.content": "",
   "core.deaths.why": "",
   "core.error.generic": "",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "semantic-ui-react": "^0.82",
     "stable": "^0.1.8",
     "toposort": "^2",
+    "url-search-params-polyfill": "^4.0.1",
     "vis": "^4.21.0"
   },
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,5 @@
 			You need to enable JavaScript to run this app.
 		</noscript>
 		<div id="root"></div>
-		<script type="text/javascript" src="//secure.xivdb.com/tooltips.js" async></script>
 	</body>
 </html>

--- a/src/components/ui/DbLink.js
+++ b/src/components/ui/DbLink.js
@@ -1,114 +1,235 @@
 import PropTypes from 'prop-types'
-import React, {Component} from 'react'
+import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import Observer from 'react-intersection-observer'
+import {Popup, Icon} from 'semantic-ui-react'
+import {Trans} from '@lingui/react'
+
+import _ from 'lodash'
+
+import styles from './DbLink.module.css'
 
 import LANGUAGES from 'data/LANGUAGES'
 
-// Polyfill
-import 'intersection-observer'
+function getTooltipCacheBuster() {
+	const now = new Date()
+	return `${now.getFullYear()}${now.getDate()}`
+}
 
-// -----
-// Main link component
-// -----
-export class DbLink extends Component {
-	static propTypes = {
-		type: PropTypes.string.isRequired,
-		id: PropTypes.number.isRequired,
-		name: PropTypes.string,
-		language: PropTypes.string.isRequired,
-	};
+export class XIVDBTooltipProvider {
+	static _instance = null
 
-	hasLoaded = false
-
-	constructor(props) {
-		super(props)
-
-		this.state = {
-			language: props.language,
+	static getInstance() {
+		if (this._instance) {
+			return this._instance
 		}
+
+		return this._instance = new this()
 	}
 
-	onObserverChange(isVisible) {
-		if (!this.hasLoaded && isVisible) {
-			// Might take a little bit for the tooltip lib to be ready, so just wait it out
-			const waitForTooltips = () => {
-				if (window.XIVDBTooltips) {
-					this.refreshTooltips()
-				} else {
-					setTimeout(waitForTooltips, 100)
-				}
+	constructor(source = 'https://secure.xivdb.com', delay = 50) {
+		this.source = source
+
+		this.cache = {}
+		this.pending = {}
+
+		// Make sure we have the styles
+		const tooltipStyle = document.createElement('link')
+		tooltipStyle.href = `${this.source}/tooltips.css?v=${getTooltipCacheBuster()}`
+		tooltipStyle.rel = 'stylesheet'
+		tooltipStyle.type = 'text/css'
+
+		document.head.appendChild(tooltipStyle)
+
+		// Debounce our processing method to avoid API spam.
+		this.run = _.debounce(this._process.bind(this), delay)
+	}
+
+	_process() {
+		const pending = this.pending
+		this.pending = {}
+
+		for (const [language, types] of Object.entries(pending)) {
+			const languageCache = this.cache[language] = this.cache[language] || {}
+			const params = new URLSearchParams()
+			params.append('language', language)
+
+			for (const [type, values] of Object.entries(types)) {
+				params.append(`list[${type}]`, values)
 			}
-			waitForTooltips()
-		}
-	}
 
-	componentDidUpdate() {
-		// If the language changes, we'll need to update the tooltip.
-		if (this.state.language !== this.props.language) {
-			this.setState({
-				language: this.props.language,
-			}, () => {
-				if (window.XIVDBTooltips) {
-					this.refreshTooltips()
+			fetch(`${this.source}/tooltip?t=${Date.now()}`, {
+				method: 'POST',
+				body: params,
+
+			}).then(resp => resp.json()).then(data => {
+				if (! data || typeof data !== 'object') {
+					console.log('Invalid Response from Tooltip Provider', data)
+					data = {}
+				}
+
+				for (const type of Object.keys(types)) {
+					const typeCache = languageCache[type] = languageCache[type] || {}
+					const typeData = data[type]
+					if (Array.isArray(typeData)) {
+						for (const entry of typeData) {
+							const id = entry && entry.data && entry.data.id
+							const cached = typeCache[id]
+							if (cached && !cached.done) {
+								cached.done = true
+								cached.value = entry
+								for (const promise of cached.waiting) {
+									promise(entry)
+								}
+								cached.waiting = null
+							}
+						}
+					} else {
+						for (const entry of Object.values(types[type])) {
+							const cached = typeCache[entry]
+							if (cached && !cached.done) {
+								cached.done = true
+								cached.value = null
+								for (const promise of cached.waiting) {
+									promise(null)
+								}
+								cached.waiting = null
+							}
+						}
+					}
 				}
 			})
 		}
 	}
 
-	refreshTooltips() {
-		/* global XIVDBTooltips: true */
+	get(type, id, language) {
+		const languageCache = this.cache[language] = this.cache[language] || {}
+		const typeCache = languageCache[type] = languageCache[type] || {}
+		const cached = typeCache[id]
+		if (cached) {
+			if (cached.done) {
+				return Promise.resolve(cached.value)
+			}
 
-		// Set the appropriate language in XIVDB settings. Set it in
-		// the options. Set it in the instance itself if the library
-		// is already initialized.
-		const lang = LANGUAGES[this.props.language].tooltip
-
-		window.xivdb_tooltips = {
-			...window.xivdb_tooltips,
-			language: lang,
+			return new Promise(s => cached.waiting.push(s))
 		}
 
-		if (XIVDBTooltips.options) {
-			XIVDBTooltips.options.language = lang
+		const cache = typeCache[id] = {done: false, waiting: []}
+
+		const languagePending = this.pending[language] = this.pending[language] || {}
+		const typePending = languagePending[type] = languagePending[type] || []
+		typePending.push(id)
+
+		this.run.cancel()
+		this.run()
+
+		return new Promise(s => cache.waiting.push(s))
+	}
+}
+
+/**
+ * Render a link, automatically populated with an icon, name, and rich tooltip
+ * with data from XIVDB.
+ */
+export class DbLink extends PureComponent {
+	static defaultProps = {
+		useColors: true,
+		darkenColors: true,
+		showIcon: true,
+		showTooltip: true,
+	}
+
+	static propTypes = {
+		provider: PropTypes.instanceOf(XIVDBTooltipProvider),
+		language: PropTypes.string.isRequired,
+
+		type: PropTypes.string.isRequired,
+		id: PropTypes.number.isRequired,
+		children: PropTypes.node,
+
+		showIcon: PropTypes.bool.isRequired,
+		showTooltip: PropTypes.bool.isRequired,
+		useColors: PropTypes.bool.isRequired,
+		darkenColors: PropTypes.bool.isRequired,
+	}
+
+	constructor(props) {
+		super(props)
+
+		this.state = {
+			provider: this.props.provider || XIVDBTooltipProvider.getInstance(),
+			loading: true,
+			data: null,
 		}
 
-		// Clear the tooltip data attributes from our link to ensure
-		// that XIVDB's tooltip helper doesn't just used cached data.
-		if (this.link) {
-			this.link.removeAttribute('data-xivdb-tooltip')
-			this.link.removeAttribute('data-xivdb-key')
-			this.link.removeAttribute('data-xivdb-isset')
-		}
+		this.load()
+	}
 
-		// There's some funky ass shit going on with this library and I don't want to think about it more than I have to.
-		// Triggering DOMContentLoaded seems to force it to pick up its ball game
-		// I'm... not sure if that'll break something
-		try {
-			XIVDBTooltips.getOption('fake')
-		} catch (TypeError) {
-			document.dispatchEvent(new Event('DOMContentLoaded'))
-		}
+	componentDidUpdate(prevProps) {
+		const props = this.props
+		if (props.provider !== prevProps.provider ||
+				props.language !== prevProps.language ||
+				props.type !== prevProps.type ||
+				(!isNaN(props.id) && props.id !== prevProps.id)) {
+			this.setState({
+				loading: true,
+			})
 
-		// Using getDelayed to act as a debounce
-		this.hasLoaded = true
-		XIVDBTooltips.getDelayed()
+			this.load()
+		}
+	}
+
+	async load() {
+		const {type, id, language} = this.props
+		const lang = LANGUAGES[language]
+
+		const data = await this.state.provider.get(type, id, lang ? lang.tooltip : language)
+
+		this.setState({
+			loading: false,
+			data,
+		})
 	}
 
 	render() {
-		const {type, id, name} = this.props
-		return <Observer>
-			{({inView, ref}) => {
-				// We get a ref. Observer gets a ref. Everybody gets a ref!
-				const saveRef = el => {
-					this.link = el
-					return ref(el)
-				}
+		const {type, id, children, showTooltip, showIcon, useColors, darkenColors} = this.props
+		const {loading, data} = this.state
 
-				this.onObserverChange(inView)
-				return <a href={'https://xivdb.com/'+ type +'/' + id} ref={saveRef}>{name ? name : 'Loading...'}</a>
-			}}
-		</Observer>
+		if (loading) {
+			return <a href={`https://xivdb.com/${type}/${id}`}>
+				{showIcon && <Icon loading name="circle notch" />}
+				{children || <Trans id="core.dblink.loading">Loading...</Trans>}
+			</a>
+		}
+
+		const item = data.data
+		if (!item.name) {
+			return <a href={`https://xivdb.com/${type}/${id}`}>
+				{children || <Trans id="core.dblink.not-found">Unable to Load</Trans>}
+			</a>
+		}
+
+		const color = useColors && item.color
+		const colorClass = color && `xivdb-rarity-${color}${darkenColors && '-darken'}`
+
+		const link = <a
+			className={`${styles.link} ${colorClass || ''}`}
+			href={`https://xivdb.com/${type}/${id}`}
+			data-xivdb-key
+		>
+			{showIcon && <img src={data.data.icon} alt="" />}
+			{children || data.data.name}
+		</a>
+
+		if (!showTooltip) {
+			return link
+		}
+
+		return <Popup
+			basic
+			style={{padding: '0px'}}
+			trigger={link}
+			content={<div dangerouslySetInnerHTML={{__html: data.html}} />}
+		/>
 	}
 }
 
@@ -118,11 +239,9 @@ const Wrapped = connect(state => ({
 
 export default Wrapped
 
-// -----
-// Helpers 'cus i'm lazy
-// -----
-export const ActionLink = (props) => <Wrapped type="action" {...props} />
-export const StatusLink = (props) => <Wrapped
+// Helpers, because ack is lazy.
+export const ActionLink = props => <Wrapped type="action" {...props} />
+export const StatusLink = props => <Wrapped
 	type="status"
 	{...props}
 	id={props.id - 1000000}

--- a/src/components/ui/DbLink.module.css
+++ b/src/components/ui/DbLink.module.css
@@ -1,0 +1,3 @@
+.link img {
+	height: 1.4285em;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9600,6 +9600,10 @@ url-parse@^1.1.8, url-parse@~1.4.0:
     querystringify "^2.0.0"
     requires-port "^1.0.0"
 
+url-search-params-polyfill@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-4.0.1.tgz#4eda68a5689eda19aff2287e65d98d6fb5f6bc11"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"


### PR DESCRIPTION
This PR implements `<DbLink />` in React. It performs better and updates more reasonably when something like the current language changes. It:

* Creates a XIVDBTooltipProvider class that handles debouncing and caching requests to be nice to XIVDB's API.
* Rewrites the `<DbLink />` component to use that provider and to format its own output.
* Removes the script tag loading the existing XIVDB tooltip JS library.

Behavior is slightly different. Rather than following your mouse cursor, the tool-tip that appears (which is implemented via Semantic UI's `<Popup />`) has a static position somewhere around the link that it will be fully visible.