### PR TITLE
Override Weaving for PLD to support instant-cast spells under Requiescat.

### DIFF
--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -49,5 +49,12 @@ export default new Meta({
 			</>,
 			contributors: [CONTRIBUTORS.LHEA],
 		},
+		{
+			date: new Date('2019-07-23'),
+			Changes: () => <>
+				Fix penalties for double-weaving during an active Requiescat window.
+			</>,
+			contributors: [CONTRIBUTORS.LHEA],
+		},
 	],
 })

--- a/src/parser/jobs/pld/modules/Weaving.tsx
+++ b/src/parser/jobs/pld/modules/Weaving.tsx
@@ -1,0 +1,29 @@
+import ACTIONS from 'data/ACTIONS'
+import STATUSES from 'data/STATUSES'
+import {dependency} from 'parser/core/Module'
+import Combatants from 'parser/core/modules/Combatants'
+import CoreWeaving from 'parser/core/modules/Weaving'
+
+const SPELLS = [
+	ACTIONS.HOLY_SPIRIT.id,
+	ACTIONS.HOLY_CIRCLE.id,
+	ACTIONS.CONFITEOR.id,
+	ACTIONS.CLEMENCY.id,
+]
+
+export default class Weaving extends CoreWeaving {
+
+	@dependency private combatants!: Combatants
+
+	isBadWeave(weave: any /*, maxWeaves*/) {
+		if (weave.hasOwnProperty('leadingGcdEvent')) {
+			// Requiescat makes spells instant cast, so they get 2 weaves by default.
+			if (this.combatants.selected.hasStatus(STATUSES.REQUIESCAT.id)
+				&& SPELLS.includes(weave.leadingGcdEvent.ability.guid)) {
+				return weave.weaves.length > 2
+			}
+		}
+
+		return super.isBadWeave(weave)
+	}
+}

--- a/src/parser/jobs/pld/modules/index.tsx
+++ b/src/parser/jobs/pld/modules/index.tsx
@@ -4,6 +4,7 @@ import FightOrFlight from './FightOrFlight'
 import Goring from './Goring'
 import OGCDDowntime from './OGCDDowntime'
 import Requiescat from './Requiescat'
+import Weaving from './Weaving'
 
 export default [
 	Combos,
@@ -12,4 +13,5 @@ export default [
 	Goring,
 	OGCDDowntime,
 	Requiescat,
+	Weaving,
 ]


### PR DESCRIPTION
Title.

Sample log with double weaves under Requiescat: https://www.fflogs.com/reports/rF8NmGvLgxzp9JqA#fight=9&type=damage-done&view=events&source=5&sourcebuffs=-1000076&ability=16459

```
00:04:02.721 | Damelia Lhea Holy Spirit Innocence *18266*
00:04:03.456 | Damelia Lhea Spirits Within Innocence 8418
00:04:04.183 | Damelia Lhea Intervene Innocence 4654
00:04:05.216 | Damelia Lhea Holy Spirit Innocence 15661
```