### PR TITLE
Combos

### DIFF
--- a/src/data/ACTIONS/NIN.js
+++ b/src/data/ACTIONS/NIN.js
@@ -8,6 +8,12 @@ export default {
 		name: 'Armor Crush',
 		icon: 'https://secure.xivdb.com/img/game/002000/002915.png',
 		onGcd: true,
+		potency: 100,
+		combo: {
+			from: 2242,
+			potency: 300,
+			end: true,
+		},
 	},
 
 	// -----

--- a/src/data/ACTIONS/RDM.js
+++ b/src/data/ACTIONS/RDM.js
@@ -7,27 +7,25 @@ export default {
 		name: 'Embolden',
 		icon: 'https://secure.xivdb.com/img/game/003000/003218.png',
 		cooldown: 120,
-		preservesCombo: true,
 	},
 	ACCELERATION: {
 		id: 7518,
 		name: 'Acceleration',
 		icon: 'https://secure.xivdb.com/img/game/003000/003214.png',
 		cooldown: 35,
-		preservesCombo: true,
 	},
 	MANAFICATION: {
 		id: 7521,
 		name: 'Manafication',
 		icon: 'https://secure.xivdb.com/img/game/003000/003219.png',
 		cooldown: 120,
+		breaksCombo: true,
 	},
 	CONTRE_SIXTE: {
 		id: 7519,
 		name: 'Contre Sixte',
 		icon: 'https://secure.xivdb.com/img/game/003000/003217.png',
 		cooldown: 45,
-		preservesCombo: true,
 		potency: 300, //Note 2nd enemy takes 10% less, 3rd 20%, 4th 30%, 5th 40%, and beyond 50%
 	},
 	DISPLACEMENT: {
@@ -35,7 +33,6 @@ export default {
 		name: 'Displacement',
 		icon: 'https://secure.xivdb.com/img/game/003000/003211.png',
 		cooldown: 35,
-		preservesCombo: true,
 		potency: 130,
 	},
 	CORPS_A_CORPS: {
@@ -43,7 +40,6 @@ export default {
 		name: 'Corps-a-corps',
 		icon: 'https://secure.xivdb.com/img/game/003000/003204.png',
 		cooldown: 40,
-		preservesCombo: true,
 		potency: 130,
 	},
 	FLECHE: {
@@ -51,7 +47,6 @@ export default {
 		name: 'Fleche',
 		icon: 'https://secure.xivdb.com/img/game/003000/003212.png',
 		cooldown: 25,
-		preservesCombo: true,
 		potency: 420,
 	},
 
@@ -65,6 +60,9 @@ export default {
 		onGcd: true,
 		cooldown: 2.5,
 		potency: 130,
+		combo: {
+			start: true,
+		},
 	},
 	ENCHANTED_RIPOSTE: {
 		id: 7527,
@@ -73,6 +71,9 @@ export default {
 		onGcd: true,
 		cooldown: 1.5,
 		potency: 210, //consumes 30 white, 30 black
+		combo: {
+			start: true,
+		},
 	},
 	ZWERCHHAU: {
 		id: 7512,
@@ -132,6 +133,7 @@ export default {
 		combo: {
 			from: 7529,
 			potency: 550,
+			end: true,
 		},
 	},
 	VERHOLY: {
@@ -144,6 +146,7 @@ export default {
 		combo: {
 			from: 7529,
 			potency: 550,
+			end: true,
 		},
 	},
 	JOLT: {

--- a/src/data/ACTIONS/ROG.js
+++ b/src/data/ACTIONS/ROG.js
@@ -8,6 +8,10 @@ export default {
 		name: 'Spinning Edge',
 		icon: 'https://secure.xivdb.com/img/game/000000/000601.png',
 		onGcd: true,
+		potency: 150,
+		combo: {
+			start: true,
+		},
 	},
 
 	GUST_SLASH: {
@@ -15,6 +19,11 @@ export default {
 		name: 'Gust Slash',
 		icon: 'https://secure.xivdb.com/img/game/000000/000602.png',
 		onGcd: true,
+		potency: 100,
+		combo: {
+			from: 2240,
+			potency: 200,
+		},
 	},
 
 	AEOLIAN_EDGE: {
@@ -22,6 +31,12 @@ export default {
 		name: 'Aeolian Edge',
 		icon: 'https://secure.xivdb.com/img/game/000000/000605.png',
 		onGcd: true,
+		potency: 100,
+		combo: {
+			from: 2242,
+			potency: 340, // TODO - *Cries in positionals*
+			end: true,
+		},
 	},
 
 	SHADOW_FANG: {
@@ -29,6 +44,12 @@ export default {
 		name: 'Shadow Fang',
 		icon: 'https://secure.xivdb.com/img/game/000000/000606.png',
 		onGcd: true,
+		potency: 100,
+		combo: {
+			from: 2242,
+			potency: 200,
+			end: true,
+		},
 	},
 
 	DEATH_BLOSSOM: {
@@ -36,6 +57,8 @@ export default {
 		name: 'Death Blossom',
 		icon: 'https://secure.xivdb.com/img/game/000000/000615.png',
 		onGcd: true,
+		potency: 110,
+		breaksCombo: true,
 	},
 
 	THROWING_DAGGER: {
@@ -43,6 +66,8 @@ export default {
 		name: 'Throwing Dagger',
 		icon: 'https://secure.xivdb.com/img/game/000000/000614.png',
 		onGcd: true,
+		potency: 120,
+		breaksCombo: true,
 	},
 
 	// -----

--- a/src/parser/core/modules/Combos.js
+++ b/src/parser/core/modules/Combos.js
@@ -1,6 +1,7 @@
 // If you can make it through this entire file without hitting semantic saturation of the word "combo", hats off to you. IT DOESN'T LOOK REAL ANYMORE.
 
-import React, {Fragment} from 'react'
+import React from 'react'
+import {Plural, Trans} from '@lingui/react'
 
 import {getAction} from 'data/ACTIONS'
 import Module from 'parser/core/Module'
@@ -28,7 +29,7 @@ export default class Combos extends Module {
 
 	constructor(...args) {
 		super(...args)
-		this.addHook('cast', {by: 'player'}, this._onCast) // TODO - Can we filter to onGcd=true? That would be neat.
+		this.addHook('cast', {by: 'player'}, this._onCast)
 		this.addHook('complete', this._onComplete)
 	}
 
@@ -87,18 +88,18 @@ export default class Combos extends Module {
 
 	_onComplete() {
 		if (this._brokenComboCount > 0 || this._uncomboedGcdCount > 0) {
-			const why = [
-				this._brokenComboCount > 0 && `broke ${this._brokenComboCount} combo${this._brokenComboCount !== 1 ? 's' : ''}`,
-				this._uncomboedGcdCount > 0 && `used ${this._uncomboedGcdCount} uncomboed GCD${this._uncomboedGcdCount !== 1 ? 's' : ''}`,
-			].filter(Boolean)
-
 			this.suggestions.add(new Suggestion({
 				icon: this.constructor.suggestionIcon,
-				content: <Fragment>
+				content: <Trans id="core.combos.content">
 					Avoid misusing your combo GCDs at the wrong combo step or breaking existing combos with non-combo GCDs. Breaking combos can cost you significant amounts DPS as well as important secondary effects.
-				</Fragment>,
+				</Trans>,
 				severity: SEVERITY.MEDIUM, // TODO
-				why: <Fragment>You {why.join(' and ')}.</Fragment>,
+				why: <Plural
+					id="core.combos.why"
+					value={this._brokenComboCount + this._uncomboedGcdCount}
+					one="You misused # combo action."
+					other="You misused # combo actions."
+				/>,
 			}))
 		}
 

--- a/src/parser/core/modules/Combos.js
+++ b/src/parser/core/modules/Combos.js
@@ -107,7 +107,7 @@ export default class Combos extends Module {
 
 	comboHit(/*event*/) {
 		// To be overridden by subclasses. This is for tracking anything a successful combo hit gets you (e.g. Beast Gauge or Kenki).
-		// The parameter is the ID of the combo action (in case that wasn't obvious).
+		// The parameter is the event containing the combo action.
 	}
 
 	addJobSpecificSuggestions(/*comboBreakers, uncomboedGcds*/) {

--- a/src/parser/core/modules/Combos.js
+++ b/src/parser/core/modules/Combos.js
@@ -1,0 +1,118 @@
+// If you can make it through this entire file without hitting semantic saturation of the word "combo", hats off to you. IT DOESN'T LOOK REAL ANYMORE.
+
+import React, {Fragment} from 'react'
+
+import {getAction} from 'data/ACTIONS'
+import Module from 'parser/core/Module'
+import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+
+const NO_COMBO = -1
+const GCD_TIMEOUT_MILLIS = 12000
+
+export default class Combos extends Module {
+	static handle = 'combos'
+	static dependencies = [
+		'suggestions',
+	]
+
+	// This should be redefined by subclassing modules; the default is the basic 'Attack' icon
+	static suggestionIcon = 'https://secure.xivdb.com/img/game/000000/000405.png'
+
+	_lastAction = NO_COMBO
+	_lastGcdTime = this.parser.fight.start_time
+	_brokenComboCount = 0
+	_uncomboedGcdCount = 0
+
+	_comboBreakers = []
+	_uncomboedGcds = []
+
+	constructor(...args) {
+		super(...args)
+		this.addHook('cast', {by: 'player'}, this._onCast) // TODO - Can we filter to onGcd=true? That would be neat.
+		this.addHook('complete', this._onComplete)
+	}
+
+	_onCast(event) {
+		const action = getAction(event.ability.guid)
+
+		if (!action) {
+			return
+		}
+
+		if (action.onGcd) {
+			if (event.timestamp - this._lastGcdTime > GCD_TIMEOUT_MILLIS) {
+				// If we've had enough downtime between GCDs to let the combo expire, reset the state so we don't count erroneous combo breaks
+				this._lastAction = NO_COMBO
+			}
+
+			this._lastGcdTime = event.timestamp
+		}
+
+		if (action.combo) {
+			if (this._lastAction === NO_COMBO) {
+				// Not in a combo
+				if (action.combo.start) {
+					// Combo starter, we good
+					this._lastAction = action.id
+					this.comboHit(event)
+				} else if (action.combo.from) {
+					// Combo action that isn't a starter, that's a paddlin'
+					this._uncomboedGcdCount++
+					this._uncomboedGcds.push(event)
+				}
+			} else if (action.combo.from === this._lastAction) {
+				// Continuing a combo correctly, yay
+				this._lastAction = action.combo.end ? NO_COMBO : action.id // If it's a finisher, reset the combo
+				this.comboHit(event)
+			} else if (action.combo.start) {
+				// Combo starter mid-combo, that's a paddlin'
+				this._lastAction = action.id
+				this._brokenComboCount++
+				this._comboBreakers.push(event)
+			} else {
+				// Incorrect combo action, that's a paddlin'
+				this._lastAction = NO_COMBO
+				this._brokenComboCount++
+				this._comboBreakers.push(event)
+				this._uncomboedGcdCount++
+				this._uncomboedGcds.push(event)
+			}
+		} else if (action.breaksCombo && this._lastAction !== NO_COMBO) {
+			// Combo breaking action, that's a paddlin'
+			this._lastAction = NO_COMBO
+			this._brokenComboCount++
+			this._comboBreakers.push(event)
+		}
+	}
+
+	_onComplete() {
+		if (this._brokenComboCount > 0 || this._uncomboedGcdCount > 0) {
+			const why = [
+				this._brokenComboCount > 0 && `broke ${this._brokenComboCount} combo${this._brokenComboCount !== 1 ? 's' : ''}`,
+				this._uncomboedGcdCount > 0 && `used ${this._uncomboedGcdCount} uncomboed GCD${this._uncomboedGcdCount !== 1 ? 's' : ''}`,
+			].filter(Boolean)
+
+			this.suggestions.add(new Suggestion({
+				icon: this.constructor.suggestionIcon,
+				content: <Fragment>
+					Avoid misusing your combo GCDs at the wrong combo step or breaking existing combos with non-combo GCDs. Breaking combos can cost you significant amounts DPS as well as important secondary effects.
+				</Fragment>,
+				severity: SEVERITY.MEDIUM, // TODO
+				why: <Fragment>You {why.join(' and ')}.</Fragment>,
+			}))
+		}
+
+		this.addJobSpecificSuggestions(this._comboBreakers, this._uncomboedGcds)
+	}
+
+	comboHit(/*event*/) {
+		// To be overridden by subclasses. This is for tracking anything a successful combo hit gets you (e.g. Beast Gauge or Kenki).
+		// The parameter is the ID of the combo action (in case that wasn't obvious).
+	}
+
+	addJobSpecificSuggestions(/*comboBreakers, uncomboedGcds*/) {
+		// To be overridden by subclasses. This is called in _onComplete() and passed two arrays of event objects - one for events that
+		// broke combos, and one for combo GCDs used outside of combos. Subclassing modules can add job-specific suggestions based on
+		// what particular actions were misused and when in the fight.
+	}
+}

--- a/src/parser/core/modules/index.js
+++ b/src/parser/core/modules/index.js
@@ -6,6 +6,7 @@ import Arcanum from './Arcanum'
 import CastTime from './CastTime'
 import Checklist from './Checklist'
 import Combatants from './Combatants'
+import Combos from './Combos'
 import Cooldowns from './Cooldowns'
 import Death from './Death'
 import Downtime from './Downtime'
@@ -31,6 +32,7 @@ export default [
 	CastTime,
 	Checklist,
 	Combatants,
+	Combos,
 	Cooldowns,
 	Death,
 	Downtime,

--- a/src/parser/jobs/nin/Combos.js
+++ b/src/parser/jobs/nin/Combos.js
@@ -1,9 +1,7 @@
 import ACTIONS from 'data/ACTIONS'
-import Combos from 'parser/core/modules/Combos'
+import CoreCombos from 'parser/core/modules/Combos'
 
-export default class NinCombos extends Combos {
-	static handle = 'combos'
-
+export default class Combos extends CoreCombos {
 	// Overrides
 	static suggestionIcon = ACTIONS.SPINNING_EDGE.icon
 

--- a/src/parser/jobs/nin/NinCombos.js
+++ b/src/parser/jobs/nin/NinCombos.js
@@ -1,0 +1,13 @@
+import ACTIONS from 'data/ACTIONS'
+import Combos from 'parser/core/modules/Combos'
+
+export default class NinCombos extends Combos {
+	static handle = 'combos'
+
+	// Overrides
+	static suggestionIcon = ACTIONS.SPINNING_EDGE.icon
+
+	comboHit(/*event*/) {
+		// One day, this will be used for Huton tracking. But today is not that day.
+	}
+}

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -1,5 +1,6 @@
 import About from './About'
 import Duality from './Duality'
+import NinCombos from './NinCombos'
 import Ninjutsu from './Ninjutsu'
 import Ninki from './Ninki'
 import NinWeaving from './NinWeaving'
@@ -9,6 +10,7 @@ import Utility from './Utility'
 export default [
 	About,
 	Duality,
+	NinCombos,
 	Ninjutsu,
 	Ninki,
 	NinWeaving,

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -1,6 +1,6 @@
 import About from './About'
+import Combos from './Combos'
 import Duality from './Duality'
-import NinCombos from './NinCombos'
 import Ninjutsu from './Ninjutsu'
 import Ninki from './Ninki'
 import NinWeaving from './NinWeaving'
@@ -9,8 +9,8 @@ import TrickAttackWindow from './TrickAttackWindow'
 import Utility from './Utility'
 export default [
 	About,
+	Combos,
 	Duality,
-	NinCombos,
 	Ninjutsu,
 	Ninki,
 	NinWeaving,


### PR DESCRIPTION
For use with any jobs that have combos. Except MNK because forms are fucky. The core module provides hooks for `comboHit()` (invoked every time a successful combo action is executed) and `addJobSpecificSuggestions()` (invoked during `_onComplete()`, allows subclasses to provide job-specific suggestion content in addition to the generic one).