### PR TITLE
Fix issue with single stack use

### DIFF
--- a/src/parser/jobs/sch/modules/Aetherflow.js
+++ b/src/parser/jobs/sch/modules/Aetherflow.js
@@ -136,7 +136,7 @@ export default class Aetherflow extends Module {
 				</Table.Row>
 			</Table.Header>
 			<Table.Body>
-				{[].concat(aetherflows, dissipations, ...uses)
+				{[].concat(aetherflows, dissipations, uses)
 					.sort((a, b) => a.timestamp - b.timestamp)
 					.reduce((prev, curr) => {
 						if (prev.length === 0) {
@@ -189,6 +189,13 @@ export default class Aetherflow extends Module {
 							wasted = EXTRA_AETHERFLOWS - debit || 0
 							totalWasted += wasted
 						}
+
+						if (!Array.isArray(timestamp)) {
+							// I mean, they should be doing more than one AF cast per stack
+							// but who am I to judge?
+							timestamp = [timestamp]
+						}
+
 						return <Table.Row key={timestamp}>
 							<Table.Cell>{timestamp.map(t => this.parser.formatTimestamp(t)).join(', ')}</Table.Cell>
 							<Table.Cell>{downtime > 0 && this.parser.formatDuration(downtime)}</Table.Cell>


### PR DESCRIPTION
This should not affect the majority use case of xivanalysis for SCH (instanced raids, etc), but it could look bad if it's content like dungeons or when they have a parse where they started with aetherflow stacks.

For some examples of where this currently breaks, see the following:
* [striking dummy test](https://xivanalysis.com/analyse/M6bkczhpNrAR2Pqd/3/7/)
* [old content where AF could be used outside of combat](https://xivanalysis.com/analyse/nV4z6WXbqjy9vHd1/219/5888/)

Won't help with old content, but I'd rather cover the edge case for current content anyway.