### PR TITLE
Dragon Sight bugfix

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -224,6 +224,8 @@
   "drg.buffs.suggestions.bad-lcs.why": "",
   "drg.buffs.suggestions.life-surge.content": "",
   "drg.buffs.suggestions.life-surge.why": "",
+  "drg.buffs.suggestions.solo-ds.content": "",
+  "drg.buffs.suggestions.solo-ds.why": "",
   "drg.buffs.title": "",
   "drg.debuffs.checklist.description": "",
   "drg.debuffs.checklist.name": "Halte deine DoTs aufrecht",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -224,6 +224,8 @@
   "drg.buffs.suggestions.bad-lcs.why": "{badLanceCharges} of your Lance Charge windows started right after a standard combo finisher.",
   "drg.buffs.suggestions.life-surge.content": "Avoid using <0/> on any GCD that isn't <1/> or a 5th combo hit. Any other combo action will have significantly less potency, losing a lot of the benefit of the guaranteed crit.",
   "drg.buffs.suggestions.life-surge.why": "You used {0} on a non-optimal GCD {1, plural, one {# time} other {# times}}.",
+  "drg.buffs.suggestions.solo-ds.content": "Although it doesn't impact your personal DPS, try to always use Dragon Sight on a partner in group content so that someone else can benefit from the damage bonus too.",
+  "drg.buffs.suggestions.solo-ds.why": "At least 1 of your Dragon Sight casts didn't have a tether partner.",
   "drg.buffs.title": "Lance Charge & Dragon Sight",
   "drg.debuffs.checklist.description": "<0/> provides a potent DoT which should be maintained at all times.",
   "drg.debuffs.checklist.name": "Keep your debuffs up",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -224,6 +224,8 @@
   "drg.buffs.suggestions.bad-lcs.why": "",
   "drg.buffs.suggestions.life-surge.content": "Évitez d'utiliser <0/> sur un GCD qui n'est ni <1/> ni la 5ème action de votre combo. Toute autre action de combo aura une puissance significativement inférieure, vous faisant perdre une grande partie du bénéfice d'un coup critique garanti.",
   "drg.buffs.suggestions.life-surge.why": "Vous avez utilisé {0} sur un GCD non optimal {1, plural, one {# fois} other {# fois}}.",
+  "drg.buffs.suggestions.solo-ds.content": "",
+  "drg.buffs.suggestions.solo-ds.why": "",
   "drg.buffs.title": "",
   "drg.debuffs.checklist.description": "",
   "drg.debuffs.checklist.name": "Maintenez vos débuffs actifs",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -224,6 +224,8 @@
   "drg.buffs.suggestions.bad-lcs.why": "",
   "drg.buffs.suggestions.life-surge.content": "<0/> は<1/>かコンボの5段目に使用するようにしましょう。他の箇所では確定クリティカルの恩恵が小さくなります。",
   "drg.buffs.suggestions.life-surge.why": "あなたは最適でないGCD上で {0} を使っている {1, plural, one {# time} other {# times}}.",
+  "drg.buffs.suggestions.solo-ds.content": "",
+  "drg.buffs.suggestions.solo-ds.why": "",
   "drg.buffs.title": "",
   "drg.debuffs.checklist.description": "",
   "drg.debuffs.checklist.name": "デバフの維持率",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -224,6 +224,8 @@
   "drg.buffs.suggestions.bad-lcs.why": "{badlyTimedLcs} 회의 랜스 돌격이 올바르지 않은 글쿨 순서에 사용되었습니다.",
   "drg.buffs.suggestions.life-surge.content": "<0/>를 <1/>나 5번째 콤보가 아닌 글쿨에 사용하는 것을 피하세요. 다른 무기 기술은 현저하게 낮은 위력으로 인해 그 효과가 떨어집니다.",
   "drg.buffs.suggestions.life-surge.why": "{0} 를 적절하지 못한 무기 기술에 {0, plural, one {#회} other {#회}} 사용했습니다.",
+  "drg.buffs.suggestions.solo-ds.content": "",
+  "drg.buffs.suggestions.solo-ds.why": "",
   "drg.buffs.title": "랜스 돌격 & 용의 눈",
   "drg.debuffs.checklist.description": "<0/>는 상당한 지속 데미지를 주며 상시 유지시켜야 합니다.",
   "drg.debuffs.checklist.name": "항상 디버프가 유지되도록 하십시오",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -224,6 +224,8 @@
   "drg.buffs.suggestions.bad-lcs.why": "",
   "drg.buffs.suggestions.life-surge.content": "不要在<1/>与龙5以外的GCD使用<0/>。用在其他任何连击技能上，都会显著降低威力，损失大量必定暴击带来的收益。",
   "drg.buffs.suggestions.life-surge.why": "你在非最优GCD使用了 {1, plural, other {# 次}}{0}",
+  "drg.buffs.suggestions.solo-ds.content": "",
+  "drg.buffs.suggestions.solo-ds.why": "",
   "drg.buffs.title": "",
   "drg.debuffs.checklist.description": "",
   "drg.debuffs.checklist.name": "维持你的Debuff覆盖",

--- a/src/data/STATUSES/DRG.js
+++ b/src/data/STATUSES/DRG.js
@@ -13,6 +13,14 @@ export default {
 		duration: 20,
 	},
 
+	// Because apparently Right Eye has a different status ID if you don't have a tether partner. Thanks, SE.
+	RIGHT_EYE_SOLO: {
+		id: 1910,
+		name: 'Right Eye',
+		icon: 'https://xivapi.com/i/012000/012581.png',
+		duration: 20,
+	},
+
 	LEFT_EYE: {
 		id: 1454,
 		name: 'Left Eye',


### PR DESCRIPTION
Apparently the Right Eye status has a different ID if you don't have a tether buddy, so analysis was going goofy on dummy logs or any time someone's macro fizzled (or they were just being dumb). This should fix it, plus add a minor suggestion to make sure you always tether someone in group content if it detects the solo Right Eye status.