### PR TITLE
Totally unnecessary refactor of fetchEventsAndParse

### DIFF
--- a/src/components/Analyse/Analyse.js
+++ b/src/components/Analyse/Analyse.js
@@ -170,10 +170,10 @@ class Analyse extends Component {
 		try {
 			(await Promise.all(modules.map(meta => meta.modules())))
 				.forEach(({default: loadedModules = []}, index) => {
-					// TODO: at this point the UnloadedModuleMeta should be cast to a proper ModuleMeta once that is defined
-					const meta = modules[index]
-					meta.modules = loadedModules
-					parser.addMeta(meta)
+					parser.addMeta({
+						...modules[index],
+						modules: loadedModules,
+					})
 				})
 		} catch (error) {
 			if (process.env.NODE_ENV === 'development') {

--- a/src/components/Analyse/Analyse.js
+++ b/src/components/Analyse/Analyse.js
@@ -202,7 +202,7 @@ class Analyse extends Component {
 
 	// Normalise module metadata - old modules are just an async to load the module group, new ones have proper metadata
 	/**
-	 * @template T extends import('../Module').default
+	 * @template T extends (typeof import('../Module').default)[]
 	 * @param {UnloadedModuleMeta<T>|(() => Promise<T>)} meta
 	 * @returns {UnloadedModuleMeta<T>}
 	 */

--- a/src/components/Analyse/Analyse.js
+++ b/src/components/Analyse/Analyse.js
@@ -170,6 +170,7 @@ class Analyse extends Component {
 		try {
 			(await Promise.all(modules.map(meta => meta.modules())))
 				.forEach(({default: loadedModules = []}, index) => {
+					// TODO: at this point the UnloadedModuleMeta should be cast to a proper ModuleMeta once that is defined
 					const meta = modules[index]
 					meta.modules = loadedModules
 					parser.addMeta(meta)

--- a/src/parser/core/Module.js
+++ b/src/parser/core/Module.js
@@ -34,6 +34,10 @@ export default class Module {
 
 	_hooks = new Map()
 
+	/**
+	 *
+	 * @param {import('./Parser').default} parser
+	 */
 	constructor(parser) {
 		this.parser = parser
 		this.constructor.dependencies.forEach(dep => {

--- a/src/parser/core/Parser.js
+++ b/src/parser/core/Parser.js
@@ -19,11 +19,16 @@ class Parser {
 	meta = {}
 	_timestamp = 0
 
+	/** @type {Record<string, import('./Module').default>} */
 	modules = {}
+	/** @type {Record<string, typeof import('./Module').default>} */
 	_constructors = {}
 
+	/** @type {string[]} */
 	moduleOrder = []
+	/** @type {string[]} */
 	_triggerModules = []
+	/** @type {Record<string, Error | { toString (): string }>} */
 	_moduleErrors = {}
 
 	_fabricationQueue = []


### PR DESCRIPTION
The use of the object and its keys made it more error-prone than just using an array to hold the modules.

`Promise.all` is guaranteed to return the results in the same order as the input iterable yielded them, regardless of load order, so we can trust the indexes to be the same.