### PR TITLE
Included a death refund for wipe logs

### DIFF
--- a/src/parser/core/modules/Death.js
+++ b/src/parser/core/modules/Death.js
@@ -61,11 +61,16 @@ export default class Death extends Module {
 			this.addDeathToTimeline(this.parser.fight.end_time)
 		}
 
-		// Deaths are always major
+		if (!this.parser.fight.kill) {
+			// If the parse was a wipe, refund one death since the last one is pretty meaningless to ding them on
+			this._count--
+		}
+
 		if (!this._count) {
 			return
 		}
 
+		// Deaths are always major
 		this.suggestions.add(new Suggestion({
 			icon: ACTIONS.RAISE.icon,
 			content: <Trans id="core.deaths.content">


### PR DESCRIPTION
Per issue #207, I twiddled the `Death.js` module so it ignores one death if the parse it's analyzing is a wipe, since bitching about the wipe-induced death is pretty unhelpful.