### PR TITLE
BLM ShB Action ID and Rotation Tweaks 

### DIFF
--- a/src/data/ACTIONS/BLM.js
+++ b/src/data/ACTIONS/BLM.js
@@ -35,9 +35,9 @@ export default {
 		castTime: 3.0,
 	},
 	UMBRAL_SOUL: {
-		id: 999999999159, // ID once known
+		id: 16506,
 		name: 'Umbral Soul',
-		icon: 'https://xivapi.com/i/002000/002653.png', // Needs updating once known, still Freeze's icon
+		icon: 'https://xivapi.com/i/002000/002666.png',
 		onGcd: true,
 	},
 	FIRE_I: {
@@ -76,9 +76,9 @@ export default {
 		castTime: 4.0,
 	},
 	DESPAIR: {
-		id: 999999999162, // ID once known
+		id: 16505,
 		name: 'Flare',
-		icon: 'https://xivapi.com/i/002000/002652.png', // Update once this is known, still Flare's icon.
+		icon: 'https://xivapi.com/i/002000/002665.png',
 		onGcd: true,
 		castTime: 3.0,
 	},
@@ -124,9 +124,9 @@ export default {
 		castTime: 2.5,
 	},
 	XENOGLOSSY: {
-		id: 9999999997422, // ID once known
+		id: 16507,
 		name: 'Xenoglossy',
-		icon: 'https://xivapi.com/i/002000/002664.png', // Needs update once known, still Foul's icon
+		icon: 'https://xivapi.com/i/002000/002667.png',
 		onGcd: true,
 	},
 	SLEEP: {
@@ -142,7 +142,7 @@ export default {
 		icon: 'https://xivapi.com/i/000000/000466.png',
 		cooldown: 8,
 	},
-	MANAFONT: { // For now, I'm going to assume SE just re-named the action. Updatable if wrong.
+	MANAFONT: {
 		id: 158,
 		name: 'Manafont',
 		icon: 'https://xivapi.com/i/002000/002651.png',

--- a/src/parser/jobs/blm/modules/Gauge.js
+++ b/src/parser/jobs/blm/modules/Gauge.js
@@ -316,6 +316,8 @@ export default class Gauge extends Module {
 			this.tryConsumeUmbralHearts(event, 1)
 			break
 		case ACTIONS.DESPAIR.id:
+			this.onGainAstralFireStacks(event, MAX_ASTRAL_UMBRAL_STACKS, false)
+			break
 		case ACTIONS.FLARE.id:
 			this.tryConsumeUmbralHearts(event, FLARE_MAX_HEART_CONSUMPTION, true)
 			this.onGainAstralFireStacks(event, MAX_ASTRAL_UMBRAL_STACKS, false)

--- a/src/parser/jobs/blm/modules/RotationWatchdog.js
+++ b/src/parser/jobs/blm/modules/RotationWatchdog.js
@@ -16,7 +16,7 @@ import DISPLAY_ORDER from './DISPLAY_ORDER'
 import {getDataBy} from 'data'
 
 const EXPECTED_FIRE4 = 6
-const FIRE4_FROM_MANAFONT = 2
+const FIRE4_FROM_MANAFONT = 1
 const MIN_MP_LEAVING_UI_NORMALLY = 12960
 const DEBUG_LOG_ALL_FIRE_COUNTS = false && process.env.NODE_ENV !== 'production'
 const AFUIBUFFMAXSTACK = 3


### PR DESCRIPTION
- Update new BLM actions with IDs and icons, remove TODO-style comments
- Update Gauge; Despair does not consume Umbral Hearts
- Update expected fire 4 after Manafont from 2 to 1
    - Despair -> Manafont -> Fire 4 -> Despair is now preferred