### PR TITLE
fix: aggregate the successfulHit property correctly

### DIFF
--- a/src/parser/core/modules/AoE.js
+++ b/src/parser/core/modules/AoE.js
@@ -178,7 +178,7 @@ export default class AoE extends Module {
 				hits: Object.values(hitsByTarget),
 				sourceID: event.events[eventType][0].sourceID,
 				amount: Object.values(hitsByTarget).reduce((total, hit) => total + hit.amount, 0),
-				successfulHit: Object.values(hitsByTarget).reduce((successfulHit, hit) => successfulHit || hit, false),
+				successfulHit: Object.values(hitsByTarget).reduce((successfulHit, hit) => successfulHit || hit.successfulHit, false),
 			}
 			if (event.events[eventType][0].hasOwnProperty('sourceResources')) {
 				fabricatedEvent.sourceResources = event.events[eventType][0].sourceResources

--- a/src/parser/jobs/drk/modules/ResourceSimulator.js
+++ b/src/parser/jobs/drk/modules/ResourceSimulator.js
@@ -118,7 +118,7 @@ export default class Resources extends Module {
 
 	constructor(...args) {
 		super(...args)
-		this.addHook(['damage', 'aoedamage', 'combo'], {by: 'player', abilityId: this._resourceEvents}, this._onEvent)
+		this.addHook(['aoedamage', 'combo'], {by: 'player', abilityId: this._resourceEvents}, this._onEvent)
 		// Hook cast for Living Shadow, as it doesn't directly deal damage so doesn't have an aoedamage event
 		this.addHook('cast', {by: 'player', abilityId: ACTIONS.LIVING_SHADOW.id}, this._onEvent)
 		// Hook cast for TBN application

--- a/src/parser/jobs/drk/modules/ResourceSimulator.js
+++ b/src/parser/jobs/drk/modules/ResourceSimulator.js
@@ -212,7 +212,6 @@ export default class Resources extends Module {
 	}
 
 	_onEvent(event) {
-		console.log(`${JSON.stringify(event, null, 4)}`)
 		const abilityId = event.ability.guid
 		let actionBloodGain = 0
 		let actionMPGain = 0

--- a/src/parser/jobs/drk/modules/ResourceSimulator.js
+++ b/src/parser/jobs/drk/modules/ResourceSimulator.js
@@ -118,7 +118,7 @@ export default class Resources extends Module {
 
 	constructor(...args) {
 		super(...args)
-		this.addHook(['aoedamage', 'combo'], {by: 'player', abilityId: this._resourceEvents}, this._onEvent)
+		this.addHook(['damage', 'aoedamage', 'combo'], {by: 'player', abilityId: this._resourceEvents}, this._onEvent)
 		// Hook cast for Living Shadow, as it doesn't directly deal damage so doesn't have an aoedamage event
 		this.addHook('cast', {by: 'player', abilityId: ACTIONS.LIVING_SHADOW.id}, this._onEvent)
 		// Hook cast for TBN application
@@ -212,6 +212,7 @@ export default class Resources extends Module {
 	}
 
 	_onEvent(event) {
+		console.log(`${JSON.stringify(event, null, 4)}`)
 		const abilityId = event.ability.guid
 		let actionBloodGain = 0
 		let actionMPGain = 0

--- a/src/parser/jobs/rdm/modules/Gauge.js
+++ b/src/parser/jobs/rdm/modules/Gauge.js
@@ -90,7 +90,7 @@ class GaugeAction {
 		const abilityId = event.ability.guid
 		const {white, black} = MANA_GAIN[abilityId] || {}
 		if (white || black) {
-			if (event.amount === 0) {
+			if (!event.successfulHit) {
 				// Melee combo skills will still consume mana but will not continue the combo, set an invuln/missed flag for downstream consumers
 				this.missOrInvuln = true
 


### PR DESCRIPTION
Aggregation was merging the entire hit object, rather than just the successfulHit property.  

This also supersedes the change to Gauge.js in #497, per my discussion with Cephid in the dev channel.  This PR should win on the merge conflict for that specific file.