### PR TITLE
[Bugfix] Added Stardiver to the list of bad weave jumps

### DIFF
--- a/src/parser/jobs/drg/modules/Weaving.js
+++ b/src/parser/jobs/drg/modules/Weaving.js
@@ -6,6 +6,7 @@ const JUMPS = [
 	ACTIONS.HIGH_JUMP.id,
 	ACTIONS.SPINESHATTER_DIVE.id,
 	ACTIONS.DRAGONFIRE_DIVE.id,
+	ACTIONS.STARDIVER.id,
 ]
 
 export default class Weaving extends CoreWeaving {


### PR DESCRIPTION
Smol bugfix. Double-weaving on Stardiver is a no-no.