### PR TITLE
Add Ruin II to SCH

### DIFF
--- a/src/data/ACTIONS/ACN.js
+++ b/src/data/ACTIONS/ACN.js
@@ -60,7 +60,7 @@ export default {
 		cooldownGroup: SMN_COOLDOWN_GROUP.SUMMON,
 	},
 
-	RUIN_II: {
+	SMN_RUIN_II: {
 		id: 172,
 		name: 'Ruin II',
 		icon: 'https://xivapi.com/i/000000/000502.png',

--- a/src/data/ACTIONS/SCH.js
+++ b/src/data/ACTIONS/SCH.js
@@ -27,6 +27,13 @@ export default {
 		castTime: 2.5,
 	},
 
+	SCH_RUIN_II: {
+		id: 17870,
+		name: 'Ruin II',
+		icon: 'https://xivapi.com/i/000000/000502.png',
+		onGcd: true,
+	},
+
 	RECITATION: {
 		id: 16542,
 		name: 'Recitation',

--- a/src/parser/jobs/sch/modules/Weaving.js
+++ b/src/parser/jobs/sch/modules/Weaving.js
@@ -44,9 +44,9 @@ export default class Weaving extends CoreWeaving {
 	// Now this, we want to overwrite
 	_onComplete() {
 		this.suggestions.add(new TieredSuggestion({
-			icon: ACTIONS.RUIN_II.icon,
+			icon: ACTIONS.SCH_RUIN_II.icon,
 			content: <Trans id="sch.weaving.suggestion.content">
-				<ActionLink {...ACTIONS.RUIN_II} /> may seem like a great choice for weaving,
+				<ActionLink {...ACTIONS.SCH_RUIN_II} /> may seem like a great choice for weaving,
 				but because its potency is <i>absurdly</i> low compared to <ActionLink {...ACTIONS.BROIL_III} />,
 				it is actually better to just clip your GCD with Broil than to waste your mana.
 				An exception is if you are moving - so the module below only tracks instances of Ruin 2 while not moving.
@@ -68,7 +68,7 @@ export default class Weaving extends CoreWeaving {
 		}
 
 		// Ruin 2 is just bad for weaving
-		if (weave.leadingGcdEvent.ability.guid === ACTIONS.RUIN_II.id &&
+		if (weave.leadingGcdEvent.ability.guid === ACTIONS.SCH_RUIN_II.id &&
 			weave.weaves.length > 0
 		) {
 			// ...unless you were using it for movement

--- a/src/parser/jobs/smn/modules/Ruin2.js
+++ b/src/parser/jobs/smn/modules/Ruin2.js
@@ -74,7 +74,7 @@ export default class Ruin2 extends Module {
 		// If there was no oGCD cast between the R2 and now, mark an issue
 		if (
 			action.onGcd &&
-			lastGcdActionId === ACTIONS.RUIN_II.id &&
+			lastGcdActionId === ACTIONS.SMN_RUIN_II.id &&
 			!this._ogcdUsed &&
 			invulnTime === 0
 		) {
@@ -91,7 +91,7 @@ export default class Ruin2 extends Module {
 		this._pos = this.combatants.selected.resources
 
 		// If this is an R2 cast, track it
-		if (action.id === ACTIONS.RUIN_II.id) {
+		if (action.id === ACTIONS.SMN_RUIN_II.id) {
 			this._all.push(event)
 			// Explicitly setting the ogcd tracker to true while bahamut is out,
 			// we don't want to fault people for using R2 for WWs during bahamut.
@@ -117,7 +117,7 @@ export default class Ruin2 extends Module {
 			tiers: BAD_CAST_SEVERITY,
 			value: issues,
 			content: <Trans id="smn.ruin-ii.suggestions.issues.content">
-				<ActionLink {...ACTIONS.RUIN_II}/> is a DPS loss when not used to weave oGCDs or proc <ActionLink {...ACTIONS.WYRMWAVE}/>s. Prioritise casting <ActionLink {...ACTIONS.RUIN_III}/>.
+				<ActionLink {...ACTIONS.SMN_RUIN_II}/> is a DPS loss when not used to weave oGCDs or proc <ActionLink {...ACTIONS.WYRMWAVE}/>s. Prioritise casting <ActionLink {...ACTIONS.RUIN_III}/>.
 			</Trans>,
 			why: <Trans id="smn.ruin-ii.suggestions.issues.why">
 				{issues * potLossPerR2} potency lost to {issues} unnecessary Ruin II
@@ -126,9 +126,9 @@ export default class Ruin2 extends Module {
 		}))
 
 		this.suggestions.add(new TieredSuggestion({
-			icon: ACTIONS.RUIN_II.icon,
+			icon: ACTIONS.SMN_RUIN_II.icon,
 			content: <Trans id="smn.ruin-ii.suggestions.warnings.content">
-				Unless significant movement is required, avoid using <ActionLink {...ACTIONS.RUIN_II}/> for movement. Most position adjustments can be performed with slidecasting and the additional mobility available during <ActionLink {...ACTIONS.DREADWYRM_TRANCE}/>.
+				Unless significant movement is required, avoid using <ActionLink {...ACTIONS.SMN_RUIN_II}/> for movement. Most position adjustments can be performed with slidecasting and the additional mobility available during <ActionLink {...ACTIONS.DREADWYRM_TRANCE}/>.
 			</Trans>,
 			why: <Trans id="smn.ruin-ii.suggestions.warnings.why">
 				{warnings * potLossPerR2} potency lost to {warnings} Ruin II


### PR DESCRIPTION
SCH has a separate Ruin II ability from ACN with its own id. This commit simply adds that ability to the SCH job actions.

Compare:
ACN: https://garlandtools.org/db/#action/172
SCH: https://garlandtools.org/db/#action/17870