### PR TITLE
DRK linter cleanup, improved oGCD tracking and bug fixes

### DIFF
--- a/src/parser/jobs/drk/index.js
+++ b/src/parser/jobs/drk/index.js
@@ -10,12 +10,12 @@ export default {
 	modules: () => import('./modules' /* webpackChunkName: "jobs-drk" */),
 
 	description: <Fragment>
-		<p>This analyzer focuses on blood and mana usage, and then further explores common resource generation problems such as Blood Weapon up-time and dropping GCDs.</p>
+		<p>This analyzer focuses on blood and mana usage, and then further explores common resource generation problems such as Blood Weapon usage and dropping GCDs.</p>
 		<p>Most of the data in this evaluation tool is simulated, and edge cases from FFLogs can cause weird results.  If something doesn't look right, please report it in the discord.</p>
 		<Message warning icon>
 			<Icon name="warning sign"/>
 			<Message.Content>
-				Full capabilities of this tool require logs to be from the current patch.  Logs from 4.2 and before will not be accurately evaluated for resources due to balancing.
+				Full capabilities of this tool require logs to be from the current patch.  Logs from 4.2 and before will not be accurately evaluated for resources due to job changes.
 			</Message.Content>
 		</Message>
 	</Fragment>,
@@ -25,12 +25,17 @@ export default {
 	},
 	contributors: [
 		{user: CONTRIBUTORS.ACRI, role: ROLES.THEORYCRAFT},
-		{user: CONTRIBUTORS.AZARIAH, role: ROLES.DEVELOPER},
+		{user: CONTRIBUTORS.AZARIAH, role: ROLES.MAINTAINER},
 	],
 	changelog: [
 		{
 			date: new Date('2019-01-25'),
 			changes: 'Update analyzer for 4.5 patch, remove inaccurate recommendation for DA usage during enmity combo.',
+			contributors: [CONTRIBUTORS.AZARIAH],
+		},
+		{
+			date: new Date('2019-02-18'),
+			changes: 'Change to tracking Blood Weapon & Delirium as oGCDs instead of normalized uptime.  Add suggestions for dropped GCDs and wasted Deliriums.',
 			contributors: [CONTRIBUTORS.AZARIAH],
 		},
 	],

--- a/src/parser/jobs/drk/modules/Buffs.js
+++ b/src/parser/jobs/drk/modules/Buffs.js
@@ -74,9 +74,8 @@ export default class Buffs extends Module {
 	_wastedDelirium = 0
 
 	_severityWastedDelirium = {
-		1: SEVERITY.MINOR,
-		2: SEVERITY.MEDIUM,
-		3: SEVERITY.MAJOR,
+		1: SEVERITY.MEDIUM,
+		2: SEVERITY.MAJOR,
 	}
 
 	constructor(...args) {
@@ -196,19 +195,17 @@ export default class Buffs extends Module {
 			],
 		}))
 
-		if (this._wastedDelirium > 0) {
-			this.suggestions.add(new TieredSuggestion({
-				icon: ACTIONS.DELIRIUM.icon,
-				content: <Fragment>
-					You used Delirium without Blood Price or Blood Weapon active, spending blood for no effect
-				</Fragment>,
-				tiers: this._severityWastedDelirium,
-				value: this._wastedDelirium,
-				why: <Fragment>
-					You cast Delirium {this._wastedDelirium} <Plural value={this._wastedDelirium} one="time" other="times" /> without extending a buff.
-				</Fragment>,
-			}))
-		}
+		this.suggestions.add(new TieredSuggestion({
+			icon: ACTIONS.DELIRIUM.icon,
+			content: <Fragment>
+				You used Delirium without Blood Price or Blood Weapon active, spending blood for no effect
+			</Fragment>,
+			tiers: this._severityWastedDelirium,
+			value: this._wastedDelirium,
+			why: <Fragment>
+				You cast Delirium {this._wastedDelirium} <Plural value={this._wastedDelirium} one="time" other="times" /> without extending a buff.
+			</Fragment>,
+		}))
 	}
 
 	output() {

--- a/src/parser/jobs/drk/modules/GCDs.js
+++ b/src/parser/jobs/drk/modules/GCDs.js
@@ -41,6 +41,12 @@ const GCD_COMBO_ACTIONS = {
 		next: [undefined],
 	},
 }
