### PR TITLE
Timeline tweaks

### DIFF
--- a/src/parser/core/modules/Timeline/Timeline.js
+++ b/src/parser/core/modules/Timeline/Timeline.js
@@ -1,11 +1,11 @@
+import {Trans, i18nMark} from '@lingui/react'
 import React from 'react'
-import {i18nMark} from '@lingui/react'
 import VisTimeline from 'react-visjs-timeline'
 import vis from 'vis/dist/vis-timeline-graph2d.min'
 
 import Module, {DISPLAY_ORDER} from 'parser/core/Module'
 
-import './Timeline.module.css'
+import styles from './Timeline.module.css'
 
 // We default to showing the first minute of the pull
 const ONE_MINUTE = 60000
@@ -65,10 +65,15 @@ export default class Timeline extends Module {
 			horizontalScroll: true,
 		}
 
-		return <VisTimeline
-			options={options}
-			groups={this._groups.map(group => group.getObject())}
-			items={this._items.map(item => item.getObject())}
-		/>
+		return <>
+			<Trans id="core.timeline.help-text" render="span" className={styles.helpText}>
+				Scroll or click+drag to pan, ctrl+scroll or pinch to zoom.
+			</Trans>
+			<VisTimeline
+				options={options}
+				groups={this._groups.map(group => group.getObject())}
+				items={this._items.map(item => item.getObject())}
+			/>
+		</>
 	}
 }

--- a/src/parser/core/modules/Timeline/Timeline.js
+++ b/src/parser/core/modules/Timeline/Timeline.js
@@ -1,5 +1,6 @@
 import {Trans, i18nMark} from '@lingui/react'
 import React from 'react'
+import {scroller} from 'react-scroll'
 import VisTimeline from 'react-visjs-timeline'
 import vis from 'vis/dist/vis-timeline-graph2d.min'
 
@@ -15,10 +16,20 @@ export default class Timeline extends Module {
 	static displayOrder = DISPLAY_ORDER.BOTTOM
 
 	static i18n_id = i18nMark('core.timeline.title')
-	static title  = 'Timeline'
+	static title = 'Timeline'
 
+	// Data to be displayed on the timeline
 	_groups = []
 	_items = []
+
+	// Ref for the timeline component so we can modify it post-render
+	_ref = null
+
+	constructor(...args) {
+		super(...args)
+
+		this._ref = React.createRef()
+	}
 
 	// TODO: Do more with these, it's pretty bad rn
 	addGroup(group) {
@@ -27,6 +38,23 @@ export default class Timeline extends Module {
 
 	addItem(item) {
 		this._items.push(item)
+	}
+
+	/**
+	 * Move & zoom the viewport to show the specified range
+	 * @param {number} start - Timestamp of the start of the range
+	 * @param {number} end - Timestamp of the end of the range
+	 * @param {boolean} [scrollTo=true] - If true, the page will scroll to reveal the timeline on call.
+	 */
+	show(start, end, scrollTo=true) {
+		// Grab the vis instance. This is a bit hacky but so is vis so /shrug
+		const vis = this._ref.current.$el
+		vis.setWindow(start, end)
+
+		// If not disabled, scroll the page to us
+		if (scrollTo) {
+			scroller.scrollTo(this.constructor.title)
+		}
 	}
 
 	output() {
@@ -70,6 +98,7 @@ export default class Timeline extends Module {
 				Scroll or click+drag to pan, ctrl+scroll or pinch to zoom.
 			</Trans>
 			<VisTimeline
+				ref={this._ref}
 				options={options}
 				groups={this._groups.map(group => group.getObject())}
 				items={this._items.map(item => item.getObject())}

--- a/src/parser/core/modules/Timeline/Timeline.js
+++ b/src/parser/core/modules/Timeline/Timeline.js
@@ -59,6 +59,10 @@ export default class Timeline extends Module {
 			// Show first minute by default, full fight view is a bit hard to grok.
 			start: 0,
 			end: Math.min(this.parser.fightDuration, ONE_MINUTE),
+
+			// Zoom key handling
+			zoomKey: 'ctrlKey',
+			horizontalScroll: true,
 		}
 
 		return <VisTimeline

--- a/src/parser/core/modules/Timeline/Timeline.module.css
+++ b/src/parser/core/modules/Timeline/Timeline.module.css
@@ -1,3 +1,15 @@
+.helpText {
+	font-style: italic;
+}
+
+@media (min-width: 992px) {
+	.helpText {
+		position: absolute;
+		top: 1em;
+		right: 0;
+	}
+}
+
 :global .vis-background .vis-item-content {
 	padding: 0;
 	height: 100%;


### PR DESCRIPTION
This PR:

- _Finally_ fixes gestures on touchpads.
  - Scroll will now scroll the view (horizontally), ctrl+scroll will zoom. Click+drag works as before.
- Adds the new `timeline.show` function for other modules to consume.

@AkairyuGestalter this may be of interest to you - lmk thoughts on `.show` re: your stuff.