### PR TITLE
MNK buff uptime tracking

### DIFF
--- a/src/data/ACTIONS/PGL.js
+++ b/src/data/ACTIONS/PGL.js
@@ -16,6 +16,7 @@ export default {
 		name: 'True Strike',
 		icon: 'https://xivapi.com/i/000000/000209.png',
 		onGcd: true,
+		potency: 180,
 	},
 
 	SNAP_PUNCH: {
@@ -30,6 +31,7 @@ export default {
 		name: 'Twin Snakes',
 		icon: 'https://xivapi.com/i/000000/000213.png',
 		onGcd: true,
+		potency: 130,
 	},
 
 	ARM_OF_THE_DESTROYER: {

--- a/src/parser/jobs/mnk/BuffUptime.js
+++ b/src/parser/jobs/mnk/BuffUptime.js
@@ -57,11 +57,11 @@ export default class BuffUptime extends Module {
 		// Only include GCDs, but don't double increment either
 		if (action.onGcd && !BUFF_CHECK_SKILLS.includes(action)) {
 			if (this._lastDragonKickUse[event.targetID]) {
-        this._gcdsSinceDK[event.targetID] += 1
+				this._gcdsSinceDK[event.targetID] += 1
 			}
 
 			if (this._lastTwinSnakesUse !== null) {
-        this._gcdsSinceTS++
+				this._gcdsSinceTS++
 			}
 		}
 	}

--- a/src/parser/jobs/mnk/BuffUptime.js
+++ b/src/parser/jobs/mnk/BuffUptime.js
@@ -5,7 +5,7 @@ import ACTIONS, {getAction} from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {Rule, Requirement} from 'parser/core/modules/Checklist'
-import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+import {Suggestion, TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
 const GCD_CYCLE_LENGTH = 6
 
@@ -57,7 +57,7 @@ export default class BuffUptime extends Module {
 		// Only include GCDs, but don't double increment either
 		if (action.onGcd && !BUFF_CHECK_SKILLS.includes(action)) {
 			if (this._lastDragonKickUse[event.targetID]) {
-				this._gcdsSinceDK[event.targetID] += 1
+				this._gcdsSinceDK[event.targetID]++
 			}
 
 			if (this._lastTwinSnakesUse !== null) {
@@ -143,12 +143,16 @@ export default class BuffUptime extends Module {
 		if (this._earlyTwinSnakes) {
 			const lostTruePotency = this._earlyTwinSnakes * (ACTIONS.TRUE_STRIKE.potency - ACTIONS.TWIN_SNAKES.potency)
 
-			this.suggestions.add(new Suggestion({
+			this.suggestions.add(new TieredSuggestion({
 				icon: ACTIONS.TWIN_SNAKES.icon,
 				content: <Fragment>
 					Avoid refreshing <ActionLink {...ACTIONS.TWIN_SNAKES} /> signficantly before its expiration as you're losing uses of the higher potency <ActionLink {...ACTIONS.TRUE_STRIKE} />.
 				</Fragment>,
-				severity: SEVERITY.MAJOR,
+				tiers: {
+					1: SEVERITY.MEDIUM,
+					4: SEVERITY.MAJOR,
+				},
+				value: this._earlyTwinSnakes,
 				why: <Fragment>
 					{lostTruePotency} potency lost to {this._earlyTwinSnakes} early refreshes.
 				</Fragment>,

--- a/src/parser/jobs/mnk/BuffUptime.js
+++ b/src/parser/jobs/mnk/BuffUptime.js
@@ -7,7 +7,12 @@ import Module from 'parser/core/Module'
 import {Rule, Requirement} from 'parser/core/modules/Checklist'
 import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
-const GCD_CYCLE_LENGTH = 5
+const GCD_CYCLE_LENGTH = 6
+
+const BUFF_CHECK_SKILLS = [
+	ACTIONS.DRAGON_KICK.id,
+	ACTIONS.TWIN_SNAKES.id,
+]
 
 export default class BuffUptime extends Module {
 	static handle = 'BuffUptime'
@@ -49,9 +54,15 @@ export default class BuffUptime extends Module {
 			return
 		}
 
-		if (action.onGcd) {
-			this._gcdsSinceDK[event.targetID] += 1
-			this._gcdsSinceTS++
+		// Only include GCDs, but don't double increment either
+		if (action.onGcd && !BUFF_CHECK_SKILLS.includes(action)) {
+			if (this._lastDragonKickUse[event.targetID]) {
+        this._gcdsSinceDK[event.targetID] += 1
+			}
+
+			if (this._lastTwinSnakesUse !== null) {
+        this._gcdsSinceTS++
+			}
 		}
 	}
 
@@ -130,7 +141,7 @@ export default class BuffUptime extends Module {
 		}
 
 		if (this._earlyTwinSnakes) {
-			const _lostTruePotency = this._earlyTwinSnakes * (ACTIONS.TRUE_STRIKE.potency - ACTIONS.TWIN_SNAKES.potency)
+			const lostTruePotency = this._earlyTwinSnakes * (ACTIONS.TRUE_STRIKE.potency - ACTIONS.TWIN_SNAKES.potency)
 
 			this.suggestions.add(new Suggestion({
 				icon: ACTIONS.TWIN_SNAKES.icon,
@@ -139,7 +150,7 @@ export default class BuffUptime extends Module {
 				</Fragment>,
 				severity: SEVERITY.MAJOR,
 				why: <Fragment>
-					{_lostTruePotency} potency lost to {this._earlyTwinSnakes} early refreshes.
+					{lostTruePotency} potency lost to {this._earlyTwinSnakes} early refreshes.
 				</Fragment>,
 			}))
 		}

--- a/src/parser/jobs/mnk/BuffUptime.js
+++ b/src/parser/jobs/mnk/BuffUptime.js
@@ -1,0 +1,161 @@
+import React, {Fragment} from 'react'
+
+import {ActionLink} from 'components/ui/DbLink'
+import ACTIONS, {getAction} from 'data/ACTIONS'
+import STATUSES from 'data/STATUSES'
+import Module from 'parser/core/Module'
+import {Rule, Requirement} from 'parser/core/modules/Checklist'
+import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+
+const GCD_CYCLE_LENGTH = 5
+
+export default class BuffUptime extends Module {
+	static handle = 'BuffUptime'
+	static dependencies = [
+		'checklist',
+		'combatants',
+		'enemies',
+		'invuln',
+		'suggestions',
+	]
+
+	// Dragon kick can be applied to multiple enemies
+	_lastDragonKickUse = {}
+	_lastTwinSnakesUse = null
+
+	_earlyDragonKicks = 0
+	_earlyTwinSnakes = 0
+
+	_gcdsSinceDK = {}
+	_gcdsSinceTS = 0
+
+	constructor(...args) {
+		super(...args)
+
+		// Hook all GCDs so we can count GCDs in buff windows
+		this.addHook('cast', {by: 'player'}, this._onCast)
+
+		// Apparently DK is a bit busted but let's use the debuff for now
+		this.addHook(['applybuff', 'refreshbuff'], {by: 'player', abilityId: STATUSES.BLUNT_RESISTANCE_DOWN.id}, this._onDragonKick)
+		this.addHook(['applybuff', 'refreshbuff'], {by: 'player', abilityId: STATUSES.TWIN_SNAKES.id}, this._onTwinSnakes)
+
+		this.addHook('complete', this._onComplete)
+	}
+
+	_onCast(event) {
+		const action = getAction(event.ability.guid)
+
+		if (!action) {
+			return
+		}
+
+		if (action.onGcd) {
+			this._gcdsSinceDK[event.targetID] += 1
+			this._gcdsSinceTS++
+		}
+	}
+
+	_onDragonKick(event) {
+		// Make sure we're tracking for this target
+		const lastApplication = this._lastDragonKickUse[event.targetID]
+
+		// If it's not been applied yet set it and skip out
+		if (!lastApplication) {
+			this._lastDragonKickUse[event.targetID] = event.timestamp
+			return
+		}
+
+		// This logic is busted if the player's GCD is under 1.67s
+		if (this._gcdsSinceDK[event.targetID] < GCD_CYCLE_LENGTH) {
+			this._earlyDragonKicks++
+		}
+
+		this._lastDragonKickUse[event.targetID] = event.timestamp
+		this._gcdsSinceDK[event.targetID] = 0
+	}
+
+	_onTwinSnakes(event) {
+		// If it's not been applied yet set it and skip out
+		if (!this._lastTwinSnakesUse) {
+			this._lastTwinSnakesUse = event.timestamp
+			return
+		}
+
+		if (this._gcdsSinceTS < GCD_CYCLE_LENGTH) {
+			this._earlyTwinSnakes++
+		}
+
+		this._lastTwinSnakesUse = event.timestamp
+		this._gcdsSinceTS = 0
+	}
+
+	_onComplete() {
+		this.checklist.add(new Rule({
+			name: 'Keep Dragon Kick up',
+			description: <Fragment>
+				Dragon Kick's blunt resistance debuff should always be applied to your primary target.
+			</Fragment>,
+			requirements: [
+				new Requirement({
+					name: <Fragment><ActionLink {...ACTIONS.DRAGON_KICK} /> uptime</Fragment>,
+					percent: () => this.getDebuffUptimePercent(STATUSES.BLUNT_RESISTANCE_DOWN.id),
+				}),
+			],
+		}))
+
+		this.checklist.add(new Rule({
+			name: 'Keep Twin Snakes up',
+			description: <Fragment>
+				Twin Snakes is an easy 10% buff to your DPS across the board.
+			</Fragment>,
+			requirements: [
+				new Requirement({
+					name: <Fragment><ActionLink {...ACTIONS.TWIN_SNAKES} /> uptime</Fragment>,
+					percent: () => this.getBuffUptimePercent(STATUSES.TWIN_SNAKES.id),
+				}),
+			],
+		}))
+
+		if (this._earlyDragonKicks) {
+			this.suggestions.add(new Suggestion({
+				icon: ACTIONS.DRAGON_KICK.icon,
+				content: <Fragment>
+					Avoid refreshing <ActionLink {...ACTIONS.DRAGON_KICK} /> signficantly before its expiration as you're trading it for the higher damage <ActionLink {...ACTIONS.BOOTSHINE} />.
+				</Fragment>,
+				severity: SEVERITY.MEDIUM,
+				why: <Fragment>
+					{this._earlyDragonKicks} rotation cycles were interrupted by early refreshes.
+				</Fragment>,
+			}))
+		}
+
+		if (this._earlyTwinSnakes) {
+			const _lostTruePotency = this._earlyTwinSnakes * (ACTIONS.TRUE_STRIKE.potency - ACTIONS.TWIN_SNAKES.potency)
+
+			this.suggestions.add(new Suggestion({
+				icon: ACTIONS.TWIN_SNAKES.icon,
+				content: <Fragment>
+					Avoid refreshing <ActionLink {...ACTIONS.TWIN_SNAKES} /> signficantly before its expiration as you're losing uses of the higher potency <ActionLink {...ACTIONS.TRUE_STRIKE} />.
+				</Fragment>,
+				severity: SEVERITY.MAJOR,
+				why: <Fragment>
+					{_lostTruePotency} potency lost to {this._earlyTwinSnakes} early refreshes.
+				</Fragment>,
+			}))
+		}
+	}
+
+	getDebuffUptimePercent(statusId) {
+		const statusUptime = this.enemies.getStatusUptime(statusId)
+		const fightDuration = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
+
+		return (statusUptime / fightDuration) * 100
+	}
+
+	getBuffUptimePercent(statusId) {
+		const statusUptime = this.combatants.getStatusUptime(statusId, this.parser.player.id)
+		const fightUptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
+
+		return (statusUptime / fightUptime) * 100
+	}
+}

--- a/src/parser/jobs/mnk/Fists.js
+++ b/src/parser/jobs/mnk/Fists.js
@@ -25,7 +25,6 @@ export default class Fists extends Module {
 	static dependencies = [
 		'checklist',
 		'combatants',
-		'invuln',
 		'suggestions',
 	]
 
@@ -65,6 +64,7 @@ export default class Fists extends Module {
 					percent: () => this.getBuffUptimePercent(STATUSES.FISTS_OF_FIRE.id),
 				}),
 			],
+			// For frequent TK+RoW (maybe 2 GCDs every 30s), you end up with 93%ish, rounded down to 90 to handle the occasional RoE
 			target: 90,
 		}))
 
@@ -81,8 +81,7 @@ export default class Fists extends Module {
 
 	getBuffUptimePercent(statusId) {
 		const statusUptime = this.combatants.getStatusUptime(statusId, this.parser.player.id)
-		const fightUptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
-		return (statusUptime / fightUptime) * 100
+		return (statusUptime / this.parser.fightDuration) * 100
 	}
 }

--- a/src/parser/jobs/mnk/NOTES.md
+++ b/src/parser/jobs/mnk/NOTES.md
@@ -13,6 +13,8 @@
 - [ ] Earth Tackle, not even once
 - [x] Fists, make sure at least one is up
 - [ ] Fists of Fire uptime?
+- [x] Dragon Kick uptime and clipping
+- [x] Twin Snakes uptime and clipping
 
 ### AoE
 - [x] Make sure there's enough enemies for RB or AotD effectiveness

--- a/src/parser/jobs/mnk/NOTES.md
+++ b/src/parser/jobs/mnk/NOTES.md
@@ -12,7 +12,7 @@
 - [ ] General auto-attack uptime
 - [ ] Earth Tackle, not even once
 - [x] Fists, make sure at least one is up
-- [ ] Fists of Fire uptime?
+- [x] Fists of Fire uptime
 - [x] Dragon Kick uptime and clipping
 - [x] Twin Snakes uptime and clipping
 

--- a/src/parser/jobs/mnk/Speedmod.js
+++ b/src/parser/jobs/mnk/Speedmod.js
@@ -9,13 +9,14 @@ const GREASED_LIGHTNING_STATUSES = [
 	STATUSES.GREASED_LIGHTNING_III.id,
 ]
 
+const ROF_SPEEDMOD = 1.15
+
 export default class Speedmod extends CoreSpeedmod {
-	/* NOTE: Use this to force modules to run before Speedmod. ie: normalise to generate Huton events so Speedmod can pick them up natively
+	// Force modules to run before Speedmod. ie: normalise to Greased Lightning events so Speedmod can pick them up natively
 	static dependencies = [
 		...CoreSpeedmod.dependencies,
-		'forms',
+		'greasedlightning', // eslint-disable-line xivanalysis/no-unused-dependencies
 	]
-	*/
 
 	_isRofActive = false
 
@@ -53,9 +54,6 @@ export default class Speedmod extends CoreSpeedmod {
 	}
 
 	getJobAdditionalSpeedbuffScalar() {
-		if (this._isRofActive) {
-			return 1.15
-		}
-		return 1.0
+		return this._isRofActive ? ROF_SPEEDMOD : 1
 	}
 }

--- a/src/parser/jobs/mnk/index.js
+++ b/src/parser/jobs/mnk/index.js
@@ -1,4 +1,5 @@
 import About from './About'
+import BuffUptime from './BuffUptime'
 import Demolish from './Demolish'
 import Fists from './Fists'
 import Forms from './Forms'
@@ -8,6 +9,7 @@ import Speedmod from './Speedmod'
 
 export default [
 	About,
+	BuffUptime,
 	Demolish,
 	Fists,
 	Forms,


### PR DESCRIPTION
Mostly building on @nfriendly's work in #110, I also added FoF uptime checking and fixed normalisation for speedmod a little. The checklist percentages here are very hit and miss and I'm on the fence about the severity but the logic is good so derp. If this is good to go, it also closes the older PR.