+// Recommendation severities
+const _severityDroppedGCDCombo = {
+	1: SEVERITY.MINOR,
+	2: SEVERITY.MEDIUM,
+	7: SEVERITY.MAJOR,
+}
 
 export default class GCDs extends Module {
 	static handle = 'gcds'
@@ -55,13 +61,6 @@ export default class GCDs extends Module {
 	_last3eventsAndCurrent = []
 	_lastComboGCDTimeStamp = undefined
 	_GCDChainDrops = []
-
-	// Recommendation severities
-	_severityDroppedGCDCombo = {
-		1: SEVERITY.MINOR,
-		2: SEVERITY.MEDIUM,
-		6: SEVERITY.MAJOR,
-	}
 
 	inGCDCombo() {
 		return this._GCDComboActive
@@ -105,19 +104,17 @@ export default class GCDs extends Module {
 
 	_onComplete() {
 		//dropped combo chain
-		if (this._GCDChainDrops.length > 0) {
-			this.suggestions.add(new TieredSuggestion({
-				icon: ACTIONS.SPINNING_SLASH.icon,
-				content: <Fragment>
-					You dropped your GCD combo, loosing out on potency and/or mana.
-				</Fragment>,
-				tiers: this._severityDroppedGCDCombo,
-				value: this._GCDChainDrops.length,
-				why: <Fragment>
-					You wasted {this._GCDChainDrops.length} GCD chain actions.
-				</Fragment>,
-			}))
-		}
+		this.suggestions.add(new TieredSuggestion({
+			icon: ACTIONS.SPINNING_SLASH.icon,
+			content: <Fragment>
+				You dropped your GCD combo, loosing out on potency and/or mana.
+			</Fragment>,
+			tiers: _severityDroppedGCDCombo,
+			value: this._GCDChainDrops.length,
+			why: <Fragment>
+				You wasted {this._GCDChainDrops.length} GCD chain actions.
+			</Fragment>,
+		}))
 	}
 
 	output() {

--- a/src/parser/jobs/drk/modules/GCDs.js
+++ b/src/parser/jobs/drk/modules/GCDs.js
@@ -2,7 +2,7 @@ import React, {Fragment} from 'react'
 import {Accordion, Message} from 'semantic-ui-react'
 import Rotation from 'components/ui/Rotation'
 import {ActionLink} from 'components/ui/DbLink'
-import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
 import Module from 'parser/core/Module'
 import ACTIONS from 'data/ACTIONS'
@@ -56,6 +56,13 @@ export default class GCDs extends Module {
 	_lastComboGCDTimeStamp = undefined
 	_GCDChainDrops = []
 
+	// Recommendation severities
+	_severityDroppedGCDCombo = {
+		1: SEVERITY.MINOR,
+		2: SEVERITY.MEDIUM,
+		6: SEVERITY.MAJOR,
+	}
+
 	inGCDCombo() {
 		return this._GCDComboActive
 	}
@@ -63,6 +70,7 @@ export default class GCDs extends Module {
 	constructor(...args) {
 		super(...args)
 		this.addHook('cast', {by: 'player'}, this._onCast)
+		this.addHook('complete', this._onComplete)
 	}
 
 	_onCast(event) {
@@ -95,17 +103,18 @@ export default class GCDs extends Module {
 		}
 	}
 
-	onComplete() {
+	_onComplete() {
 		//dropped combo chain
 		if (this._GCDChainDrops.length > 0) {
-			this.suggestions.add(new Suggestion({
+			this.suggestions.add(new TieredSuggestion({
 				icon: ACTIONS.SPINNING_SLASH.icon,
 				content: <Fragment>
 					You dropped your GCD combo, loosing out on potency and/or mana.
 				</Fragment>,
-				severity: this._GCDChainDrops.length <= (1) ? SEVERITY.MINOR : this._GCDChainDrops.length <= (6) ? SEVERITY.MEDIUM : SEVERITY.MAJOR,
+				tiers: this._severityDroppedGCDCombo,
+				value: this._GCDChainDrops.length,
 				why: <Fragment>
-					You wasted {this._GCDChainDrops} GCD chain actions.
+					You wasted {this._GCDChainDrops.length} GCD chain actions.
 				</Fragment>,
 			}))
 		}

--- a/src/parser/jobs/drk/modules/OGCDDowntime.js
+++ b/src/parser/jobs/drk/modules/OGCDDowntime.js
@@ -1,0 +1,14 @@
+import ACTIONS from 'data/ACTIONS'
+import CooldownDowntime from 'parser/core/modules/CooldownDowntime'
+
+export default class OGCDDowntime extends CooldownDowntime {
+	// eslint-disable-next-line no-magic-numbers
+	allowedDowntime = 2500
+	trackedCds = [
+		ACTIONS.BLOOD_WEAPON.id,
+		ACTIONS.DELIRIUM.id,
+		ACTIONS.SOLE_SURVIVOR.id,
+		ACTIONS.PLUNGE.id,
+		ACTIONS.SALTED_EARTH.id,
+	]
+}

--- a/src/parser/jobs/drk/modules/ResourceSimulator.js
+++ b/src/parser/jobs/drk/modules/ResourceSimulator.js
@@ -37,8 +37,6 @@ const BLOOD_PRICE_BLOOD_PASSIVE_RATE = 3000
 const BLOOD_PRICE_BLOOD_PASSIVE_AMOUNT = 4
 const BLOOD_PRICE_MAX_DURATION = 15000
 
-const CARVE_AND_SPIT_NO_DA_MANA_GAIN = 1200
-
 //using this as a lookup table instead of a collector
 const RESOURCE_STATUS_EFFECTS = {
 	[STATUSES.ANOTHER_VICTIM.id]: {
@@ -64,6 +62,7 @@ const RESOURCE_STATUS_EFFECTS = {
 const MANA_MODIFIERS = {
 	// generators
 	[ACTIONS.DELIRIUM.id]: {value: 2400},
+	[ACTIONS.CARVE_AND_SPIT.id]: {value: 1200}, // if no DA active
 	// spenders
 	[ACTIONS.DARKSIDE.id]: {value: -600},
 	[ACTIONS.DARK_ARTS.id]: {value: -2400},
@@ -258,7 +257,7 @@ export default class Resources extends Module {
 		if (ACTIONS.CARVE_AND_SPIT.id === abilityId && !this.buffs.darkArtsActive()) {
 			//great why are we here
 			this._noDACarve += 1
-			this.modifyMana(event.ability, CARVE_AND_SPIT_NO_DA_MANA_GAIN)
+			this.modifyMana(event.ability, MANA_MODIFIERS[abilityId].value)
 		}
 	}
 

--- a/src/parser/jobs/drk/modules/ResourceSimulator.js
+++ b/src/parser/jobs/drk/modules/ResourceSimulator.js
@@ -24,23 +24,30 @@ const BLOODSPILLER_BLOOD_COST = 50
 // Meters
 // ------
 const MAX_MANA = 9480
+const MANA_REGEN_PERCENT_PER_TICK = 0.02
+const TICK_RATE = 3000
+
 const MAX_BLOOD = 100
 //const MANA_PER_OUT_OF_COMBAT_TICK = 568 // DA should be used at least 2 ticks pre pull
 //const DARKSIDE_MANA_COST = 600
 
-const BLOOD_PRICE_BLOOD_DAMAGE_TRIGGERED_BLOOD_AMOUNT = 1
-const BLOOD_PRICE_BLOOD_DAMAGE_TRIGGERED_MANA_AMOUNT = 120
+const BLOOD_PRICE_DAMAGE_TAKEN_BLOOD_AMOUNT = 1
+const BLOOD_PRICE_DAMAGE_TAKEN_MANA_AMOUNT = 120
 const BLOOD_PRICE_BLOOD_PASSIVE_RATE = 3000
 const BLOOD_PRICE_BLOOD_PASSIVE_AMOUNT = 4
 const BLOOD_PRICE_MAX_DURATION = 15000
+
+const CARVE_AND_SPIT_NO_DA_MANA_GAIN = 1200
 
 //using this as a lookup table instead of a collector
 const RESOURCE_STATUS_EFFECTS = {
 	[STATUSES.ANOTHER_VICTIM.id]: {
 		duration: 15000,
 		type: 'debuff',
+		// eslint-disable-next-line no-magic-numbers
 		expire_mana: MAX_MANA * 0.2,
 		expire_blood: 0,
+		// eslint-disable-next-line no-magic-numbers
 		activate_mana: MAX_MANA * 0.3,
 		activate_blood: 0,
 	},
@@ -251,7 +258,7 @@ export default class Resources extends Module {
 		if (ACTIONS.CARVE_AND_SPIT.id === abilityId && !this.buffs.darkArtsActive()) {
 			//great why are we here
 			this._noDACarve += 1
-			this.modifyMana(event.ability, 1200)
+			this.modifyMana(event.ability, CARVE_AND_SPIT_NO_DA_MANA_GAIN)
 		}
 	}
 
@@ -306,8 +313,8 @@ export default class Resources extends Module {
 		if (this._darksideRemoveTimestamp !== undefined) {
 			//give mana ticks for how long they had it down for
 			//using 2% of max mana per tick
-			const ticks = Math.floor((event.timestamp - this._darksideRemoveTimestamp) / 3000)
-			this.modifyMana(undefined, ticks * Math.floor(MAX_MANA * 0.02))
+			const ticks = Math.floor((event.timestamp - this._darksideRemoveTimestamp) / TICK_RATE)
+			this.modifyMana(undefined, ticks * Math.floor(MAX_MANA * MANA_REGEN_PERCENT_PER_TICK))
 			//reset darkside in case something breaks
 			this._darksideRemoveTimestamp = undefined
 		}
@@ -357,8 +364,8 @@ export default class Resources extends Module {
 	_onDamageTaken() { //event) {
 		// blood price incoming damage
 		if (this.buffs.bloodPriceActive()) {
-			this.modifyBlood(ACTIONS.BLOOD_PRICE, BLOOD_PRICE_BLOOD_DAMAGE_TRIGGERED_BLOOD_AMOUNT)
-			this.modifyMana(ACTIONS.BLOOD_PRICE, BLOOD_PRICE_BLOOD_DAMAGE_TRIGGERED_MANA_AMOUNT)
+			this.modifyBlood(ACTIONS.BLOOD_PRICE, BLOOD_PRICE_DAMAGE_TAKEN_BLOOD_AMOUNT)
+			this.modifyMana(ACTIONS.BLOOD_PRICE, BLOOD_PRICE_DAMAGE_TAKEN_MANA_AMOUNT)
 		}
 	}
 
@@ -547,6 +554,10 @@ export default class Resources extends Module {
 		// also include spenders and generators
 		const panels = []
 		const lists = this._filterResourceTrackingLists()
+
+		const bloodSpentPercentage = (((this._totalSpentBlood * -1)/(this._totalGainedBlood)) * 100).toFixed(2)
+		const manaSpentPercentage = (((this._totalSpentMana * -1)/(this._totalGainedMana)) * 100).toFixed(2)
+
 		panels.push({
 			key: 'key-bloodSpenders',
 			title: {
@@ -593,8 +604,8 @@ export default class Resources extends Module {
 		})
 		return <Fragment>
 			<Message>
-				<p>Blood Used vs Blood Gained: {this._totalSpentBlood * -1} / {this._totalGainedBlood + (this._wastedBlood * -1)} - {Math.floor(((this._totalSpentBlood * -1)/(this._totalGainedBlood + (this._wastedBlood * -1))) * 10000) / 100}%</p>
-				<p>Mana Used vs Mana Gained: {this._totalSpentMana * -1} / {this._totalGainedMana + (this._wastedMana * -1)} - {Math.floor(((this._totalSpentMana * -1)/(this._totalGainedMana + (this._wastedMana * -1))) * 10000) / 100}%</p>
+				<p>Blood Used vs Blood Gained: {this._totalSpentBlood * -1} / {this._totalGainedBlood} - {bloodSpentPercentage}%</p>
+				<p>Mana Used vs Mana Gained: {this._totalSpentMana * -1} / {this._totalGainedMana} - {manaSpentPercentage}%</p>
 			</Message>
 			<Accordion
 				exclusive={false}

--- a/src/parser/jobs/drk/modules/index.js
+++ b/src/parser/jobs/drk/modules/index.js
@@ -4,6 +4,7 @@ import Buffs from './Buffs'
 import DarkArts from './DarkArts'
 import Speedmod from './Speedmod'
 import Cooldowns from './Cooldowns'
+import OGCDDowntime from './OGCDDowntime'
 
 export default [
 	ResourceSimulator,
@@ -12,4 +13,5 @@ export default [
 	Buffs,
 	DarkArts,
 	Cooldowns,
+	OGCDDowntime,
 ]


### PR DESCRIPTION
Remove normalized uptime calculations for Blood Weapon/Delirium, track as oGCDs instead
Add TieredSuggestion for using Delirium without extending BW/BP
Convert dropped GCD suggestion to TieredSuggestion, fix bug of not actually calling onComplete to add suggestion
Clean up magic constant values in resource simulator