### PR TITLE
Event type sort order for events with same timestamp

### DIFF
--- a/src/parser/core/modules/AdditionalEvents.js
+++ b/src/parser/core/modules/AdditionalEvents.js
@@ -34,6 +34,25 @@ const QUERY_FILTER = [
 	},
 ]
 
+const EVENT_TYPE_ORDER = {
+	death: -4,
+	begincast: -3,
+	cast: -2,
+	damage: -1,
+	heal: -1,
+	default: 0,
+	removebuff: 1,
+	removebuffstack: 1,
+	removedebuff: 1,
+	removedebuffstack: 1,
+	refreshbuff: 2,
+	refreshdebuff: 2,
+	applybuff: 3,
+	applybuffstack: 3,
+	applydebuff: 3,
+	applydebuffstack: 3,
+}
+
 export default class AdditionalEvents extends Module {
 	static handle = 'additionalEvents'
 	static dependencies = [
@@ -80,7 +99,14 @@ export default class AdditionalEvents extends Module {
 
 		// Add them onto the end, then sort. Using stable to ensure order is kept, as it can be sensitive sometimes.
 		events.push(...newEvents)
-		stable.inplace(events, (a, b) => a.timestamp - b.timestamp)
+		stable.inplace(events, (a, b) => {
+			if (a.timestamp === b.timestamp) {
+				const aTypeOrder = EVENT_TYPE_ORDER[a.type] || EVENT_TYPE_ORDER.default
+				const bTypeOrder = EVENT_TYPE_ORDER[b.type] || EVENT_TYPE_ORDER.default
+				return aTypeOrder - bTypeOrder
+			}
+			return a.timestamp - b.timestamp
+		})
 
 		return events
 	}


### PR DESCRIPTION
This adds an extra condition to `AdditionalEvents`' sort, to provide a defined order to events occuring at the same timestamp.

This should have a relatively minor effect across the board, and help make classes that rely heavily on buff procs much more reliable to write modules for. Examples are from a RDM log, as it's the job that is most heavily effected by the prior inconsistencies.

Open for feedback on the sort order, this should follow "expectation" but may need tweaks.

**Before:**
![image](https://user-images.githubusercontent.com/534235/43987329-6ad1f034-9d62-11e8-9b30-5b275c0df464.png)

**After:**
![image](https://user-images.githubusercontent.com/534235/43987336-744644bc-9d62-11e8-91b2-9f42460e7645.png)
