### PR TITLE
Fixed a minor DRG bug

### DIFF
--- a/src/parser/jobs/drg/modules/Procs.js
+++ b/src/parser/jobs/drg/modules/Procs.js
@@ -85,7 +85,7 @@ export default class Procs extends Module {
 			},
 			value: droppedMirage,
 			why: <Trans id="drg.procs.suggestions.mirage-dropped.why">
-				You dropped <Plural value={droppedWheeling} one="# Mirage Dive proc" other="# Mirage Dive procs"/>.
+				You dropped <Plural value={droppedMirage} one="# Mirage Dive proc" other="# Mirage Dive procs"/>.
 			</Trans>,
 		}))
 


### PR DESCRIPTION
Funny story, using one variable for the `value` and another in the `why` text for a suggestion produces goofy results.