### PR TITLE
Fixed a bug in timestamp display

### DIFF
--- a/src/parser/core/Parser.js
+++ b/src/parser/core/Parser.js
@@ -368,7 +368,7 @@ class Parser {
 			return seconds.toFixed(precision) + 's'
 		}
 		const precision = secondPrecision !== null ? secondPrecision : 0
-		const secondsText = seconds.toFixed(precision)
+		const secondsText = precision ? seconds.toFixed(precision) : '' + Math.floor(seconds)
 		let pointPos = secondsText.indexOf('.')
 		if (pointPos === -1) { pointPos = secondsText.length }
 		return `${Math.floor(duration / 60)}:${pointPos === 1? '0' : ''}${secondsText}`


### PR DESCRIPTION
Mentioned it on Discord but I'll put it here for posterity - apparently `.toFixed(0)` is functionally equivalent to `Math.round()` plus a string conversion, which can result in the seconds displaying as 60 in `m:ss` format (something like 1:59.7 getting displayed as 1:60, for instance). I slapped on a small fix that explicitly floors it if precision is 0.