### PR TITLE
Bump MNK supported version to 4.5

### DIFF
--- a/src/parser/jobs/mnk/index.js
+++ b/src/parser/jobs/mnk/index.js
@@ -25,7 +25,7 @@ export default {
 	</>,
 	supportedPatches: {
 		from: '4.2',
-		to: '4.4',
+		to: '4.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.ACCHAN, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Changes in 4.5 don't matter for analysis (they're for making mistakes less punishing), bumping version but no other changes required. We don't reference FoF potency so that's cool too.