### PR TITLE
Update tooltip format for timeline charts to display relative timestamps

### DIFF
--- a/src/components/ui/TimeLineChart.js
+++ b/src/components/ui/TimeLineChart.js
@@ -14,6 +14,9 @@ const DEFAULT_OPTIONS = {
 					second: 'm:ss',
 					millisecond: 'm:ss.SS',
 				},
+				// This tooltip format displays similar to a "relative" timestamp,
+				// since react assumes UNIX epoch timestamps for the data.
+				tooltipFormat: 'mm:ss.SSS',
 			},
 		}],
 	},


### PR DESCRIPTION
Before:

<img width="966" alt="Screen Shot 2019-06-03 at 8 28 02 PM" src="https://user-images.githubusercontent.com/47466448/58849153-23e7d100-863e-11e9-9a36-d538dd272a8c.png">

After:

<img width="963" alt="Screen Shot 2019-06-03 at 9 19 28 PM" src="https://user-images.githubusercontent.com/47466448/58850883-4df0c180-8645-11e9-882d-c53b6b29118a.png">

`tooltipFormat` is the property used by Chart.js for displaying the hover tooltip. Documentation [here](https://www.chartjs.org/docs/latest/axes/cartesian/time.html#configuration-options).

This is kind of a hacky way to fix it, but it works. Basically, it assumes that the input timestamp is an offset from 0ms, and we treat that like a UNIX timestamp. Conveniently, it thus displays as a "relative" timestamp from wherever we started.

Full list of uses:

```
➜  xivanalysis git:(TimestampFix) ✗ grep -r 'TimeLineChart' src
src/components/ui/TimeLineChart.js:export default class TimeLineChart extends PureComponent {
src/parser/jobs/drk/modules/ResourceSimulator.js:import TimeLineChart from 'components/ui/TimeLineChart'
src/parser/jobs/drk/modules/ResourceSimulator.js:			<TimeLineChart
src/parser/jobs/mnk/modules/GreasedLightning.js:import TimeLineChart from 'components/ui/TimeLineChart'
src/parser/jobs/mnk/modules/GreasedLightning.js:		return <TimeLineChart
src/parser/jobs/nin/modules/Ninki.js:import TimeLineChart from 'components/ui/TimeLineChart'
src/parser/jobs/nin/modules/Ninki.js:			<TimeLineChart data={chartdata} />
src/parser/jobs/rdm/modules/Gauge.js:import TimeLineChart from 'components/ui/TimeLineChart'
src/parser/jobs/rdm/modules/Gauge.js:			return <TimeLineChart
src/parser/jobs/sam/modules/Kenki.js:import TimeLineChart from 'components/ui/TimeLineChart'
src/parser/jobs/sam/modules/Kenki.js:				<TimeLineChart
src/parser/jobs/war/modules/Gauge.js:import TimeLineChart from 'components/ui/TimeLineChart'
src/parser/jobs/war/modules/Gauge.js:		return <TimeLineChart
```

Did a basic regression test across all of the above jobs to verify that the graphs still display correctly.