### PR TITLE
Mark GNB as supported for 5.01.

### DIFF
--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -22,7 +22,7 @@ export default new Meta({
 
 	supportedPatches: {
 		from: '5.0',
-		to: '5.0',
+		to: '5.01',
 	},
 
 	contributors: [


### PR DESCRIPTION
No actual job changes from patch notes.