### PR TITLE
Fix GCD length calcs when modified by castTime

### DIFF
--- a/src/parser/core/modules/CastTime.js
+++ b/src/parser/core/modules/CastTime.js
@@ -47,13 +47,15 @@ export default class CastTime extends Module {
 	}
 
 	forEvent(event) {
-		const actionId = event.ability.guid
+		return this.forAction(event.ability.guid, event.timestamp)
+	}
 
+	forAction(actionId, timestamp = this.parser.currentTimestamp) {
 		// Get any cast time modifiers active when the event took place
 		const matchingTimes = this._castTimes.filter(ct =>
 			(ct.actions === 'all' || ct.actions.includes(actionId)) &&
-			ct.start <= event.timestamp &&
-			(ct.end === null || ct.end >= event.timestamp)
+			ct.start <= timestamp &&
+			(ct.end === null || ct.end >= timestamp)
 		)
 
 		const defaultCastTime = getAction(actionId).castTime

--- a/src/parser/core/modules/PrecastStatus.js
+++ b/src/parser/core/modules/PrecastStatus.js
@@ -4,6 +4,10 @@ import Module from 'parser/core/Module'
 // Fake buff applications so modules don't need to take it into account
 export default class PrecastStatus extends Module {
 	static handle = 'precastStatus'
+	static dependencies = [
+		// Forcing action to run first, cus we want to always splice in before it.
+		'precastAction',
+	]
 
 	_combatantStatuses = {}
 


### PR DESCRIPTION
The recent GCD changes massively improved the accuracy of the durations, but didn't take into account casts that had been adjusted by spells like swiftcast.

This issue is most visible on RDM parses, as the high frequency of dualcast'd >2.5s casts was bloating the ABC calculation, and causing some funky shit in the timeline.

There's also a minor fix that forces `precastAction` to run before `precastStatus` so the events spliced by `precastStatus` are readable by the cast event for the action.

Using [this log](https://www.fflogs.com/reports/6KDf7GhvZNkq1AyR#fight=2&source=9) for the below.

**Before:**
![image](https://user-images.githubusercontent.com/534235/43642130-a3dba43c-9769-11e8-8f56-c4a775334de7.png)
![image](https://user-images.githubusercontent.com/534235/43642135-ae323e0a-9769-11e8-9403-68c20bbd35c7.png)

**After:**
![image](https://user-images.githubusercontent.com/534235/43642172-d10d15a8-9769-11e8-9582-8be079c01561.png)
![image](https://user-images.githubusercontent.com/534235/43642177-d6b05d1c-9769-11e8-8a20-7d1421d418a9.png)