### PR TITLE
Added completion% for languages in menu

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ indent_size = 2
 [package.json]
 indent_style = space
 indent_size = 2
+
+[yarn.lock]
+end_of_line = crlf

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,9 +1,40 @@
 /* global require, module */
+const _ = require('lodash')
+const glob = require('glob')
 const {injectBabelPlugin} = require('react-app-rewired')
 const rewireEslint = require('react-app-rewire-eslint')
 const rewireLodash = require('react-app-rewire-lodash')
+const webpack = require('webpack')
+
+const packageJson = require('./package.json')
 
 module.exports = (config, env) => {
+	// Pull in all the locale files
+	const localeFiles = glob.sync('./locale/*/messages.json')
+	const localeKeyRegex = /\/(\w{2})\/messages/
+	const localeCount = {}
+	localeFiles.forEach(file => {
+		const localeKey = localeKeyRegex.exec(file)[1]
+		const data = require(file)
+		localeCount[localeKey] = Object.values(data)
+			.reduce((carry, value) => carry + (value? 1 : 0), 0)
+	})
+
+	// Calculate the completion
+	const sourceLocale = packageJson.lingui.sourceLocale
+	const localeCompletion = _.reduce(localeCount, (carry, value, key) => {
+		carry[key] = ((value / localeCount[sourceLocale]) * 100).toFixed(0)
+		return carry
+	}, {})
+
+	// Add the completion%s to the environment
+	config.plugins = (config.plugins || []).concat([
+		new webpack.DefinePlugin({
+			'process.env.LOCALE_COMPLETION': localeCompletion,
+		}),
+	])
+
+	// Rest of the rewires
 	config = rewireEslint(config, env)
 	config = rewireLodash(config, env)
 

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-jest": "^21.22.0",
     "eslint-plugin-xivanalysis": "file:./linter",
+    "glob": "^7.1.3",
     "husky": "^1.0.0-rc.13",
     "jest-chain": "^1.0.3",
     "jest-extended": "^0.8.1",

--- a/src/data/LANGUAGES.js
+++ b/src/data/LANGUAGES.js
@@ -40,6 +40,7 @@ export const LANGUAGE_ARRAY = Object.entries(LANGUAGES)
 		val.value = key
 		if (val.menu) {
 			val.menu.value = key
+			val.menu.description = (process.env.LOCALE_COMPLETION[key] || '0') + '%'
 		}
 		return val
 	})

--- a/src/data/LANGUAGES.js
+++ b/src/data/LANGUAGES.js
@@ -40,7 +40,7 @@ export const LANGUAGE_ARRAY = Object.entries(LANGUAGES)
 		val.value = key
 		if (val.menu) {
 			val.menu.value = key
-			val.menu.description = (process.env.LOCALE_COMPLETION[key] || '0') + '%'
+			val.menu.description = ((process.env.LOCALE_COMPLETION || {})[key] || '0') + '%'
 		}
 		return val
 	})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3802,9 +3802,9 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"


### PR DESCRIPTION
This PR adds %s to the locale menu that display how complete that translation is. %s are calculated at build time, so there's no loading of locale data to render the info.

Aiming for this to be the first part of a few updates to the i18n, hoping to get something _visible_ by 4.4!

Preview:
![image](https://user-images.githubusercontent.com/534235/45227459-e569f380-b303-11e8-8180-031a383b9f12.png)

I have no idea how the lockfile ended up as CRLF but it is and I don't really want to deal with 9k+ line changes right now.
