### PR TITLE
Check for numpty PLDs opening on weaved oGCDs.

### DIFF
--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -56,5 +56,12 @@ export default new Meta({
 			</>,
 			contributors: [CONTRIBUTORS.LHEA],
 		},
+		{
+			date: new Date('2019-07-25'),
+			Changes: () => <>
+				Minor fix for weaving case where player leads on oGCDs.
+			</>,
+			contributors: [CONTRIBUTORS.LHEA],
+		},
 	],
 })

--- a/src/parser/jobs/pld/modules/Weaving.tsx
+++ b/src/parser/jobs/pld/modules/Weaving.tsx
@@ -16,7 +16,9 @@ export default class Weaving extends CoreWeaving {
 	@dependency private combatants!: Combatants
 
 	isBadWeave(weave: any /*, maxWeaves*/) {
-		if (weave.hasOwnProperty('leadingGcdEvent')) {
+		if (weave.hasOwnProperty('leadingGcdEvent')
+			&& weave.leadingGcdEvent.hasOwnProperty('ability') // Check for if the homie opened on an oGCD for w/e reason
+		) {
 			// Requiescat makes spells instant cast, so they get 2 weaves by default.
 			if (this.combatants.selected.hasStatus(STATUSES.REQUIESCAT.id)
 				&& SPELLS.includes(weave.leadingGcdEvent.ability.guid)) {


### PR DESCRIPTION
It's fine to defer this to core Weaving module anyways because it's impossible to have the Requiescat buff at the start of any sensible log -- you need a target to cast it.


Sample log: https://www.fflogs.com/reports/JKFPG7n9tB3MNmrR#fight=6&source=27&type=casts&view=events

Bad sequence:

![Screen Shot 2019-07-24 at 11 40 11 AM](https://user-images.githubusercontent.com/47466448/61819403-dac72880-ae07-11e9-8ac7-605dc01c26c1.png)

Fixed weaving window:

![Screen Shot 2019-07-24 at 11 36 40 AM](https://user-images.githubusercontent.com/47466448/61819448-f16d7f80-ae07-11e9-9630-00747c931f02.png)