### PR TITLE
Fix logs that ended on GL3 for uptime calculation

### DIFF
--- a/src/parser/jobs/mnk/GreasedLightning.js
+++ b/src/parser/jobs/mnk/GreasedLightning.js
@@ -313,7 +313,7 @@ export default class GreasedLightning extends Module {
 
 		const statusUptime = this._stacks.reduce((duration, value, index) => {
 			const last = this._stacks[index-1] || {}
-			if (value.stack === 0 && last.stack === GL_MAX_STACKS) {
+			if ([0, GL_MAX_STACKS].includes(value.stack) && last.stack === GL_MAX_STACKS) {
 				duration += value.timestamp - last.timestamp
 			}
 


### PR DESCRIPTION
Still not really happy with this logic, it basically calculates total GL3 spanning the whole fight even where downtime occurred. Maybe just using `getStatusUptime` with a filter on stacks could work, not sure how that goes for `applybuffstack` buffs. This should at least fix the log for Jojo Zep of Tonberry. Open to any ideas for subtracting downtime segments.