### PR TITLE
Patch refactor

### DIFF
--- a/src/components/Find/CombatantList.tsx
+++ b/src/components/Find/CombatantList.tsx
@@ -4,7 +4,7 @@ import Color from 'color'
 import JobIcon from 'components/ui/JobIcon'
 import {getDataBy} from 'data'
 import JOBS, {Role, ROLES} from 'data/JOBS'
-import {PatchNumber, patchSupported} from 'data/PATCHES'
+import {languageToEdition, PatchNumber, patchSupported} from 'data/PATCHES'
 import * as Errors from 'errors'
 import {Actor, ActorType} from 'fflogs'
 import {computed} from 'mobx'
@@ -76,9 +76,10 @@ class CombatantList extends React.Component<Props> {
 
 			const supportedPatches = jobMeta[type].supportedPatches
 			if (supportedPatches) {
+				const {lang, start} = this.props.report
 				const from = supportedPatches.from as PatchNumber
 				const to = (supportedPatches.to as PatchNumber) || from
-				if (!patchSupported(from, to, this.props.report.start)) {
+				if (!patchSupported(languageToEdition(lang), from, to, start)) {
 					role = ROLES.OUTDATED.id
 				}
 			}

--- a/src/components/GlobalSidebar/Breadcrumbs.js
+++ b/src/components/GlobalSidebar/Breadcrumbs.js
@@ -3,12 +3,20 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {Helmet} from 'react-helmet'
 import {withRouter, Link} from 'react-router-dom'
+import {Icon} from 'semantic-ui-react'
 
 import {getZoneBanner, getCorrectedFight} from 'data/BOSSES'
+import {GameEdition, languageToEdition, getPatch} from 'data/PATCHES'
 import {ReportStore} from 'store/report'
 import {formatDuration, getPathMatch} from 'utilities'
 
 import styles from './Breadcrumbs.module.css'
+
+const editionName = {
+	[GameEdition.GLOBAL]: <Icon name="globe"/>,
+	[GameEdition.KOREAN]: 'KR',
+	[GameEdition.CHINESE]: 'CN',
+}
 
 @inject('reportStore')
 @observer
@@ -45,11 +53,19 @@ class Breadcrumbs extends React.Component {
 		// Report
 		if (code) {
 			let title = code
+			let subtitle = null
+
 			if (reportLoaded) {
 				title = report.title
+
+				const edition = languageToEdition(report.lang)
+				const patch = getPatch(edition, report.start / 1000)
+				subtitle = <>({editionName[edition]} {patch})</>
 			}
+
 			crumbs.push({
 				title,
+				subtitle,
 				url: `/find/${code}/`,
 			})
 		}

--- a/src/components/ui/I18nMenu.js
+++ b/src/components/ui/I18nMenu.js
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 import {Dropdown, Icon, Image} from 'semantic-ui-react'
 
-import {LANGUAGES, GameEdition} from 'data/LANGUAGES'
+import {LANGUAGES} from 'data/LANGUAGES'
+import {GameEdition} from 'data/PATCHES'
 import {I18nStore} from 'store/i18n'
 
 import crowdinLogo from './crowdin-dark-symbol.png'

--- a/src/data/LANGUAGES.ts
+++ b/src/data/LANGUAGES.ts
@@ -1,5 +1,6 @@
 import {StrictDropdownItemProps} from 'semantic-ui-react'
 import {stringBefore} from 'utilities'
+import {GameEdition} from './PATCHES'
 
 interface LanguageData {
 	enable: boolean
@@ -12,10 +13,6 @@ export enum Language {
 	JAPANESE = 'ja',
 	FRENCH = 'fr',
 	GERMAN = 'de',
-}
-
-export enum GameEdition {
-	GLOBAL,
 }
 
 export const LANGUAGES: Record<Language, LanguageData> = {

--- a/src/data/PATCHES.ts
+++ b/src/data/PATCHES.ts
@@ -1,59 +1,119 @@
+import {ReportLanguage} from 'fflogs'
 import _ from 'lodash'
-// This is all right from /PatchList - should be easy to sync Eventually™
 
-export interface Patch {
-	date: number
+export enum GameEdition {
+	GLOBAL,
+	KOREAN,
+	CHINESE,
 }
 
+export function languageToEdition(lang: ReportLanguage): GameEdition {
+	switch (lang) {
+		case ReportLanguage.JAPANESE:
+		case ReportLanguage.ENGLISH:
+		case ReportLanguage.GERMAN:
+		case ReportLanguage.FRENCH:
+			return GameEdition.GLOBAL
+
+		case ReportLanguage.KOREAN:
+			return GameEdition.KOREAN
+
+		case ReportLanguage.CHINESE:
+			return GameEdition.CHINESE
+	}
+
+	throw new Error()
+}
+
+export interface Patch {
+	// Using global as a source of truth on the order of patch keys
+	date: Partial<Record<GameEdition, number>> & {[GameEdition.GLOBAL]: number}
+}
+
+// This is all right from /PatchList - should be easy to sync Eventually™
 const PATCHES = {
 	// Not going to support pre-4.0 at all
 	'2.0 - 3.57': {
-		date: 0,
+		date: {
+			[GameEdition.GLOBAL]: 0,
+			[GameEdition.KOREAN]: 0,
+			[GameEdition.CHINESE]: 0,
+		},
 	},
 	'4.0': {
-		date: 1497517200,
+		date: {
+			[GameEdition.GLOBAL]: 1497517200,
+		},
 	},
 	'4.01': {
-		date: 1499162101,
+		date: {
+			[GameEdition.GLOBAL]: 1499162101,
+		},
 	},
 	'4.05': {
-		date: 1500368961,
+		date: {
+			[GameEdition.GLOBAL]: 1500368961,
+		},
 	},
 	'4.06': {
-		date: 1501747200,
+		date: {
+			[GameEdition.GLOBAL]: 1501747200,
+		},
 	},
 	'4.1': {
-		date: 1507622400,
+		date: {
+			[GameEdition.GLOBAL]: 1507622400,
+		},
 	},
 	'4.11': {
-		date: 1508839200,
+		date: {
+			[GameEdition.GLOBAL]: 1508839200,
+		},
 	},
 	'4.15': {
-		date: 1511258400,
+		date: {
+			[GameEdition.GLOBAL]: 1511258400,
+		},
 	},
 	'4.2': {
-		date: 1517227200,
+		date: {
+			[GameEdition.GLOBAL]: 1517227200,
+		},
 	},
 	'4.25': {
-		date: 1520935200,
+		date: {
+			[GameEdition.GLOBAL]: 1520935200,
+		},
 	},
 	'4.3': {
-		date: 1526976000,
+		date: {
+			[GameEdition.GLOBAL]: 1526976000,
+		},
 	},
 	'4.31': {
-		date: 1528223134,
+		date: {
+			[GameEdition.GLOBAL]: 1528223134,
+		},
 	},
 	'4.35': {
-		date: 1530617875,
+		date: {
+			[GameEdition.GLOBAL]: 1530617875,
+		},
 	},
 	'4.36': {
-		date: 1533635005,
+		date: {
+			[GameEdition.GLOBAL]: 1533635005,
+		},
 	},
 	'4.4': {
-		date: 1537268400,
+		date: {
+			[GameEdition.GLOBAL]: 1537268400,
+		},
 	},
 	'4.5': {
-		date: 1546857979,
+		date: {
+			[GameEdition.GLOBAL]: 1546857979,
+		},
 	},
 }
 
@@ -65,15 +125,24 @@ const patchData: PatchData = PATCHES
 
 // This is intentionally in newest->oldest order
 const sortedPatches = (Object.keys(patchData) as PatchNumber[]).sort(
-	(a, b) => patchData[b].date - patchData[a].date,
+	(a, b) => patchData[b].date[GameEdition.GLOBAL] - patchData[a].date[GameEdition.GLOBAL],
 )
 
-export function getPatch(timestamp = (new Date()).getTime()): PatchNumber {
-	const key = sortedPatches.find(key => patchData[key].date < timestamp)
-	return key!
+export function getPatch(edition: GameEdition, timestamp: number): PatchNumber {
+	const key = sortedPatches.find(key => (patchData[key].date[edition] || Infinity) < timestamp)
+	return key || '2.0 - 3.57'
+}
+
+export function getPatchDate(edition: GameEdition, patch: PatchNumber) {
+	const globalPatchTime = patchData[patch].date[GameEdition.GLOBAL]
+	const key = sortedPatches
+		.filter(key => patchData[key].date[GameEdition.GLOBAL] > globalPatchTime)
+		.find(key => patchData[key].date[edition] !== undefined)
+	return patchData[key || '2.0 - 3.57'].date[edition] || 0
 }
 
 export function patchSupported(
+	edition: GameEdition,
 	from: PatchNumber,
 	to: PatchNumber,
 	at = (new Date()).getTime(),
@@ -81,10 +150,12 @@ export function patchSupported(
 	if (!from) { return false }
 
 	const nextPatchKey = sortedPatches[sortedPatches.indexOf(to) - 1]
-	const nextPatch = patchData[nextPatchKey] || {date: Infinity}
+	const nextPatch = patchData[nextPatchKey]
 
-	const fromDate = patchData[from].date
-	const toDate = nextPatch.date
+	const fromDate = getPatchDate(edition, from)
+	const toDate = nextPatch
+		? getPatchDate(edition, nextPatchKey)
+		: Infinity
 
 	return _.inRange(at, fromDate, toDate)
 }

--- a/src/data/PATCHES.ts
+++ b/src/data/PATCHES.ts
@@ -136,7 +136,7 @@ export function getPatch(edition: GameEdition, timestamp: number): PatchNumber {
 export function getPatchDate(edition: GameEdition, patch: PatchNumber) {
 	const globalPatchTime = patchData[patch].date[GameEdition.GLOBAL]
 	const key = sortedPatches
-		.filter(key => patchData[key].date[GameEdition.GLOBAL] > globalPatchTime)
+		.filter(key => patchData[key].date[GameEdition.GLOBAL] <= globalPatchTime)
 		.find(key => patchData[key].date[edition] !== undefined)
 	return patchData[key || '2.0 - 3.57'].date[edition] || 0
 }

--- a/src/data/PATCHES.ts
+++ b/src/data/PATCHES.ts
@@ -37,7 +37,8 @@ const PATCHES = {
 	[FALLBACK_KEY]: {
 		date: {
 			[GameEdition.GLOBAL]: 0,
-			// NOTE: Don't fill in other editions here - it's left blank so they fall back to `Infinity`
+			[GameEdition.KOREAN]: 0,
+			[GameEdition.CHINESE]: 0,
 		},
 	},
 	'4.0': {
@@ -134,11 +135,12 @@ export function getPatch(edition: GameEdition, timestamp: number): PatchNumber {
 }
 
 export function getPatchDate(edition: GameEdition, patch: PatchNumber) {
-	const globalPatchTime = patchData[patch].date[GameEdition.GLOBAL]
-	const key = sortedPatches
-		.filter(key => patchData[key].date[GameEdition.GLOBAL] <= globalPatchTime)
-		.find(key => patchData[key].date[edition] !== undefined)
-	return patchData[key || FALLBACK_KEY].date[edition] || Infinity
+	let date: number | undefined
+	for (const key of sortedPatches) {
+		date = patchData[key].date[edition]
+		if (key === patch) { break }
+	}
+	return date || Infinity
 }
 
 export function patchSupported(

--- a/src/data/PATCHES.ts
+++ b/src/data/PATCHES.ts
@@ -31,13 +31,13 @@ export interface Patch {
 }
 
 // This is all right from /PatchList - should be easy to sync Eventually™
+const FALLBACK_KEY = '✖'
 const PATCHES = {
 	// Not going to support pre-4.0 at all
-	'2.0 - 3.57': {
+	[FALLBACK_KEY]: {
 		date: {
 			[GameEdition.GLOBAL]: 0,
-			[GameEdition.KOREAN]: 0,
-			[GameEdition.CHINESE]: 0,
+			// NOTE: Don't fill in other editions here - it's left blank so they fall back to `Infinity`
 		},
 	},
 	'4.0': {
@@ -130,7 +130,7 @@ const sortedPatches = (Object.keys(patchData) as PatchNumber[]).sort(
 
 export function getPatch(edition: GameEdition, timestamp: number): PatchNumber {
 	const key = sortedPatches.find(key => (patchData[key].date[edition] || Infinity) < timestamp)
-	return key || '2.0 - 3.57'
+	return key || FALLBACK_KEY
 }
 
 export function getPatchDate(edition: GameEdition, patch: PatchNumber) {
@@ -138,7 +138,7 @@ export function getPatchDate(edition: GameEdition, patch: PatchNumber) {
 	const key = sortedPatches
 		.filter(key => patchData[key].date[GameEdition.GLOBAL] <= globalPatchTime)
 		.find(key => patchData[key].date[edition] !== undefined)
-	return patchData[key || '2.0 - 3.57'].date[edition] || 0
+	return patchData[key || FALLBACK_KEY].date[edition] || Infinity
 }
 
 export function patchSupported(

--- a/src/fflogs.ts
+++ b/src/fflogs.ts
@@ -191,6 +191,19 @@ export interface BuffStackEvent extends AbilityEvent {
 }
 
 // -----
+// Misc
+// -----
+
+export enum ReportLanguage {
+	JAPANESE = 'ja',
+	ENGLISH = 'en',
+	GERMAN = 'de',
+	FRENCH = 'fr',
+	KOREAN = 'kr',
+	CHINESE = 'cn',
+}
+
+// -----
 // Direct API
 // -----
 
@@ -209,7 +222,7 @@ export interface ReportFightsResponse {
 	fights: Fight[]
 	friendlies: Actor[]
 	friendlyPets: Pet[]
-	lang: string
+	lang: ReportLanguage
 	owner: string
 	phases: Phase[]
 	start: number

--- a/src/parser/core/Module.test.js
+++ b/src/parser/core/Module.test.js
@@ -17,6 +17,8 @@ const pet = {
 	petOwner: player.id,
 }
 const report = {
+	lang: 'en',
+	start: 0,
 	friendlies: [player],
 	friendlyPets: [pet],
 }

--- a/src/parser/core/Parser.test.js
+++ b/src/parser/core/Parser.test.js
@@ -46,6 +46,8 @@ const friendlyNotInFight = {
 	fights: [{id: 9000}],
 }
 const report = {
+	lang: 'en',
+	start: 0,
 	friendlies: [friendlyInFight, friendlyNotInFight],
 	friendlyPets: [],
 }

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -1,7 +1,8 @@
 import ResultSegment from 'components/Analyse/ResultSegment'
 import ErrorMessage from 'components/ui/ErrorMessage'
+import {languageToEdition} from 'data/PATCHES'
 import {DependencyCascadeError} from 'errors'
-import {Actor, Event, Fight, Pet, ReportFightsResponse} from 'fflogs'
+import {Actor, Event, Fight, Pet} from 'fflogs'
 import {mergeWith, sortBy} from 'lodash'
 import Raven from 'raven-js'
 import React from 'react'
@@ -10,6 +11,7 @@ import toposort from 'toposort'
 import {extractErrorContext} from 'utilities'
 import {Meta} from '.'
 import Module, {DISPLAY_MODE, MappedDependency} from './Module'
+import {Patch} from './Patch'
 
 interface Player extends Actor {
 	pets: Pet[]
@@ -32,6 +34,7 @@ class Parser {
 	// Properties
 	// -----
 	readonly player: Player
+	readonly patch: Patch
 
 	meta: Partial<LoadedMeta> = {}
 	_timestamp = 0
@@ -86,6 +89,11 @@ class Parser {
 			...actor,
 			pets,
 		}
+
+		this.patch = new Patch(
+			languageToEdition(report.lang),
+			this.parseDate,
+		)
 	}
 
 	// -----

--- a/src/parser/core/Patch.ts
+++ b/src/parser/core/Patch.ts
@@ -1,0 +1,66 @@
+import {GameEdition, getPatch, getPatchDate, PatchNumber} from 'data/PATCHES'
+import {matchClosestLower} from 'utilities'
+
+export class Patch {
+	constructor(
+		private readonly edition: GameEdition,
+		private readonly timestamp: number,
+	) {}
+
+	get key() {
+		return getPatch(this.edition, this.timestamp)
+	}
+
+	/**
+	 * Compare the stored patch with the one specified. A negative, zero, or
+	 * postive number will be returned if the patch is before, equal to, or
+	 * after the stored patch, respectively.
+	 * @param patch The patch to compare to
+	 */
+	compare(patch: PatchNumber) {
+		const a = getPatchDate(this.edition, this.key)
+		const b = getPatchDate(this.edition, patch)
+		return b - a
+	}
+
+	/**
+	 * Check if the specified patch is before the currently stored patch
+	 * @param patch Patch to compare to
+	 */
+	before(patch: PatchNumber) {
+		return this.compare(patch) < 0
+	}
+
+	/**
+	 * Check if the specified patch is equal to the currently stored patch
+	 * @param patch Patch to compare to
+	 */
+	is(patch: PatchNumber) {
+		return this.compare(patch) === 0
+	}
+
+	/**
+	 * Check if the specified patch is after the currently stored patch
+	 * @param patch Patch to compare to
+	 */
+	after(patch: PatchNumber) {
+		return this.compare(patch) > 0
+	}
+
+	/**
+	 * Given a mapping between patches and values, find the value for the most recent
+	 * patch for the currently stored timestamp, or undefined if no patch is early
+	 * enough.
+	 * @param values Patch => value mapping
+	 */
+	match<V>(values: Partial<Record<PatchNumber, V>>): V | undefined {
+		const dateValues = Object.entries(values).reduce(
+			(carry, [patch, value]) => {
+				carry[getPatchDate(this.edition, patch as PatchNumber)] = value
+				return carry
+			},
+			{} as Partial<Record<number, V>>,
+		)
+		return matchClosestLower(dateValues, getPatchDate(this.edition, this.key))
+	}
+}

--- a/src/parser/core/modules/About.js
+++ b/src/parser/core/modules/About.js
@@ -3,7 +3,7 @@ import React from 'react'
 import {Grid, Message, Icon, Segment} from 'semantic-ui-react'
 
 import ContributorLabel from 'components/ui/ContributorLabel'
-import {getPatch, patchSupported} from 'data/PATCHES'
+import {patchSupported, languageToEdition} from 'data/PATCHES'
 import Module, {DISPLAY_MODE} from 'parser/core/Module'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
@@ -61,7 +61,12 @@ export default class About extends Module {
 
 		// Work out the supported patch range (and if we're in it)
 		const {from, to = from} = this.supportedPatches
-		const supported = patchSupported(from, to, this.parser.parseDate)
+		const supported = patchSupported(
+			languageToEdition(this.parser.report.lang),
+			from,
+			to,
+			this.parser.parseDate,
+		)
 
 		return <Grid>
 			<Grid.Column mobile={16} computer={10}>
@@ -73,7 +78,7 @@ export default class About extends Module {
 							<Trans id="core.about.patch-unsupported.title">Report patch unsupported</Trans>
 						</Message.Header>
 						<Trans id="core.about.patch-unsupported.description">
-							This report was logged during patch {getPatch(this.parser.parseDate)}, which is not supported by the analyser. Calculations and suggestions may be impacted by changes in the interim.
+							This report was logged during patch {this.parser.patch.key}, which is not supported by the analyser. Calculations and suggestions may be impacted by changes in the interim.
 						</Trans>
 					</Message.Content>
 				</Message>}

--- a/src/parser/jobs/rdm/modules/Gauge.js
+++ b/src/parser/jobs/rdm/modules/Gauge.js
@@ -1,6 +1,5 @@
 import Color from 'color'
 import React, {Fragment} from 'react'
-import PATCHES, {getPatch} from 'data/PATCHES'
 import TimeLineChart from 'components/ui/TimeLineChart'
 import ACTIONS from 'data/ACTIONS'
 import JOBS from 'data/JOBS'
@@ -222,7 +221,7 @@ export default class Gauge extends Module {
 				this.cooldowns.resetCooldown(ACTIONS.CORPS_A_CORPS.id)
 				this.cooldowns.resetCooldown(ACTIONS.DISPLACEMENT.id)
 			} else {
-				gaugeAction.calculateCastManaGained(event, this.combatants.selected, this._getIsPre44)
+				gaugeAction.calculateCastManaGained(event, this.combatants.selected, this.parser.patch.before('4.4'))
 			}
 
 			this._whiteMana = gaugeAction.mana.white.afterCast
@@ -370,11 +369,5 @@ export default class Gauge extends Module {
 		*/
 		get blackMana() {
 			return this._blackMana
-		}
-
-		get _getIsPre44() {
-			const currentParseDate = getPatch(this.parser.parseDate)
-			// The report timestamp is relative to the report timestamp, and in ms. Convert.
-			return PATCHES[currentParseDate].date < PATCHES['4.4'].date
 		}
 }

--- a/src/parser/jobs/sch/modules/ShadowFlare.js
+++ b/src/parser/jobs/sch/modules/ShadowFlare.js
@@ -2,18 +2,16 @@ import React, {Fragment} from 'react'
 
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
-import PATCHES from 'data/PATCHES'
 import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {Suggestion, SEVERITY} from 'parser/core/modules/Suggestions'
-import {matchClosestLower} from 'utilities'
 
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 // In a single target scenario, SF should always tick 5 times + 1 time on the cast (4.4 patch)
 const MIN_HITS = {
-	[PATCHES['4.0'].date]: 5,
-	[PATCHES['4.4'].date]: 6,
+	'4.0': 5,
+	'4.4': 6,
 }
 
 // Ticks every 3s
@@ -51,7 +49,7 @@ export default class ShadowFlare extends Module {
 
 	_onComplete() {
 		// Work out the appropriate number of hits based on patch
-		const minHits = matchClosestLower(MIN_HITS, this.parser.parseDate)
+		const minHits = this.parser.patch.match(MIN_HITS)
 
 		const missedTicks = this._casts.reduce((carry, cast) => {
 			const hits = cast.hits.reduce((carry, value) => carry + value.hits.length, 0)

--- a/src/parser/jobs/smn/modules/Pets.js
+++ b/src/parser/jobs/smn/modules/Pets.js
@@ -4,7 +4,6 @@ import React from 'react'
 import {ActionLink, StatusLink} from 'components/ui/DbLink'
 import ACTIONS, {getAction} from 'data/ACTIONS'
 import JOBS, {ROLES} from 'data/JOBS'
-import PATCHES, {getPatch} from 'data/PATCHES'
 import PETS from 'data/PETS'
 import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
@@ -213,10 +212,10 @@ export default class Pets extends Module {
 		}
 
 		// Disabling ifrit check post-4.4 due to changes made to RS
-		const currentPatch = getPatch(this.parser.parseDate)
-		const pre44 = PATCHES[currentPatch].date < PATCHES['4.4'].date
-
-		if (pre44 && numCasters === 1 && mostUsedPet !== PETS.IFRIT_EGI.id) {
+		if (
+			this.parser.patch.before('4.4') &&
+			numCasters === 1 && mostUsedPet !== PETS.IFRIT_EGI.id
+		) {
 			this.suggestions.add(new Suggestion({
 				icon: ACTIONS.SUMMON_III.icon,
 				severity: SEVERITY.MEDIUM,

--- a/src/parser/jobs/smn/modules/ShadowFlare.js
+++ b/src/parser/jobs/smn/modules/ShadowFlare.js
@@ -3,18 +3,16 @@ import React from 'react'
 
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
-import PATCHES from 'data/PATCHES'
 import STATUSES from 'data/STATUSES'
 import Module from 'parser/core/Module'
 import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
-import {matchClosestLower} from 'utilities'
 
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 // In a single target scenario, SF should always tick 5 times + 1 time on the cast (4.4 patch)
 const MIN_HITS = {
-	[PATCHES['4.0'].date]: 5,
-	[PATCHES['4.4'].date]: 6,
+	'4.0': 5,
+	'4.4': 6,
 }
 
 // Ticks every 3s
@@ -56,7 +54,7 @@ export default class ShadowFlare extends Module {
 
 	_onComplete() {
 		// Work out the appropriate number of hits based on patch
-		const minHits = matchClosestLower(MIN_HITS, this.parser.parseDate)
+		const minHits = this.parser.patch.match(MIN_HITS)
 
 		const missedTicks = this._casts.reduce((carry, cast) => {
 			const hits = cast.hits.reduce((carry, value) => carry + value.hits.length, 0)

--- a/src/parser/jobs/whm/modules/Assize.js
+++ b/src/parser/jobs/whm/modules/Assize.js
@@ -5,7 +5,6 @@ import ACTIONS from 'data/ACTIONS'
 import Module from 'parser/core/Module'
 import {TieredRule, TARGET, Requirement} from 'parser/core/modules/Checklist'
 import {Trans} from '@lingui/react'
-import PATCHES, {getPatch} from 'data/PATCHES'
 
 const EXCUSED_HOLD_DEFAULT = 1500 //time allowed to hold it every time it's off cd
 const WARN_TARGET_PERCENT = 0.9 //percentage as a decimal for warning tier on checklist
@@ -25,9 +24,9 @@ export default class Assize extends Module {
 	_totalHeld = 0
 	_excusedHeld = 0
 
-	currentPatch = getPatch(this.parser.parseDate)
-	pre45 = PATCHES[this.currentPatch].date < PATCHES['4.5'].date
-	ASSIZE_COOLDOWN = this.pre45 ? PRE45_ASSIZE_COOLDOWN : ACTIONS.ASSIZE.cooldown
+	ASSIZE_COOLDOWN = this.parser.patch.before('4.5')
+		? PRE45_ASSIZE_COOLDOWN
+		: ACTIONS.ASSIZE.cooldown
 
 	constructor(...args) {
 		super(...args)

--- a/src/store/i18n.ts
+++ b/src/store/i18n.ts
@@ -1,4 +1,5 @@
-import {GameEdition, Language, LANGUAGES} from 'data/LANGUAGES'
+import {Language, LANGUAGES} from 'data/LANGUAGES'
+import {GameEdition} from 'data/PATCHES'
 import {action, observable} from 'mobx'
 import {getUserLanguage} from 'utilities'
 


### PR DESCRIPTION
This refactors `data/PATCHES` to be able to handle different patch dates per game edition, as well as adding a bunch of nice helper stuff within the parser, and fixing up all the existing call sites.

Don't merge just yet, I need to work out some details around who the hell is going to maintain the patch date list for non-global editions, because I sure ain't.