### PR TITLE
WHM 4.4 Version update: 

### DIFF
--- a/src/parser/jobs/whm/About.js
+++ b/src/parser/jobs/whm/About.js
@@ -34,7 +34,7 @@ export default class About extends CoreAbout {
 	</Fragment>
 	supportedPatches = {
 		from: '4.05',
-		to: '4.36',
+		to: '4.4',
 	}
 	contributors = [
 		{user: CONTRIBUTORS.VULCWEN, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Asylum isn't currently tracked; Tick change has no effect here. No issues with this job module in 4.4