### PR TITLE
Added a broken log trigger in BotD in case of non-LotD Nastrond casts

### DIFF
--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.js
@@ -19,6 +19,7 @@ export default class BloodOfTheDragon extends Module {
 	static i18n_id = i18nMark('drg.blood.title')
 	static title = 'Life of the Dragon'
 	static dependencies = [
+		'brokenLog',
 		'checklist',
 		'death',
 		'suggestions',
@@ -122,8 +123,14 @@ export default class BloodOfTheDragon extends Module {
 	}
 
 	_onNastrondCast(event) {
-		if (this._lifeWindows.current !== null && !this._lifeWindows.current.nastronds.some(nastrond => nastrond.timestamp === event.timestamp)) {
-			// Ensure we have an open window and dedupe Nastrond casts, since that can occasionally happen
+		if (this._lifeWindows.current === null) {
+			// Nastrond outside of LotD - gentlemen, we have us a broken log
+			this.brokenLog.trigger()
+			return
+		}
+
+		if (!this._lifeWindows.current.nastronds.some(nastrond => nastrond.timestamp === event.timestamp)) {
+			// Dedupe Nastrond casts, since that can occasionally happen
 			this._lifeWindows.current.nastronds.push(event)
 		}
 	}


### PR DESCRIPTION
[Broken parse I tested with](https://xivanalysis.com/analyse/vxBCY2pFWXZr7Nmt/14/8/). ACT and/or fflogs somehow swallowed a Spineshatter cast, causing the Blood/Life simulator to go out of whack and report 0 Nastronds in a few LotD windows. This change watches for that manner of fuckery and flags the log as broken if it detects it.