### PR TITLE
Twiddled weaving logic for NIN

### DIFF
--- a/src/parser/jobs/nin/Weaving.js
+++ b/src/parser/jobs/nin/Weaving.js
@@ -80,8 +80,8 @@ export default class Weaving extends CoreWeaving {
 			}
 		}
 
-		if (ninjutsuCounted || dwadDupe) {
-			return weaveCount > 1
+		if ((ninjutsuCounted || dwadDupe) && weaveCount === 1) {
+			return false
 		}
 
 		return super.isBadWeave(weave, 1)


### PR DESCRIPTION
Now it should fall back on the default logic for big weaves regardless of whether or not they included a Ninjutsu/duped DWaD cast, so the "ignore downtime weaves" logic should apply.