### PR TITLE
Move Demolish to core DoT module and add display order to MNK checklists

### DIFF
--- a/src/parser/jobs/mnk/modules/BuffUptime.js
+++ b/src/parser/jobs/mnk/modules/BuffUptime.js
@@ -6,6 +6,7 @@ import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {Rule, Requirement} from 'parser/core/modules/Checklist'
 import {Suggestion, TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 const GCD_CYCLE_LENGTH = 6
 
@@ -106,6 +107,7 @@ export default class BuffUptime extends Module {
 			description: <Fragment>
 				Dragon Kick's blunt resistance debuff should always be applied to your primary target.
 			</Fragment>,
+			displayOrder: DISPLAY_ORDER.DRAGON_KICK,
 			requirements: [
 				new Requirement({
 					name: <Fragment><ActionLink {...ACTIONS.DRAGON_KICK} /> uptime</Fragment>,
@@ -119,6 +121,7 @@ export default class BuffUptime extends Module {
 			description: <Fragment>
 				Twin Snakes is an easy 10% buff to your DPS across the board.
 			</Fragment>,
+			displayOrder: DISPLAY_ORDER.TWIN_SNAKES,
 			requirements: [
 				new Requirement({
 					name: <Fragment><ActionLink {...ACTIONS.TWIN_SNAKES} /> uptime</Fragment>,

--- a/src/parser/jobs/mnk/modules/DISPLAY_ORDER.js
+++ b/src/parser/jobs/mnk/modules/DISPLAY_ORDER.js
@@ -3,4 +3,7 @@ export default {
 	RIDDLE_OF_FIRE: 2,
 	INTERNAL_RELEASE: 3,
 	FISTS: 4,
+	DRAGON_KICK: 5,
+	TWIN_SNAKES: 6,
+	DEMOLISH: 7,
 }

--- a/src/parser/jobs/mnk/modules/Demolish.js
+++ b/src/parser/jobs/mnk/modules/Demolish.js
@@ -4,72 +4,42 @@ import {ActionLink, StatusLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
 
-import Module from 'parser/core/Module'
+import DoTs from 'parser/core/modules/DoTs'
 import {Rule, Requirement} from 'parser/core/modules/Checklist'
 import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+import DISPLAY_ORDER from './DISPLAY_ORDER'
 
-const DEMO_DURATION_MILLIS = STATUSES.DEMOLISH.duration * 1000
-
-export default class Demolish extends Module {
-	static handle = 'demolish'
+export default class Demolish extends DoTs {
 	static dependencies = [
+		...DoTs.dependencies,
 		'checklist',
-		'enemies',
-		'invuln',
 		'suggestions',
 	]
 
-	_clipDemo = 0
-	_lastDemo = {}
+	static statusesToTrack = [
+		STATUSES.DEMOLISH.id,
+	]
 
-	constructor(...args) {
-		super(...args)
-
-		const filter = {
-			by: 'player',
-			abilityId: STATUSES.DEMOLISH.id,
-		}
-
-		this.addHook(['applydebuff', 'refreshdebuff'], filter, this._onApply)
-		this.addHook('complete', this._onComplete)
-	}
-
-	// Aggregate Demo uptime
-	_onApply(event) {
-		const applicationKey = `${event.targetID}|${event.targetInstance}`
-		const lastDemo = this._lastDemo[applicationKey] = this._lastDemo[applicationKey] || 0
-
-		if (!lastDemo) {
-			this._lastDemo[applicationKey] = event.timestamp
-			return
-		}
-
-		let clip = DEMO_DURATION_MILLIS - (event.timestamp - lastDemo)
-
-		clip -= this.invuln.getUntargetableUptime('all', event.timestamp - DEMO_DURATION_MILLIS, event.timestamp)
-		clip -= this.invuln.getInvulnerableUptime('all', event.timestamp, event.timestamp + DEMO_DURATION_MILLIS + clip)
-
-		this._clipDemo += Math.max(0, clip)
-		this._lastDemo[applicationKey] = event.timestamp
-	}
-
-	_onComplete() {
+	addChecklistRules() {
 		this.checklist.add(new Rule({
 			name: 'Keep Demolish up',
 			description: <Fragment>
 				<ActionLink {...ACTIONS.DEMOLISH}/> is your strongest finisher (assuming at least 4 DoT ticks hit).
 			</Fragment>,
+			displayOrder: DISPLAY_ORDER.DEMOLISH,
 			requirements: [
 				new Requirement({
 					name: <Fragment><ActionLink {...ACTIONS.DEMOLISH}/> uptime</Fragment>,
-					percent: () => this.getDotUptimePercent(),
+					percent: () => this.getUptimePercent(STATUSES.DEMOLISH.id),
 				}),
 			],
 			// TODO: calculate the number of good Demolishes a fight should have
 			//       and set target to allow dropping without losing a tick
 			target: 85,
 		}))
+	}
 
+	addClippingSuggestions(clip) {
 		this.suggestions.add(new TieredSuggestion({
 			icon: ACTIONS.DEMOLISH.icon,
 			content: <Fragment>
@@ -80,22 +50,10 @@ export default class Demolish extends Module {
 				10: SEVERITY.MEDIUM,
 				12: SEVERITY.MAJOR,
 			},
-			value: this.getDotClippingAmount(),
+			value: this.getClippingAmount(STATUSES.DEMOLISH.id),
 			why: <Fragment>
-				You lost {this.parser.formatDuration(this._clipDemo)} of Demolish to early refreshes.
+				You lost {this.parser.formatDuration(clip[STATUSES.DEMOLISH.id])} of Demolish to early refreshes.
 			</Fragment>,
 		}))
-	}
-
-	getDotUptimePercent() {
-		const statusUptime = this.enemies.getStatusUptime(STATUSES.DEMOLISH.id)
-		const fightDuration = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
-		return (statusUptime / fightDuration) * 100
-	}
-
-	getDotClippingAmount() {
-		const fightDurationMillis = (this.parser.fightDuration - this.invuln.getInvulnerableUptime())
-		const clipSecsPerMin = Math.round((this._clipDemo * 60) / fightDurationMillis)
-		return clipSecsPerMin
 	}
 }

--- a/src/parser/jobs/mnk/modules/GreasedLightning.js
+++ b/src/parser/jobs/mnk/modules/GreasedLightning.js
@@ -261,6 +261,7 @@ export default class GreasedLightning extends Module {
 			description: <Fragment>
 				<StatusLink {...STATUSES.GREASED_LIGHTNING_I}/> is a huge chunk of MNK's damage, increasing your damage by 30% and attack speed by 15%.
 			</Fragment>,
+			displayOrder: DISPLAY_ORDER.GREASED_LIGHTNING,
 			requirements: [
 				new Requirement({
 					name: <Fragment><StatusLink {...STATUSES.GREASED_LIGHTNING_I}/> uptime</Fragment>,


### PR DESCRIPTION
This is basically a transparent change, Demo still needs work around GL0 and intentional clipping but the rules for it are complicated so just migrating to get rid of that annoying magic-numbers warning tbh.