### PR TITLE
Added a module for missed Trick Attacks

### DIFF
--- a/src/parser/jobs/nin/TrickAttackPositional.js
+++ b/src/parser/jobs/nin/TrickAttackPositional.js
@@ -1,0 +1,57 @@
+import React, {Fragment} from 'react'
+
+import {ActionLink} from 'components/ui/DbLink'
+import ACTIONS from 'data/ACTIONS'
+import STATUSES from 'data/STATUSES'
+import Module from 'parser/core/Module'
+import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+
+const VULN_APPLICATION_BUFFER = 2000
+
+export default class TrickAttackPositional extends Module {
+	static handle = 'taPositional'
+	static dependencies = [
+		'suggestions',
+	]
+
+	_taCasts = []
+
+	constructor(...args) {
+		super(...args)
+		this.addHook('cast', {by: 'player', abilityId: ACTIONS.TRICK_ATTACK.id}, this._onTrickAttack)
+		this.addHook('applydebuff', {by: 'player', abilityId: STATUSES.TRICK_ATTACK_VULNERABILITY_UP.id}, this._onVulnApplied)
+		this.addHook('complete', this._onComplete)
+	}
+
+	_onTrickAttack(event) {
+		this._taCasts.push({timestamp: event.timestamp, missed: true})
+	}
+
+	_onVulnApplied(event) {
+		if (this._taCasts.length > 0) {
+			// Should always be true, but just as a precaution
+			const lastCast = this._taCasts[this._taCasts.length - 1]
+			if (lastCast.missed && event.timestamp - lastCast.timestamp < VULN_APPLICATION_BUFFER) {
+				// Make sure the last recorded TA cast was less than a second ago
+				// This should also always be true, but I DON'T TRUST FFLOGS ANYMORE
+				lastCast.missed = false
+			}
+		}
+	}
+
+	_onComplete() {
+		const missed = this._taCasts.filter(event => event.missed)
+		if (missed.length > 0) {
+			this.suggestions.add(new Suggestion({
+				icon: ACTIONS.TRICK_ATTACK.icon,
+				content: <Fragment>
+					<ActionLink {...ACTIONS.TRICK_ATTACK}/> provides a huge raid buff to you and your party. Missing the positional can be crippling to raid DPS, especially if it happens more than once in a single fight.
+				</Fragment>,
+				severity: SEVERITY.MAJOR,
+				why: <Fragment>
+					You missed the positional on Trick Attack {missed.length} time{missed.length !== 1 && 's'}.
+				</Fragment>,
+			}))
+		}
+	}
+}

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -4,6 +4,7 @@ import Ninjutsu from './Ninjutsu'
 import Ninki from './Ninki'
 import NinWeaving from './NinWeaving'
 import ShadowFang from './ShadowFang'
+import TrickAttackPositional from './TrickAttackPositional'
 import TrickAttackWindow from './TrickAttackWindow'
 import Utility from './Utility'
 export default [
@@ -13,6 +14,7 @@ export default [
 	Ninki,
 	NinWeaving,
 	ShadowFang,
+	TrickAttackPositional,
 	TrickAttackWindow,
 	Utility,
 ]

--- a/src/parser/jobs/nin/notes.md
+++ b/src/parser/jobs/nin/notes.md
@@ -13,6 +13,7 @@
 ### Trick Attack
 - [x] Aligning DWaD with Trick Attack windows (TrickAttackWindow.js)
 - [x] Avoiding Armor Crush inside Trick Attack windows (TrickAttackWindow.js)
+- [x] Missing Trick Attack positionals (TrickAttackPositional.js)
 - [ ] Using Trick Attack on cooldown
 
 ### DoTs


### PR DESCRIPTION
Pretty much what it says on the box. It looks for TA casts and lines them up with vuln debuff applications from the player (in case there are 2+ NINs in the parse). I went with a 2-second window to be safe; most applications I saw in my logs while testing this out were in the 850-900ms range for how long it took from the cast to the debuff application, so I doubled it and rounded up.