### PR TITLE
Invalidate AoE damage events that do no damage

### DIFF
--- a/src/parser/core/index.ts
+++ b/src/parser/core/index.ts
@@ -1,6 +1,6 @@
 import {ReactNode} from 'react'
 
-import {Contributor, Role} from 'data/CONTRIBUTORS'
+import CONTRIBUTORS, {Contributor, Role} from 'data/CONTRIBUTORS'
 import {PatchNumber} from 'data/PATCHES'
 import Module from './Module'
 
@@ -30,5 +30,9 @@ export interface Meta {
 
 export default {
 	modules: () => import('./modules' /* webpackChunkName: "core" */),
-	changelog: [],
+	changelog: [{
+		date: new Date('2018-11-22'),
+		changes: 'Prevented hits that do zero damage from counting towards AoE hit counts.',
+		contributors: [CONTRIBUTORS.ACKWELL],
+	}],
 }

--- a/src/parser/core/modules/AoE.js
+++ b/src/parser/core/modules/AoE.js
@@ -176,6 +176,11 @@ export default class AoE extends Module {
 
 	isValidHit(event) {
 		// Checking the event's target - if we get a falsey value back, it's an invalid target
-		return !!this.enemies.getEntity(event.targetID)
+		const validTarget = !!this.enemies.getEntity(event.targetID)
+
+		// If there's an amount key but it's 0, it was likely a hit on an invuln target
+		const zeroAmount = event.amount === 0
+
+		return validTarget && !zeroAmount
 	}
 }


### PR DESCRIPTION
Tin. What it says on it.

cc
@ayyaruq, @Toastdeib: as discussed on discord. LMK.
@suShirow: not sure how this will play w/ heal events - though I'm not seeing any uses of `aoeheal` at all in the codebase (may be blind).