### PR TITLE
Add Crit and Direct Hit tracking to events

### DIFF
--- a/src/parser/core/modules/HitType.js
+++ b/src/parser/core/modules/HitType.js
@@ -1,0 +1,24 @@
+import Module from 'parser/core/Module'
+
+const ACTION_EVENT_TYPES = [
+	'damage',
+	'heal',
+]
+
+export default class HitType extends Module {
+	static handle = 'hittype'
+
+	normalise(events) {
+		for (let i = 0; i < events.length; i++) {
+			const event = events[i]
+
+			// Prune to only damage and heals since nothing else can crit/direct hit
+			if (!ACTION_EVENT_TYPES.includes(event.type)) { continue }
+
+			event.criticalHit = event.hitType === 2
+			event.directHit = event.multistrike === true
+		}
+
+		return events
+	}
+}

--- a/src/parser/core/modules/index.js
+++ b/src/parser/core/modules/index.js
@@ -13,6 +13,7 @@ import Death from './Death'
 import Downtime from './Downtime'
 import Enemies from './Enemies'
 import GlobalCooldown from './GlobalCooldown'
+import HitType from './HitType'
 import Invulnerability from './Invulnerability'
 import Potions from './Potions'
 import PrecastAction from './PrecastAction'
@@ -40,6 +41,7 @@ export default [
 	Downtime,
 	Enemies,
 	GlobalCooldown,
+	HitType,
 	Invulnerability,
 	Potions,
 	PrecastAction,


### PR DESCRIPTION
Basically Object boolean fields for `criticalHit` and `directHit`. Should be able to filter on these, for CDH would need both fields. Applies to `damage` and `heal` event types. AoE doesn't really support anything for individual hits that I know of so for finding AoE crits for example, would need to filter the damage events and the actual skill ID.