### PR TITLE
QoL tweaks

### DIFF
--- a/src/components/Find/FightList.js
+++ b/src/components/Find/FightList.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types'
 import React, {Component, Fragment} from 'react'
+import {connect} from 'react-redux'
 import {Checkbox, Header, Icon, Menu} from 'semantic-ui-react'
 import {Trans} from '@lingui/react'
 
 import FightItem from './FightItem'
 import ZONES from 'data/ZONES'
-import store from 'store'
-import {refreshReport} from 'store/actions'
+import {refreshReport, updateSettings} from 'store/actions'
 
 import styles from './FightList.module.css'
 
@@ -17,19 +17,24 @@ class FightList extends Component {
 				id: PropTypes.number.isRequired,
 			})).isRequired,
 		}).isRequired,
-	}
-
-	state = {
-		killsOnly: true,
+		dispatch: PropTypes.func.isRequired,
+		killsOnly: PropTypes.bool,
 	}
 
 	refreshFights = () => {
-		store.dispatch(refreshReport())
+		this.props.dispatch(refreshReport())
 	}
 
 	render() {
-		const {report} = this.props
-		const {killsOnly} = this.state
+		const {
+			dispatch,
+			report,
+		} = this.props
+
+		let killsOnly = this.props.killsOnly
+		if (killsOnly === undefined) {
+			killsOnly = true
+		}
 
 		// Build a 2d array, grouping fights by the zone they take place in
 		const fights = []
@@ -67,7 +72,9 @@ class FightList extends Component {
 						toggle
 						label={<label><Trans id="core.find.kills-only">Kills only</Trans></label>}
 						defaultChecked={killsOnly}
-						onChange={(_, data) => this.setState({killsOnly: data.checked})}
+						onChange={(_, data) => dispatch(updateSettings({
+							fightListKillsOnly: data.checked,
+						}))}
 						// className="pull-right"
 					/>
 					<span className={styles.refresh} onClick={this.refreshFights}>
@@ -99,4 +106,6 @@ class FightList extends Component {
 	}
 }
 
-export default FightList
+export default connect(state => ({
+	killsOnly: state.settings.fightListKillsOnly,
+}))(FightList)

--- a/src/components/modules/Checklist.js
+++ b/src/components/modules/Checklist.js
@@ -38,6 +38,12 @@ class Checklist extends Component {
 		const panels = rules.map((rule, index) => {
 			const ruleStyles = RULE_STYLES[rule.tier]
 
+			// We cap the percent @ 100 in production mode - calculations can always be a bit janky
+			let percent = rule.percent
+			if (process.env.NODE_ENV === 'production') {
+				percent = Math.min(percent, 100)
+			}
+
 			if (ruleStyles.autoExpand) {
 				expanded.push(index)
 			}
@@ -53,9 +59,9 @@ class Checklist extends Component {
 						/>
 						{rule.name}
 						<div className={styles.percent + ' ' + ruleStyles.text}>
-							{rule.percent.toFixed(1)}%
+							{percent.toFixed(1)}%
 							{hideProgress || <Progress
-								percent={rule.percent}
+								percent={percent}
 								className={styles.progress}
 								size="small"
 								color={ruleStyles.color}

--- a/src/components/modules/Suggestions.js
+++ b/src/components/modules/Suggestions.js
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types'
 import React, {Component, Fragment} from 'react'
+import {connect} from 'react-redux'
 import {Checkbox, Label} from 'semantic-ui-react'
 import {Trans} from '@lingui/react'
 
 // Direct path import 'cus it'll be a dep loop otherwise
 import {SEVERITY} from 'parser/core/modules/Suggestions/Suggestion'
+import {updateSettings} from 'store/actions'
 
 import styles from './Suggestions.module.css'
 
@@ -23,14 +25,12 @@ class Suggestions extends Component {
 			why: PropTypes.node.isRequired,
 			severity: PropTypes.number.isRequired,
 		})).isRequired,
-	}
-
-	state = {
-		showMinor: false,
+		dispatch: PropTypes.func.isRequired,
+		showMinor: PropTypes.bool,
 	}
 
 	render() {
-		const {showMinor} = this.state
+		const {dispatch, showMinor} = this.props
 
 		const suggestions = this.props.suggestions.filter(
 			suggestion => showMinor || suggestion.severity !== SEVERITY.MINOR
@@ -43,7 +43,9 @@ class Suggestions extends Component {
 				toggle
 				label={<label><Trans id="core.suggestion.show-minor">Show minor</Trans></label>}
 				defaultChecked={showMinor}
-				onChange={(_, data) => this.setState({showMinor: data.checked})}
+				onChange={(_, data) => dispatch(updateSettings({
+					suggestionsShowMinor: data.checked,
+				}))}
 				className={styles.checkbox}
 			/>}
 			<div className={styles.items}>
@@ -68,4 +70,6 @@ class Suggestions extends Component {
 	}
 }
 
-export default Suggestions
+export default connect(state => ({
+	showMinor: state.settings.suggestionsShowMinor,
+}))(Suggestions)

--- a/src/parser/core/Module.js
+++ b/src/parser/core/Module.js
@@ -95,15 +95,17 @@ export default class Module {
 			filter.ability.guid = filter.abilityId
 			delete filter.abilityId
 		}
-		const hook = {
-			events,
-			filter,
-			callback: cb.bind(this),
-		}
 
 		// Make sure events is an array
 		if (!Array.isArray(events)) {
 			events = [events]
+		}
+
+		// Final hook representation
+		const hook = {
+			events,
+			filter,
+			callback: cb.bind(this),
 		}
 
 		// Hook for each of the events
@@ -119,6 +121,13 @@ export default class Module {
 
 		// Return the hook representation so it can be removed (later)
 		return hook
+	}
+
+	removeHook(hook) {
+		hook.events.forEach(event => {
+			if (!this._hooks.has(event)) { return }
+			this._hooks.get(event).delete(hook)
+		})
 	}
 
 	triggerEvent(event) {

--- a/src/parser/core/Module.test.js
+++ b/src/parser/core/Module.test.js
@@ -115,4 +115,12 @@ describe('Module', () => {
 			expect(hook).toHaveBeenCalledTimes(1)
 		})
 	})
+
+	it('can remove hooks', () => {
+		const hookRef = module.addHook(event.type, hook)
+		module.triggerEvent(event)
+		module.removeHook(hookRef)
+		module.triggerEvent(event)
+		expect(hook).toHaveBeenCalledTimes(1)
+	})
 })

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -84,3 +84,9 @@ export const setI18nOverlay = state => ({
 	type: SET_I18N_OVERLAY,
 	payload: state,
 })
+
+export const UPDATE_SETTINGS = 'UPDATE_SETTINGS'
+export const updateSettings = settings => ({
+	type: UPDATE_SETTINGS,
+	payload: settings,
+})

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -65,11 +65,23 @@ const i18nOverlay = (state=false, action) => {
 	}
 }
 
+const settings = (state={}, action) => {
+	if (action.type !== ActionTypes.UPDATE_SETTINGS) {
+		return state
+	}
+
+	return {
+		...state,
+		...action.payload,
+	}
+}
+
 const rootReducer = combineReducers({
 	report,
 	globalError,
 	language,
 	i18nOverlay,
+	settings,
 })
 
 export default rootReducer

--- a/src/store/storage.js
+++ b/src/store/storage.js
@@ -1,7 +1,11 @@
 import _ from 'lodash'
 
 // We only want to store some keys of state - things like report are load-specific
-const ALLOWED_KEYS = ['language', 'i18nOverlay']
+const ALLOWED_KEYS = [
+	'i18nOverlay',
+	'language',
+	'settings',
+]
 
 // Load state from LS
 export function loadState() {


### PR DESCRIPTION
Nothing particularly visible, just a few tweaks for end user QoL

* Made the "Kills Only" and "Show Minor" switches persist across navigation and reloads
* Capped checklist %s at 100 in production builds - dev server will still show >100 for debugging purposes
* Added helper function `module.removeHook`, not that people really need it

In looking around for a test case for the second - most of the ones that have been brought up recently have been fixed already, so great work to all involved w/ speedmod changes!