### PR TITLE
Fixed a bug in the Blood of the Dragon simulation module

### DIFF
--- a/src/parser/jobs/drg/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/BloodOfTheDragon.js
@@ -70,12 +70,13 @@ export default class BloodOfTheDragon extends Module {
 			}
 		} else {
 			this._bloodDuration -= elapsedTime
-			if (this._bloodDuration <= 0) {
-				// Blood fell off; reset everything
-				this._bloodDowntime -= this._bloodDuration // Actually addition
-				this._bloodDuration = 0
-				this._eyes = 0
-			}
+		}
+
+		if (this._bloodDuration <= 0) {
+			// Blood fell off; reset everything
+			this._bloodDowntime -= this._bloodDuration // Actually addition
+			this._bloodDuration = 0
+			this._eyes = 0
 		}
 
 		this._lastEventTime = this.parser.currentTimestamp


### PR DESCRIPTION
Because the `this._bloodDuration <= 0` check wasn't happening in the LotD reversion logic, the sim was falsely persisting BotD through lengthy downtimes and allowing the player to keep eyes they should've lost, offsetting their LotD windows and generally fucking everything up.