### PR TITLE
Tweaks to event filter used in invul period guesses

### DIFF
--- a/src/parser/core/modules/Invulnerability.js
+++ b/src/parser/core/modules/Invulnerability.js
@@ -4,7 +4,7 @@ import {Item} from 'parser/core/modules/Timeline'
 // Ms of inactivity before an enemy is considered invuln
 const MIN_INVULN_INACTIVITY = 5000
 
-const ACTIVITY_EVENT_TYPES = ['damage', 'heal']
+const ACTIVITY_EVENT_TYPES = ['begincast', 'damage', 'heal']
 
 export default class Invulnerability extends Module {
 	static handle = 'invuln'
@@ -61,13 +61,22 @@ export default class Invulnerability extends Module {
 
 		for (let i = 0; i < events.length; i++) {
 			const event = events[i]
+			if (event.type === 'begincast') {
+				console.log(event)
+			}
 
-			// Ignore non-damage events, and damage to friendlies
 			if (
-				!event.targetID ||
+				// Make sure it's got all the info we care about, and we're tracking it
 				!ACTIVITY_EVENT_TYPES.includes(event.type) ||
-				(event.type === 'damage' && event.targetIsFriendly) ||
-				(event.type === 'heal' && event.sourceIsFriendly)
+				!event.targetID ||
+				!event.sourceID ||
+				// we only care about casts and heals by players onto something other than themselves
+				(
+					['begincast', 'heal'].includes(event.type) &&
+					(!event.sourceIsFriendly || event.sourceID === event.targetID)
+				) ||
+				// damage done to players happens all the time, ignore it
+				(event.type === 'damage' && event.targetIsFriendly)
 			) { continue }
 
 			if (!event.targetIsFriendly) {

--- a/src/parser/core/modules/Invulnerability.js
+++ b/src/parser/core/modules/Invulnerability.js
@@ -61,9 +61,6 @@ export default class Invulnerability extends Module {
 
 		for (let i = 0; i < events.length; i++) {
 			const event = events[i]
-			if (event.type === 'begincast') {
-				console.log(event)
-			}
 
 			if (
 				// Make sure it's got all the info we care about, and we're tracking it

--- a/src/parser/core/modules/Invulnerability.js
+++ b/src/parser/core/modules/Invulnerability.js
@@ -26,6 +26,7 @@ export default class Invulnerability extends Module {
 		// Tracking all damage for full invuln, and non-tick damage for targetable
 		// TODO: Work out how to track this better - currently relies on the person being parsed pressing buttons which isn't exactly the _best_ measure.
 		const lastHit = {}
+		const playerId = this.parser.player.id
 
 		const checkLastHits = (target, event) => {
 			const enemyLastHits = lastHit[target] || {
@@ -67,11 +68,12 @@ export default class Invulnerability extends Module {
 				!ACTIVITY_EVENT_TYPES.includes(event.type) ||
 				!event.targetID ||
 				!event.sourceID ||
-				// we only care about casts and heals by players onto something other than themselves
-				(
-					['begincast', 'heal'].includes(event.type) &&
-					(!event.sourceIsFriendly || event.sourceID === event.targetID)
-				) ||
+				// we only care about casts and heals by the player onto something other than themselves
+				(['begincast', 'heal'].includes(event.type) && (
+					!event.sourceIsFriendly ||
+					event.sourceID !== playerId ||
+					event.sourceID === event.targetID
+				)) ||
 				// damage done to players happens all the time, ignore it
 				(event.type === 'damage' && event.targetIsFriendly)
 			) { continue }


### PR DESCRIPTION
This PR tweaks the event filter used when guessing invuln periods.

- Fixed stupid mistake that was preventing heal filter from working
- Expanded heal to _exclude_ self-heals
- Added `begincast` event filter that uses same check as heal

These changes do make it a little _too_ lax about downtime, but it's the difference between being hyper trigger happy and a _bit_ too lax, which... well, it's better, i guess.

**Before (Guardian):**
![](https://cdn.discordapp.com/attachments/470049935077933076/474582255604334592/unknown.png)

**After (Guardian):**
![](https://cdn.discordapp.com/attachments/470049935077933076/474582330070138900/unknown.png)