### PR TITLE
Added suggestions for Doton use

### DIFF
--- a/src/data/STATUSES/NIN.js
+++ b/src/data/STATUSES/NIN.js
@@ -45,4 +45,18 @@ export default {
 		icon: 'https://secure.xivdb.com/img/game/012000/012902.png',
 		duration: 15,
 	},
+
+	DOTON: {
+		id: 501,
+		name: 'Doton',
+		icon: 'https://secure.xivdb.com/img/game/012000/012904.png',
+		duration: 24,
+	},
+
+	TEN_CHI_JIN: {
+		id: 1186,
+		name: 'Ten Chi Jin',
+		icon: 'https://secure.xivdb.com/img/game/012000/012911.png',
+		duration: 10,
+	},
 }

--- a/src/parser/jobs/nin/notes.md
+++ b/src/parser/jobs/nin/notes.md
@@ -2,8 +2,9 @@
 
 ### Ninjutsu
 - [x] Hyoton and Rabbit Medium casts (Ninjutsu.js)
+- [x] Single-target Dotons outside of TCJ (Ninjutsu.js)
 - [x] Huton uptime (Combos.js)
-- [ ] Single-target Dotons outside of TCJ
+- [x] Kassatsu use and misuse (Kassatsu.js)
 - [ ] Using Ninjutsu on cooldown
 
 ### Ninki


### PR DESCRIPTION
3 new suggestions for NIN regarding Doton usage. The logic on the `badStds` one is a little goofy at a glance, but the idea on it was to filter out uses where it started multi-target and ended single-target, since those are _usually_ justified (e.g. O7S adds).