### PR TITLE
RDM gauge graph

### DIFF
--- a/src/components/ui/TimeLineChart.js
+++ b/src/components/ui/TimeLineChart.js
@@ -2,27 +2,27 @@ import PropTypes from 'prop-types'
 import React, {PureComponent} from 'react'
 import {Line} from 'react-chartjs-2'
 
+const DEFAULT_OPTIONS = {
+	scales: {
+		xAxes: [{
+			type: 'time',
+			time: {
+				displayFormats: {
+					minute: 'm:ss',
+					second: 'm:ss',
+					millisecond: 'm:ss.SS',
+				},
+			},
+		}],
+	},
+}
+
 export default class TimeLineChart extends PureComponent {
 	static propTypes = {
 		data: PropTypes.object.isRequired,
 	}
 
 	render() {
-		const options = {
-			scales: {
-				xAxes: [{
-					type: 'time',
-					time: {
-						displayFormats: {
-							minute: 'm:ss',
-							second: 'm:ss',
-							millisecond: 'm:ss.SS',
-						},
-					},
-				}],
-			},
-		}
-
-		return <Line data={this.props.data} options={options}/>
+		return <Line data={this.props.data} options={DEFAULT_OPTIONS}/>
 	}
 }

--- a/src/components/ui/TimeLineChart.js
+++ b/src/components/ui/TimeLineChart.js
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types'
+import React, {PureComponent} from 'react'
+import {Line} from 'react-chartjs-2'
+
+export default class TimeLineChart extends PureComponent {
+	static propTypes = {
+		data: PropTypes.object.isRequired,
+	}
+
+	render() {
+		const options = {
+			scales: {
+				xAxes: [{
+					type: 'time',
+					time: {
+						displayFormats: {
+							minute: 'm:ss',
+							second: 'm:ss',
+							millisecond: 'm:ss.SS',
+						},
+					},
+				}],
+			},
+		}
+
+		return <Line data={this.props.data} options={options}/>
+	}
+}

--- a/src/parser/jobs/rdm/Gauge.js
+++ b/src/parser/jobs/rdm/Gauge.js
@@ -1,6 +1,10 @@
+import Color from 'color'
 import React, {Fragment} from 'react'
 import {Icon, Message} from 'semantic-ui-react'
+
+import TimeLineChart from 'components/ui/TimeLineChart'
 import ACTIONS from 'data/ACTIONS'
+import JOBS from 'data/JOBS'
 import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
@@ -47,6 +51,12 @@ export default class Gauge extends Module {
 		_missingAreo = false
 		_missingThunder = false
 		_manaficationUsed = false
+
+		// Chart handling
+		_history = {
+			white: [],
+			black: [],
+		}
 
 		constructor(...args) {
 			super(...args)
@@ -187,7 +197,11 @@ export default class Gauge extends Module {
 				}
 			}
 
-			return
+			if (abilityId in MANA_GAIN || abilityId === ACTIONS.MANAFICATION.id) {
+				const timestamp = event.timestamp - this.parser.fight.start_time
+				this._history.white.push({t: timestamp, y: this._whiteMana})
+				this._history.black.push({t: timestamp, y: this._blackMana})
+			}
 		}
 
 		_onComplete() {
@@ -287,5 +301,32 @@ export default class Gauge extends Module {
 					</Fragment>,
 				}))
 			}
+		}
+
+		output() {
+			const whm = Color(JOBS.WHITE_MAGE.colour)
+			const blm = Color(JOBS.BLACK_MAGE.colour)
+
+			// Disabling magic numbers for the chart, 'cus it's a chart
+			/* eslint-disable no-magic-numbers */
+			const data = {
+				datasets: [{
+					label: 'White Mana',
+					data: this._history.white,
+					backgroundColor: whm.fade(0.5),
+					borderColor: whm.fade(0.2),
+					steppedLine: true,
+				}, {
+					label: 'Black Mana',
+					data: this._history.black,
+					backgroundColor: blm.fade(0.5),
+					borderColor: blm.fade(0.2),
+					steppedLine: true,
+				}],
+			}
+			return <TimeLineChart
+				data={data}
+			/>
+			/* eslint-enable no-magic-numbers */
 		}
 }


### PR DESCRIPTION
Currently no support for zoom/pan, the chartjs plugin that handles it is trash and my attempts at fixing it were dodgy at best.

Core UI module added to centralise the config for this sort of thing, should make it a bit easier to deal with / adjust them down the line.

PR also fixes RDM gauge to track deaths because hey graphs make this noticeable.