### PR TITLE
Add a check for undesirable MNK skills

### DIFF
--- a/src/data/ACTIONS/MNK.js
+++ b/src/data/ACTIONS/MNK.js
@@ -97,6 +97,7 @@ export default {
 		name: 'Earth Tackle',
 		icon: 'https://xivapi.com/i/002000/002538.png',
 		cooldown: 30,
+		potency: 100,
 	},
 
 	RIDDLE_OF_WIND: {
@@ -104,6 +105,7 @@ export default {
 		name: 'Riddle of Wind',
 		icon: 'https://xivapi.com/i/002000/002543.png',
 		cooldown: 0,
+		potency: 65,
 	},
 
 	WIND_TACKLE: {
@@ -111,6 +113,7 @@ export default {
 		name: 'Wind Tackle',
 		icon: 'https://xivapi.com/i/002000/002539.png',
 		cooldown: 30,
+		potency: 65,
 	},
 
 	RIDDLE_OF_FIRE: {
@@ -125,6 +128,7 @@ export default {
 		name: 'Fire Tackle',
 		icon: 'https://xivapi.com/i/002000/002540.png',
 		cooldown: 30,
+		potency: 130,
 	},
 
 	BROTHERHOOD: {

--- a/src/parser/jobs/mnk/NOTES.md
+++ b/src/parser/jobs/mnk/NOTES.md
@@ -3,14 +3,14 @@
 ### Uptime
 - [?] Don't clip or drop Demolish by more than 2 seconds, unless reapplying would be on GL0
 - [ ] Avoid GL0 Demolish applications, if opener or downtime ignore this
-- [ ] Migrate Demo to core DoTs module
 - [x] GL3 uptime
 - [ ] GL3 efficient recovery
 - [x] GL3 holding with RoE
 - [ ] Advise when downtime was short enough and damage taken for RoE, or if Tackle is off cooldown for RoW
 - [x] Wasted RoE
 - [x] Wasted RoW
-- [ ] Earth Tackle, not even once
+- [x] Earth Tackle, not even once
+- [x] One-Ilm Punch is Officially Undesirable
 - [x] Fists, make sure at least one is up
 - [x] Dragon Kick uptime and clipping
 - [x] Twin Snakes uptime and clipping

--- a/src/parser/jobs/mnk/NOTES.md
+++ b/src/parser/jobs/mnk/NOTES.md
@@ -7,8 +7,8 @@
 - [ ] GL3 efficient recovery
 - [x] GL3 holding with RoE
 - [ ] Advise when downtime was short enough and damage taken for RoE, or if Tackle is off cooldown for RoW
-- [x] Wasted RoE
-- [x] Wasted RoW
+- [x] Wasted RoE (no trigger RoE, or no save stacks)
+- [x] Wasted RoW (TODO: deal with WT without using RoW)
 - [x] Earth Tackle, not even once
 - [x] One-Ilm Punch is Officially Undesirable
 - [x] Fists, make sure at least one is up

--- a/src/parser/jobs/mnk/modules/DISPLAY_ORDER.js
+++ b/src/parser/jobs/mnk/modules/DISPLAY_ORDER.js
@@ -6,4 +6,5 @@ export default {
 	DRAGON_KICK: 5,
 	TWIN_SNAKES: 6,
 	DEMOLISH: 7,
+	UNDESIRABLES: 10,
 }

--- a/src/parser/jobs/mnk/modules/GreasedLightning.js
+++ b/src/parser/jobs/mnk/modules/GreasedLightning.js
@@ -243,13 +243,8 @@ export default class GreasedLightning extends Module {
 			}
 		})
 
-		// Push wasted saves
-		this._earthSaves.forEach(earth => {
-			if (!earth.clean) {
-				this._wastedEarth++
-			}
-		})
-
+		// Count missed saves
+		const missedEarth = this._earthSaves.filter(earth => !earth.clean).length
 		this._windSaves.forEach(wind => {
 			if (!wind.clean) {
 				this._wastedWind++
@@ -273,7 +268,7 @@ export default class GreasedLightning extends Module {
 			target: 92,
 		}))
 
-		if (this._droppedStacks > 0) {
+		if (this._droppedStacks) {
 			this.suggestions.add(new Suggestion({
 				icon: 'https://secure.xivdb.com/img/game/001000/001775.png', // Name of Lightning
 				content: <Fragment>
@@ -286,7 +281,7 @@ export default class GreasedLightning extends Module {
 			}))
 		}
 
-		if (this._wastedEarth > 0) {
+		if (this._wastedEarth) {
 			this.suggestions.add(new Suggestion({
 				icon: ACTIONS.RIDDLE_OF_EARTH.icon,
 				content: <Fragment>
@@ -299,7 +294,20 @@ export default class GreasedLightning extends Module {
 			}))
 		}
 
-		if (this._wastedWind > 0) {
+		if (missedEarth) {
+			this.suggestions.add(new Suggestion({
+				icon: ACTIONS.RIDDLE_OF_EARTH.icon,
+				content: <Fragment>
+					Check the fight timeline to see when you can save <StatusLink {...STATUSES.GREASED_LIGHTNING_I} /> with <ActionLink {...ACTIONS.RIDDLE_OF_EARTH} />.
+				</Fragment>,
+				severity: SEVERITY.MINOR,
+				why: <Fragment>
+					<ActionLink {...ACTIONS.RIDDLE_OF_EARTH} /> was used {missedEarth} times without preserving <StatusLink {...STATUSES.GREASED_LIGHTNING_I} />,
+				</Fragment>,
+			}))
+		}
+
+		if (this._wastedWind) {
 			this.suggestions.add(new Suggestion({
 				icon: ACTIONS.RIDDLE_OF_WIND.icon,
 				content: <Fragment>

--- a/src/parser/jobs/mnk/modules/Undesirables.js
+++ b/src/parser/jobs/mnk/modules/Undesirables.js
@@ -1,4 +1,4 @@
-import React, {Fragment} from 'react'
+import React from 'react'
 
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS, {getAction} from 'data/ACTIONS'
@@ -49,31 +49,31 @@ export default class Undesirables extends Module {
 
 		this.suggestions.add(new TieredSuggestion({
 			icon: ACTIONS.EARTH_TACKLE.icon,
-			content: <Fragment>
+			content: <>
 				Avoid using <ActionLink {...ACTIONS.EARTH_TACKLE} /> as you're losing uses of the higher potency <ActionLink {...ACTIONS.FIRE_TACKLE} />.
-			</Fragment>,
+			</>,
 			tiers: {
 				1: SEVERITY.MEDIUM,
 				2: SEVERITY.MAJOR,
 			},
 			value: earthTackleCount,
-			why: <Fragment>
+			why: <>
 				{lostTacklePotency} potency lost to inefficient tackles.
-			</Fragment>,
+			</>,
 		}))
 
 		this.suggestions.add(new TieredSuggestion({
 			icon: ACTIONS.ONE_ILM_PUNCH.icon,
-			content: <Fragment>
+			content: <>
 				Avoid using <ActionLink {...ACTIONS.ONE_ILM_PUNCH} /> as you're losing uses of the higher potency <ActionLink {...ACTIONS.TRUE_STRIKE} /> and <ActionLink {...ACTIONS.TWIN_SNAKES} />.
-			</Fragment>,
+			</>,
 			tiers: {
 				1: SEVERITY.MAJOR,
 			},
 			value: oneIlmPunchCount,
-			why: <Fragment>
+			why: <>
 				<ActionLink {...ACTIONS.ONE_ILM_PUNCH} /> cost {oneIlmPunchCount} more potent GCDs.
-			</Fragment>,
+			</>,
 		}))
 	}
 

--- a/src/parser/jobs/mnk/modules/Undesirables.js
+++ b/src/parser/jobs/mnk/modules/Undesirables.js
@@ -45,7 +45,7 @@ export default class Undesirables extends Module {
 	_onComplete() {
 		const oneIlmPunchCount = this._undesirables.filter(event => event.id === ACTIONS.ONE_ILM_PUNCH.id).length
 		const earthTackleCount = this._undesirables.filter(event => event.id === ACTIONS.EARTH_TACKLE.id).length
-		const lostTacklePotency = earthTackleCount * (ACTIONS.FIRE_TACKLE.potency -	ACTIONS.EARTH_TACKLE.potency)
+		const lostTacklePotency = earthTackleCount * (ACTIONS.FIRE_TACKLE.potency - ACTIONS.EARTH_TACKLE.potency)
 
 		this.suggestions.add(new TieredSuggestion({
 			icon: ACTIONS.EARTH_TACKLE.icon,
@@ -58,7 +58,7 @@ export default class Undesirables extends Module {
 			},
 			value: earthTackleCount,
 			why: <Fragment>
-				{lostTacklePotency} potency lost to <ActionLink {...ACTIONS.EARTH_TACKLE} />.
+				{lostTacklePotency} potency lost to inefficient tackles.
 			</Fragment>,
 		}))
 

--- a/src/parser/jobs/mnk/modules/Undesirables.js
+++ b/src/parser/jobs/mnk/modules/Undesirables.js
@@ -1,0 +1,102 @@
+import React, {Fragment} from 'react'
+
+import {ActionLink} from 'components/ui/DbLink'
+import ACTIONS, {getAction} from 'data/ACTIONS'
+import Module from 'parser/core/Module'
+import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+import {Table} from 'semantic-ui-react'
+
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
+const UNDESIRABLES = [
+	ACTIONS.EARTH_TACKLE.id,
+	ACTIONS.ONE_ILM_PUNCH.id,
+]
+
+export default class Undesirables extends Module {
+	static handle = 'undesirables'
+	static dependencies = [
+		'suggestions',
+	]
+
+	static title = 'Undesirable Skills'
+	static displayOrder = DISPLAY_ORDER.UNDESIRABLES
+
+	_undesirables = []
+
+	constructor(...args) {
+		super(...args)
+
+		this.addHook('cast', {by: 'player', abilityId: UNDESIRABLES}, this._onBad)
+		this.addHook('complete', this._onComplete)
+	}
+
+	_onBad(event) {
+		const actionId = event.ability.guid
+
+		// WTF but always worth checking
+		if (!actionId) {
+			return
+		}
+
+		this._undesirables.push({id: actionId, timestamp: event.timestamp})
+	}
+
+	_onComplete() {
+		const oneIlmPunchCount = this._undesirables.filter(event => event.id === ACTIONS.ONE_ILM_PUNCH.id).length
+		const earthTackleCount = this._undesirables.filter(event => event.id === ACTIONS.EARTH_TACKLE.id).length
+		const lostTacklePotency = earthTackleCount * (ACTIONS.FIRE_TACKLE.potency -	ACTIONS.EARTH_TACKLE.potency)
+
+		this.suggestions.add(new TieredSuggestion({
+			icon: ACTIONS.EARTH_TACKLE.icon,
+			content: <Fragment>
+				Avoid using <ActionLink {...ACTIONS.EARTH_TACKLE} /> as you're losing uses of the higher potency <ActionLink {...ACTIONS.FIRE_TACKLE} />.
+			</Fragment>,
+			tiers: {
+				1: SEVERITY.MEDIUM,
+				2: SEVERITY.MAJOR,
+			},
+			value: earthTackleCount,
+			why: <Fragment>
+				{lostTacklePotency} potency lost to <ActionLink {...ACTIONS.EARTH_TACKLE} />.
+			</Fragment>,
+		}))
+
+		this.suggestions.add(new TieredSuggestion({
+			icon: ACTIONS.ONE_ILM_PUNCH.icon,
+			content: <Fragment>
+				Avoid using <ActionLink {...ACTIONS.ONE_ILM_PUNCH} /> as you're losing uses of the higher potency <ActionLink {...ACTIONS.TRUE_STRIKE} /> and <ActionLink {...ACTIONS.TWIN_SNAKES} />.
+			</Fragment>,
+			tiers: {
+				1: SEVERITY.MAJOR,
+			},
+			value: oneIlmPunchCount,
+			why: <Fragment>
+				<ActionLink {...ACTIONS.ONE_ILM_PUNCH} /> cost {oneIlmPunchCount} more potent GCDs.
+			</Fragment>,
+		}))
+	}
+
+	output() {
+		if (!this._undesirables.length > 0) {
+			return false
+		}
+
+		return <Table collapsing unstackable compact="very">
+			<Table.Header>
+				<Table.Row>
+					<Table.HeaderCell>Skill</Table.HeaderCell>
+					<Table.HeaderCell>Time</Table.HeaderCell>
+				</Table.Row>
+			</Table.Header>
+			<Table.Body>
+				{this._undesirables.map(bad => {
+					return <Table.Row key={bad.timestamp}>
+						<Table.Cell><ActionLink {...getAction(bad.id)} /></Table.Cell>
+						<Table.Cell>{this.parser.formatTimestamp(bad.timestamp)}</Table.Cell>
+					</Table.Row>
+				})}
+			</Table.Body>
+		</Table>
+	}
+}

--- a/src/parser/jobs/mnk/modules/index.js
+++ b/src/parser/jobs/mnk/modules/index.js
@@ -8,6 +8,7 @@ import InternalRelease from './InternalRelease'
 import MnkAoE from './MnkAoE'
 import RiddleOfFire from './RiddleOfFire'
 import Speedmod from './Speedmod'
+import Undesirables from './Undesirables'
 
 export default [
 	BuffUptime,
@@ -20,4 +21,5 @@ export default [
 	MnkAoE,
 	RiddleOfFire,
 	Speedmod,
+	Undesirables,
 ]


### PR DESCRIPTION
This could probably be a core module tbh, seems relevant to NIN and BLM too.

Rolling in a minor bug fix to the suggestion on Earth's Reply to make the actual suggestion clearer. A more general rework of Earth's Reply needs to happen in the future since there are times it's worth having for defence that shouldn't penalise users. It's currently minor so won't show for most players which is why I'm leaving it for now.