### PR TITLE
ABC improvements for NIN

### DIFF
--- a/src/parser/jobs/nin/GlobalCooldown.js
+++ b/src/parser/jobs/nin/GlobalCooldown.js
@@ -21,7 +21,6 @@ export default class GlobalCooldown extends CoreGlobalCooldown {
 
 	getUptime() {
 		// Include the total TCJ duration (minus 50% of a GCD per cast) in our uptime calculation so it doesn't count against GCD usage
-		const tcjUptime = this.combatants.getStatusUptime(STATUSES.TEN_CHI_JIN.id)
-		return super.getUptime() + tcjUptime - (this._tcjUses * this.getEstimate() / 2)
+		return super.getUptime() + this.combatants.getStatusUptime(STATUSES.TEN_CHI_JIN.id) - (this._tcjUses * this.getEstimate() / 2)
 	}
 }

--- a/src/parser/jobs/nin/GlobalCooldown.js
+++ b/src/parser/jobs/nin/GlobalCooldown.js
@@ -1,0 +1,27 @@
+import CoreGlobalCooldown from 'parser/core/modules/GlobalCooldown'
+import STATUSES from 'data/STATUSES'
+import ACTIONS from 'data/ACTIONS'
+
+export default class GlobalCooldown extends CoreGlobalCooldown {
+	static dependencies = [
+		...CoreGlobalCooldown.dependencies,
+		'combatants',
+	]
+
+	_tcjUses = 0
+
+	constructor(...args) {
+		super(...args)
+		this.addHook('cast', {by: 'player', abilityId: ACTIONS.TEN_CHI_JIN.id}, this._onCastTcj)
+	}
+
+	_onCastTcj() {
+		this._tcjUses++
+	}
+
+	getUptime() {
+		// Include the total TCJ duration (minus 50% of a GCD per cast) in our uptime calculation so it doesn't count against GCD usage
+		const tcjUptime = this.combatants.getStatusUptime(STATUSES.TEN_CHI_JIN.id)
+		return super.getUptime() + tcjUptime - (this._tcjUses * this.getEstimate() / 2)
+	}
+}

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -1,6 +1,7 @@
 import About from './About'
 import Combos from './Combos'
 import Duality from './Duality'
+import GlobalCooldown from './GlobalCooldown'
 import Huton from './Huton'
 import Kassatsu from './Kassatsu'
 import Ninjutsu from './Ninjutsu'
@@ -15,6 +16,7 @@ export default [
 	About,
 	Combos,
 	Duality,
+	GlobalCooldown,
 	Huton,
 	Kassatsu,
 	Ninjutsu,

--- a/src/parser/jobs/nin/notes.md
+++ b/src/parser/jobs/nin/notes.md
@@ -3,8 +3,9 @@
 ### Ninjutsu
 - [x] Hyoton and Rabbit Medium casts (Ninjutsu.js)
 - [x] Single-target Dotons outside of TCJ (Ninjutsu.js)
-- [x] Huton uptime (Combos.js)
+- [x] Huton uptime (Huton.js)
 - [x] Kassatsu use and misuse (Kassatsu.js)
+- [x] Special GCD sauce to include TCJ as uptime (GlobalCooldown.js)
 - [ ] Using Ninjutsu on cooldown
 
 ### Ninki
@@ -15,7 +16,7 @@
 - [x] Aligning DWaD with Trick Attack windows (TrickAttackWindow.js)
 - [x] Avoiding Armor Crush inside Trick Attack windows (TrickAttackWindow.js)
 - [x] Missing Trick Attack positionals (TrickAttackPositional.js)
-- [ ] Using Trick Attack on cooldown
+- [x] Using Trick Attack on cooldown (TrickAttackUsage.js)
 
 ### DoTs
 - [x] Shadow Fang uptime and clipping (ShadowFang.js)


### PR DESCRIPTION
I added in a bit of special sauce for NIN so that TCJ wouldn't count against uptime. It basically just refunds you all the time you spent under TCJ, minus half a GCD's worth per cast (since you start it as a weave, not on the GCD). I also updated notes.md since it was a tad out of date.