### PR TITLE
Few tweaks for SMN

### DIFF
--- a/src/parser/jobs/smn/Aetherflow.js
+++ b/src/parser/jobs/smn/Aetherflow.js
@@ -9,6 +9,8 @@ import Module from 'parser/core/Module'
 import {Rule, Requirement} from 'parser/core/modules/Checklist'
 import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 // Statuses that need to be up for Fester & Bane to actually do something good
 const SMN_DOT_STATUSES = [
 	STATUSES.BIO_III.id,
@@ -44,6 +46,7 @@ export default class Aetherflow extends Module {
 		'gauge',
 		'suggestions',
 	]
+	static displayOrder = DISPLAY_ORDER.AETHERFLOW
 
 	// _badBanes = []         // In case we ever want to check for Banes where 1 or 0 DoTs are spread
 	// _reallyBadBanes = []   // DoTless Bane...

--- a/src/parser/jobs/smn/Aetherflow.js
+++ b/src/parser/jobs/smn/Aetherflow.js
@@ -176,15 +176,18 @@ export default class Aetherflow extends Module {
 			</Table.Header>
 			<Table.Body>
 				{casts.map((cast, i) => {
-					let drift = 0
+					let drift = null
 					if (i > 0) {
 						const prevCast = casts[i - 1]
 						drift = cast.timestamp - (prevCast.timestamp + prevCast.length)
+						if (process.env.NODE_ENV === 'production') {
+							drift = Math.max(drift, 0)
+						}
 					}
 					totalDrift += drift
 					return <Table.Row key={cast.timestamp}>
 						<Table.Cell>{this.parser.formatTimestamp(cast.timestamp)}</Table.Cell>
-						<Table.Cell>{drift ? this.parser.formatDuration(drift) : '-'}</Table.Cell>
+						<Table.Cell>{drift !== null ? this.parser.formatDuration(drift) : '-'}</Table.Cell>
 						<Table.Cell>{totalDrift ? this.parser.formatDuration(totalDrift) : '-'}</Table.Cell>
 					</Table.Row>
 				})}

--- a/src/parser/jobs/smn/Bahamut.js
+++ b/src/parser/jobs/smn/Bahamut.js
@@ -7,6 +7,8 @@ import PETS from 'data/PETS'
 import Module from 'parser/core/Module'
 import {SUMMON_BAHAMUT_LENGTH} from './Pets'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 const DEMI_BAHAMUT_ACTIONS = Object.values(ACTIONS)
 	.filter(action => action.pet && action.pet === PETS.DEMI_BAHAMUT.id)
 	.map(action => action.id)
@@ -29,6 +31,7 @@ export default class Bahamut extends Module {
 	static dependencies = [
 		'gauge',
 	]
+	static displayOrder = DISPLAY_ORDER.BAHAMUT
 
 	_current = null
 	_history = []

--- a/src/parser/jobs/smn/DISPLAY_ORDER.js
+++ b/src/parser/jobs/smn/DISPLAY_ORDER.js
@@ -1,0 +1,9 @@
+export default {
+	AETHERFLOW: 47,
+	// some DoT thing that's pinned that I haven't written yet
+	SHADOW_FLARE: 49,
+	RUIN_IV: 51,
+	DWT: 52,
+	BAHAMUT: 53,
+	PETS: 54,
+}

--- a/src/parser/jobs/smn/DWT.js
+++ b/src/parser/jobs/smn/DWT.js
@@ -9,6 +9,8 @@ import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {Suggestion, TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 const CORRECT_GCDS = [
 	ACTIONS.RUIN_III.id,
 	ACTIONS.RUIN_IV.id,
@@ -46,6 +48,7 @@ export default class DWT extends Module {
 		'suggestions',
 	]
 	static title = 'Dreadwyrm Trance'
+	static displayOrder = DISPLAY_ORDER.DWT
 
 	_active = false
 	_dwt = {}

--- a/src/parser/jobs/smn/DWT.js
+++ b/src/parser/jobs/smn/DWT.js
@@ -233,6 +233,7 @@ export default class DWT extends Module {
 	output() {
 		const panels = this._history.map(dwt => {
 			const numGcds = dwt.casts.filter(cast => getAction(cast.ability.guid).onGcd).length
+			const noDeathflare = dwt.casts.filter(cast => cast.ability.guid === ACTIONS.DEATHFLARE.id).length === 0
 			return {
 				key: dwt.start,
 				title: {
@@ -240,6 +241,7 @@ export default class DWT extends Module {
 						{this.parser.formatTimestamp(dwt.start)}
 						&nbsp;-&nbsp;{numGcds} GCDs
 						{dwt.rushing && <span className="text-info">&nbsp;(rushing)</span>}
+						{noDeathflare && <span className="text-error">&nbsp;(no Deathflare)</span>}
 					</Fragment>,
 				},
 				content: {

--- a/src/parser/jobs/smn/Pets.js
+++ b/src/parser/jobs/smn/Pets.js
@@ -10,6 +10,7 @@ import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {Suggestion, TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
 import styles from './Pets.module.css'
 
 const NO_PET_ID = -1
@@ -46,6 +47,7 @@ export default class Pets extends Module {
 	static dependencies = [
 		'suggestions',
 	]
+	static displayOrder = DISPLAY_ORDER.PETS
 
 	_lastPet = {id: NO_PET_ID}
 	_currentPet = null

--- a/src/parser/jobs/smn/Ruin4.js
+++ b/src/parser/jobs/smn/Ruin4.js
@@ -7,6 +7,8 @@ import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 // there's also the case where if you have further ruin and an egi is about to do gcd + ogcd and they held, that can be considered a no no
 // also if they are holding further ruin during Bahamut what are they even doing
 // that one is major as hell
@@ -42,6 +44,7 @@ export default class Ruin4 extends Module {
 		'suggestions',
 	]
 	static title = 'Ruin IV'
+	static displayOrder = DISPLAY_ORDER.RUIN_IV
 
 	_procChances = 0
 	_procs = 0

--- a/src/parser/jobs/smn/ShadowFlare.js
+++ b/src/parser/jobs/smn/ShadowFlare.js
@@ -79,6 +79,10 @@ export default class ShadowFlare extends Module {
 	}
 
 	output() {
+		if (!this._casts.length) {
+			return null
+		}
+
 		return <ul>
 			{this._casts.map(cast => <li key={cast.cast.timestamp}>
 				<strong>{this.parser.formatTimestamp(cast.cast.timestamp)}</strong>:&nbsp;

--- a/src/parser/jobs/smn/ShadowFlare.js
+++ b/src/parser/jobs/smn/ShadowFlare.js
@@ -7,6 +7,8 @@ import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 // In a single target scenario, SF should always tick 5 times
 const MIN_HITS = 5
 
@@ -26,6 +28,7 @@ export default class ShadowFlare extends Module {
 	static dependencies = [
 		'suggestions',
 	]
+	static displayOrder = DISPLAY_ORDER.SHADOW_FLARE
 
 	_casts = []
 


### PR DESCRIPTION
Nothing really new.

* Stops aetherflow from showing negative drift in production builds
* Adds red error text to DWTs w/ no DF
* Hides the SF module if someone was so bad as to never use SF at all
* Added some display order stuff so it's in a bit of a better order