### PR TITLE
Core+DNC allowable dropped combos

### DIFF
--- a/src/parser/core/modules/Combos.tsx
+++ b/src/parser/core/modules/Combos.tsx
@@ -236,19 +236,23 @@ export default class Combos extends Module {
 		}))
 	}
 
+	/**
+	 * To be overridden by subclasses. This is called in _onComplete() and passed two arrays of event objects - one for events that
+	 * broke combos, and one for combo GCDs used outside of combos. Subclassing modules can add job-specific suggestions based on
+	 * what particular actions were misused and when in the fight.
+	 * The overriding module should return true if the default suggestion is not wanted
+	 */
 	addJobSpecificSuggestions(comboBreakers: AoeEvent[], uncomboedGcds: AoeEvent[]) {
-		// To be overridden by subclasses. This is called in _onComplete() and passed two arrays of event objects - one for events that
-		// broke combos, and one for combo GCDs used outside of combos. Subclassing modules can add job-specific suggestions based on
-		// what particular actions were misused and when in the fight.
-		// The overriding module should return true if the default suggestion is not wanted
 		return false
 	}
 
+	/**
+	 * To be overridden by subclasses. This is called in recordBrokenCombo, and receives the event triggering the broken combo,
+	 * and the context information for that break. Jobs can override this to indicate whether this broken combo is allowed. If so,
+	 * the event and context will not be recorded, and the current combo will be cleared with no other side effects.
+	 * Returning false will allow the break to be recorded, and displayed to the user
+	 */
 	isAllowableComboBreak(event: AoeEvent, context: AoeEvent[]): boolean {
-		// To be overridden by subclasses. This is called in recordBrokenCombo, and receives the event triggering the broken combo,
-		// and the context information for that break. Jobs can override this to indicate whether this broken combo is allowed. If so,
-		// the event and context will not be recorded, and the current combo will be cleared with no other side effects.
-		// Returning false will allow the break to be recorded, and displayed to the user
 		return false
 	}
 

--- a/src/parser/core/modules/Combos.tsx
+++ b/src/parser/core/modules/Combos.tsx
@@ -100,11 +100,13 @@ export default class Combos extends Module {
 	}
 
 	protected recordBrokenCombo(event: AoeEvent, context: AoeEvent[]) {
-		this.issues.push({
-			type: 'combobreak',
-			event,
-			context,
-		})
+		if (!this.isAllowableComboBreak(event, context)) {
+			this.issues.push({
+				type: 'combobreak',
+				event,
+				context,
+			})
+		}
 		this.currentComboChain = []
 	}
 
@@ -239,6 +241,14 @@ export default class Combos extends Module {
 		// broke combos, and one for combo GCDs used outside of combos. Subclassing modules can add job-specific suggestions based on
 		// what particular actions were misused and when in the fight.
 		// The overriding module should return true if the default suggestion is not wanted
+		return false
+	}
+
+	isAllowableComboBreak(event: AoeEvent, context: AoeEvent[]): boolean {
+		// To be overridden by subclasses. This is called in recordBrokenCombo, and receives the event triggering the broken combo,
+		// and the context information for that break. Jobs can override this to indicate whether this broken combo is allowed. If so,
+		// the event and context will not be recorded, and the current combo will be cleared with no other side effects.
+		// Returning false will allow the break to be recorded, and displayed to the user
 		return false
 	}
 

--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -36,4 +36,9 @@ export const changelog = [
 		Changes: () => <>Dancer supported for Shadowbringers.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2019-08-05'),
+		Changes: () => <>Updated combo logic to allow Fountain to drop if Cascade was used directly before both Standard and Technical Steps.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/dnc/modules/Combos.ts
+++ b/src/parser/jobs/dnc/modules/Combos.ts
@@ -1,0 +1,25 @@
+import ACTIONS from 'data/ACTIONS'
+import STATUSES from 'data/STATUSES'
+import {dependency} from 'parser/core/Module'
+import Combatants from 'parser/core/modules/Combatants'
+import CoreCombos, {AoeEvent} from 'parser/core/modules/Combos'
+import DirtyDancing from './DirtyDancing'
+
+const GCD_TIMEOUT_MILLIS = 15000
+
+export default class Combos extends CoreCombos {
+	// Override statics
+	static suggestionIcon = ACTIONS.CASCADE.icon
+
+	@dependency private dancing!: DirtyDancing
+
+	// Override check for allowable breaks. If two dances were started during the initial context's GCD timeout window,
+	// (ie, both Standard and Technical were danced), then we'll allow it
+	isAllowableComboBreak(event: AoeEvent, context: AoeEvent[]): boolean {
+		// Shouldn't ever be the case, but protect against weird shit
+		if (context.length !== 1) {
+			return false
+		}
+		return this.dancing.dancesInRange(context[0].timestamp, context[0].timestamp + GCD_TIMEOUT_MILLIS) === 2
+	}
+}

--- a/src/parser/jobs/dnc/modules/Combos.ts
+++ b/src/parser/jobs/dnc/modules/Combos.ts
@@ -1,7 +1,5 @@
 import ACTIONS from 'data/ACTIONS'
-import STATUSES from 'data/STATUSES'
 import {dependency} from 'parser/core/Module'
-import Combatants from 'parser/core/modules/Combatants'
 import CoreCombos, {AoeEvent} from 'parser/core/modules/Combos'
 import DirtyDancing from './DirtyDancing'
 

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -119,6 +119,10 @@ export default class DirtyDancing extends Module {
 		this.addHook('complete', this.onComplete)
 	}
 
+	dancesInRange(startTime: number, endTime: number) {
+		return this.danceHistory.filter(dance => dance.start >= startTime && dance.start <= endTime).length
+	}
+
 	private addDanceToHistory(event: CastEvent): Dance {
 		const newDance = new Dance(event.timestamp)
 		newDance.rotation.push(event)

--- a/src/parser/jobs/dnc/modules/index.ts
+++ b/src/parser/jobs/dnc/modules/index.ts
@@ -1,3 +1,4 @@
+import Combos from './Combos'
 import DirtyDancing from './DirtyDancing'
 import EspritGauge from './Esprit'
 import FeatherGauge from './FeatherGauge'
@@ -5,6 +6,7 @@ import OGCDDowntime from './OGCDDowntime'
 import Procs from './Procs'
 
 export default [
+	Combos,
 	Procs,
 	DirtyDancing,
 	EspritGauge,


### PR DESCRIPTION
Core Combos updated to include overrideable function that allows subclasses to flag broken combos as allowable.
DNC combos module to select an appropriate icon, and allow Flourish to drop if both Standard and Technical Steps are used during Cascade's combo window.

Note that this will be affected by #514 since it's currently referencing the AoeEvent from Core Combos.