### PR TITLE
Warrior IR copy cleanup

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -648,7 +648,7 @@
   "war.gauge.suggestions.lost-rage.content": "You used <0/>, <1/>, <2/>, or any gauge generators in a way that overcapped you.",
   "war.gauge.suggestions.lost-rage.why": "{0} rage wasted by using abilities that sent you over the cap.",
   "war.gauge.title": "Gauge Usage",
-  "war.ir.suggestions.badgcd.content": "GCDs used during <0/> should be limited to <1/> for optimal damage (or <2/> if more than one target is present).",
+  "war.ir.suggestions.badgcd.content": "GCDs used during <0/> should be limited to <1/> for optimal damage (or <2/> if three or more targets are present).",
   "war.ir.suggestions.badgcd.why": "{missedGaugeDumps} incorrect {missedGaugeDumps, plural, one {GCD was} other {GCDs were}} used during <0/> windows.",
   "war.ir.suggestions.missedgcd.content": "Try to land 5 GCDs during every <0/> window. If you cannot do this with full uptime and no clipping, consider adjusting your gearset for more Skill Speed.",
   "war.ir.suggestions.missedgcd.why": "{missedGcds} {missedGcds, plural, one {GCD was} other {GCDs were}} missed inside of <0/> windows.",

--- a/src/parser/jobs/war/modules/InnerRelease.tsx
+++ b/src/parser/jobs/war/modules/InnerRelease.tsx
@@ -120,7 +120,7 @@ export default class InnerRelease extends Module {
 		const missedGcds = this.innerReleaseWindows
 			.reduce((sum, irWindow) => sum + Math.max(0, EXPECTED_CONSTANTS.GCD - irWindow.gcds), 0)
 		const missedGaugeDumps = this.innerReleaseWindows
-			.reduce((sum, irWindow) => sum + Math.max(0, EXPECTED_CONSTANTS.GAUGE_DUMP - irWindow.gaugeDumps), 0)
+			.reduce((sum, irWindow) => sum + Math.max(0, irWindow.gcds - irWindow.gaugeDumps), 0)
 		const missedUpheavals = this.innerReleaseWindows
 			.reduce((sum, irWindow) => sum + Math.max(0, EXPECTED_CONSTANTS.UPHEAVAL - irWindow.upheavals), 0)
 		const missedOnslaughts = this.innerReleaseWindows
@@ -141,13 +141,11 @@ export default class InnerRelease extends Module {
 		}
 
 		// incorrect GCDs (not Fell Cleave or Decimate)
-		// only show this if the number of missed GCDs isn't the same value, otherwise there are bigger issues
-		// note that this is technically incorrect for Memeheaval - no, I'm not fixing it right before 5.0 when it dies
-		if (missedGaugeDumps > 0 && missedGcds !== missedGaugeDumps) {
+		if (missedGaugeDumps > 0) {
 			this.suggestions.add(new Suggestion({
 				icon: ACTIONS.FELL_CLEAVE.icon,
 				content: <Trans id="war.ir.suggestions.badgcd.content">
-					GCDs used during <ActionLink {...ACTIONS.INNER_RELEASE}/> should be limited to <ActionLink {...ACTIONS.FELL_CLEAVE}/> for optimal damage (or <ActionLink {...ACTIONS.DECIMATE}/> if more than one target is present).
+					GCDs used during <ActionLink {...ACTIONS.INNER_RELEASE}/> should be limited to <ActionLink {...ACTIONS.FELL_CLEAVE}/> for optimal damage (or <ActionLink {...ACTIONS.DECIMATE}/> if three or more targets are present).
 				</Trans>,
 				why: <Trans id="war.ir.suggestions.badgcd.why">
 					{missedGaugeDumps} incorrect <Plural value={missedGaugeDumps} one="GCD was" other="GCDs were"/> used during <ActionLink {...ACTIONS.INNER_RELEASE}/> windows.


### PR DESCRIPTION
Make missedGaugeDumps (incorrect GCD in IR window) more descriptive, clarify when Decimate is better than Fell Cleave