### PR TITLE
Converted _wastedEarth to a counter

### DIFF
--- a/src/parser/jobs/mnk/GreasedLightning.js
+++ b/src/parser/jobs/mnk/GreasedLightning.js
@@ -40,7 +40,7 @@ export default class GreasedLightning extends Module {
 	_stacks = []
 
 	_earthSaves = []
-	_wastedEarth = []
+	_wastedEarth = 0
 
 	_windSaves = []
 	_wastedWind = []
@@ -174,7 +174,7 @@ export default class GreasedLightning extends Module {
 
 	_onReply(event) {
 		if (event.timestamp - this._lastRefresh > GL_TIMEOUT_MILLIS) {
-			this._wastedEarth.push(event.timestamp)
+			this._wastedEarth++
 		} else {
 			this._lastRefresh = event.timestamp
 		}


### PR DESCRIPTION
Per discussion with acchan in #support, switching this from an array to a counter, since it was used as both and that led to this hilarity:

![image](https://user-images.githubusercontent.com/7410959/45658004-bf3e1380-baba-11e8-9db1-c937f6d8e3b4.png)
