### PR TITLE
Fix combos so they break on restarting a combo

### DIFF
--- a/src/parser/core/modules/Combos.tsx
+++ b/src/parser/core/modules/Combos.tsx
@@ -148,19 +148,26 @@ export default class Combos extends Module {
 			}
 		}
 
-		// Incorrect combo action, that's a paddlin'
+		if (combo.start) {
+			// Broken combo - starting a new combo while in a current combo
+			this.recordBrokenCombo(event, this.currentComboChain)
+			return true // Start a new combo
+		}
+
+		// Check if action continues existing combo
 		if (combo.from) {
 			const fromOptions = Array.isArray(combo.from) ? combo.from : [combo.from]
-			if (!fromOptions.includes(this.lastAction)) {
-				this.recordBrokenCombo(event, this.currentComboChain)
-				return combo.start // It's a combo if the action is the start of one
+			if (fromOptions.includes(this.lastAction)) {
+				// Combo continued correctly
+				this.fabricateComboEvent(event)
+				// If it's a finisher, reset the combo
+				return !combo.end
 			}
 		}
 
-		// Combo continued correctly
-		this.fabricateComboEvent(event)
-		// If it's a finisher, reset the combo
-		return !combo.end
+		// Action did not continue combo correctly and is not a new combo starter
+		this.recordBrokenCombo(event, this.currentComboChain)
+		return false
 	}
 
 	private onCast(event: AoeEvent) {


### PR DESCRIPTION
Currently, combos don't get marked as broken if they are restarted with a new combo starter.  This can lead to some unexpected behavior, as seen here: https://xivanalysis.com/analyse/pkGqAXfKBdC1gQMH/1/1/ -- only 1 "broken" combo is recorded for all the Hard Slash / Syphon Slash alternations, and only when he does Hard Slash > Souleater

Fix changes the logic to detect all of those Hard Slashes as separate combo breaks, will display as: 
![image](https://user-images.githubusercontent.com/26804378/62417172-5a7aa180-b617-11e9-83d7-a050c85b41dd.png)
