### PR TITLE
BugFix - RDM Enchanted Moulinet Cost

### DIFF
--- a/src/parser/jobs/rdm/index.js
+++ b/src/parser/jobs/rdm/index.js
@@ -32,5 +32,15 @@ export default new Meta({
 	],
 
 	changelog: [
+		{
+			date: new Date('2019-07-14'),
+			Changes: () => <>Initial update of existing logic for 5.0 (no new stuff)</>,
+			contributors: [CONTRIBUTORS.LEYLIA],
+		},
+		{
+			date: new Date('2019-07-26'),
+			Changes: () => <>Fix an issue with Moulinet Mana costs</>,
+			contributors: [CONTRIBUTORS.LEYLIA],
+		},
 	],
 })

--- a/src/parser/jobs/rdm/modules/Gauge.js
+++ b/src/parser/jobs/rdm/modules/Gauge.js
@@ -25,7 +25,7 @@ export const MANA_GAIN = {
 	[ACTIONS.ENCHANTED_RIPOSTE.id]: {white: -30, black: -30},
 	[ACTIONS.ENCHANTED_ZWERCHHAU.id]: {white: -25, black: -25},
 	[ACTIONS.ENCHANTED_REDOUBLEMENT.id]: {white: -25, black: -25},
-	[ACTIONS.ENCHANTED_MOULINET.id]: {white: -30, black: -30},
+	[ACTIONS.ENCHANTED_MOULINET.id]: {white: -20, black: -20},
 	[ACTIONS.ENCHANTED_REPRISE.id]: {white: -10, black: -10},
 	[ACTIONS.SCORCH.id]: {white: 7, black: 7},
 }

--- a/src/parser/jobs/rdm/modules/Gauge.js
+++ b/src/parser/jobs/rdm/modules/Gauge.js
@@ -21,6 +21,8 @@ export const MANA_GAIN = {
 	[ACTIONS.VERFLARE.id]: {white: 0, black: 21},
 	[ACTIONS.JOLT.id]: {white: 3, black: 3},
 	[ACTIONS.JOLT_II.id]: {white: 3, black: 3},
+	[ACTIONS.VERAERO_II.id]: {white: 7, black: 0},
+	[ACTIONS.VERTHUNDER_II.id]: {white: 0, black: 7},
 	[ACTIONS.IMPACT.id]: {white: 3, black: 3},
 	[ACTIONS.ENCHANTED_RIPOSTE.id]: {white: -30, black: -30},
 	[ACTIONS.ENCHANTED_ZWERCHHAU.id]: {white: -25, black: -25},


### PR DESCRIPTION
Fixed Enchanted Moulinet to cost 20 White|Black instead of the old 30.  Also added a retroactive (for 5.0) Change Log specifically so I don't forget when I mark it fully supported.