### PR TITLE
Implement fabrication queue via iterator

### DIFF
--- a/src/parser/core/Parser.js
+++ b/src/parser/core/Parser.js
@@ -23,6 +23,8 @@ class Parser {
 	_triggerModules = []
 	_moduleErrors = {}
 
+	_fabricationQueue = []
+
 	get currentTimestamp() {
 		// TODO: this.finished?
 		return Math.min(this.fight.end_time, this._timestamp)
@@ -106,30 +108,52 @@ class Parser {
 	}
 
 	parseEvents(events) {
+		// Iterator we're using to handle fabrication
+		function* iterateEvents(events) {
+			const eventIterator = events[Symbol.iterator]()
+
+			// Start the parse with an 'init' fab
+			yield this.hydrateFabrication({type: 'init'})
+
+			let obj
+			// eslint-disable-next-line no-cond-assign
+			while (!(obj = eventIterator.next()).done) {
+				// Iterate over the actual event first
+				yield obj.value
+
+				// Iterate over any fabrications arising from the event and clear the queue
+				yield* this._fabricationQueue
+				this._fabricationQueue = []
+			}
+
+			// Finish with 'complete' fab
+			yield this.hydrateFabrication({type: 'complete'})
+		}
+
 		// Create a copy of the module order that we'll use while parsing
 		this._triggerModules = this.moduleOrder.slice(0)
 
-		this.fabricateEvent({type: 'init'})
-
-		// Run the analysis pass
-		events.forEach(event => {
+		// Loop & trigger all the events & fabrications
+		for (const event of iterateEvents.bind(this)(events)) {
 			this._timestamp = event.timestamp
 			this.triggerEvent(event)
-		})
-
-		this.fabricateEvent({type: 'complete'})
+		}
 	}
 
-	fabricateEvent(event, trigger) {
+	hydrateFabrication(event) {
 		// TODO: they've got a 'triggered' prop too...?
-		this.triggerEvent({
+		return {
 			// Default to the current timestamp
 			timestamp: this.currentTimestamp,
-			trigger,
+
 			// Rest of the event, mark it as fab'd
 			...event,
 			__fabricated: true,
-		})
+		}
+	}
+
+	fabricateEvent(event) {
+		this._fabricationQueue.push(this.hydrateFabrication(event))
 	}
 
 	triggerEvent(event) {


### PR DESCRIPTION
* Changes the implementation details of event fabrication. Fabricated events now occur _after_ the current main event has been parsed, instead of interrupting mid-way through the module execution.
* Tweaks handling in `smn/Pets` to prevent issues arising from the above change.

Assuming modules execute `A` -> `B`, and `event` in `A` triggers `fab`,

**Before:**

```
A event
A fab
B fab
B event
```

**After:**

```
A event
B event
A fab
B fab
```
