### PR TITLE
Combatant lookup redirect

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -102,7 +102,7 @@ class App extends Component {
 					<ErrorBoundary>
 						<Switch>
 							<Route exact path="/" component={Home}/>
-							<Route path="/:section/:code/last/:combatant?" component={LastFightRedirect}/>
+							<Route path="/:section/:code/last/:combatant*" component={LastFightRedirect}/>
 							<Route path="/find/:code/:fight?" component={Find}/>
 							<Route path="/analyse/:code/:fight/:combatant" component={Analyse}/>
 						</Switch>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,6 +7,7 @@ import {Icon} from  'semantic-ui-react'
 import store from 'store'
 import {clearGlobalError} from 'store/actions'
 import Analyse from './Analyse'
+import CombatantLookupRedirect from './CombatantLookupRedirect'
 import ErrorBoundary from './ErrorBoundary'
 import Find from './Find'
 import GlobalSidebar from './GlobalSidebar'
@@ -103,6 +104,7 @@ class App extends Component {
 						<Switch>
 							<Route exact path="/" component={Home}/>
 							<Route path="/:section/:code/last/:combatant*" component={LastFightRedirect}/>
+							<Route path="/lookup/:code/:fight/:job/:name" component={CombatantLookupRedirect}/>
 							<Route path="/find/:code/:fight?" component={Find}/>
 							<Route path="/analyse/:code/:fight/:combatant" component={Analyse}/>
 						</Switch>

--- a/src/components/CombatantLookupRedirect.js
+++ b/src/components/CombatantLookupRedirect.js
@@ -1,0 +1,86 @@
+import {Trans} from '@lingui/react'
+import PropTypes from 'prop-types'
+import React from 'react'
+import {connect} from 'react-redux'
+import {Redirect} from 'react-router'
+import {Container, Loader} from 'semantic-ui-react'
+
+import {fetchReportIfNeeded} from 'store/actions'
+
+class CombatantLookupRedirect extends React.Component {
+	static propTypes = {
+		dispatch: PropTypes.func.isRequired,
+		match: PropTypes.shape({
+			params: PropTypes.shape({
+				code: PropTypes.string.isRequired,
+				fight: PropTypes.string.isRequired,
+				job: PropTypes.string.isRequired,
+				name: PropTypes.string.isRequired,
+			}).isRequired,
+		}).isRequired,
+		report: PropTypes.shape({
+			loading: PropTypes.bool.isRequired,
+			friendlies: PropTypes.arrayOf(PropTypes.shape({
+				name: PropTypes.string.isRequired,
+				type: PropTypes.string.isRequired,
+				id: PropTypes.number.isRequired,
+				fights: PropTypes.arrayOf(PropTypes.shape({
+					id: PropTypes.number.isRequired,
+				})),
+			})),
+		}),
+	}
+
+	componentDidMount() {
+		const {dispatch, match} = this.props
+		dispatch(fetchReportIfNeeded(match.params.code))
+	}
+
+	render() {
+		const {
+			report,
+			match: {params},
+		} = this.props
+
+		// Show a loader if we're still loading the main report
+		if (!report || report.code !== params.code || report.loading) {
+			return <Container>
+				<Loader active>
+					<Trans id="core.analyse.load-report">
+						Loading report
+					</Trans>
+				</Loader>
+			</Container>
+		}
+
+		// Find the ID of the player matching the params
+		// There _is_ a chance of dupes here (in which case it'll pick the first) - however the chance is miniscule.
+		const fightId = parseInt(params.fight, 10)
+		const combatant = report.friendlies.find(friendly =>
+			friendly.name === params.name &&
+			friendly.type === params.job &&
+			friendly.fights.some(fight => fight.id === fightId)
+		)
+
+		// If we didn't find the combatant, take them to the report page as a fallback
+		if (!combatant) {
+			return <Redirect to={'/' + [
+				'find',
+				params.code,
+				params.fight,
+			].join('/')}/>
+		}
+
+		// We've got the combatant, redirect to the analyse page
+		return <Redirect to={'/' + [
+			'analyse',
+			params.code,
+			params.fight,
+			combatant.id,
+		].join('/')}/>
+	}
+}
+
+export default connect(state => ({
+	report: state.report,
+}))(CombatantLookupRedirect)


### PR DESCRIPTION
As per req. from Lethys, a redirect route that can redirect for data from the parses fflogs endpoint.

Redirects are based on players who participated in the specified fight, using both their name and job to distinguish. In the absolutely minuscule chance there's two players meeting that criteria, the first in the list will be picked. If the provided data is malformed, it'll try to fall back to the combatant listing page.

```
Format:
/lookup/:code/:fight/:job/:name

Example:
/lookup/vrX3A1mnR489zCkM/3/Summoner/A'kwell Dinhe
/analyse/vrX3A1mnR489zCkM/3/7/

/lookup/vrX3A1mnR489zCkM/3/Summoner/legit who
/find/vrX3A1mnR489zCkM/3/
```