### PR TITLE
Fixed an empty Queen window crash

### DIFF
--- a/src/parser/jobs/mch/modules/YassQueen.js
+++ b/src/parser/jobs/mch/modules/YassQueen.js
@@ -79,7 +79,7 @@ export default class YassQueen extends Module {
 
 	_onComplete() {
 		this._finishQueenWindow()
-		const missingBunkers = this._queens.history.filter(queen => queen.casts[queen.casts.length - 1].ability.guid !== ACTIONS.PILE_BUNKER.id).length
+		const missingBunkers = this._queens.history.filter(queen => queen.casts.length && queen.casts[queen.casts.length - 1].ability.guid !== ACTIONS.PILE_BUNKER.id).length
 
 		this.suggestions.add(new TieredSuggestion({
 			icon: ACTIONS.AUTOMATON_QUEEN.icon,


### PR DESCRIPTION
Turns out that trying to do `array[array.length - 1]` when `array.length` is 0 and then hitting references on the result makes things explode slightly. Who knew?