### PR TITLE
5.05 GNB - Version bump

### DIFF
--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -22,7 +22,7 @@ export default new Meta({
 
 	supportedPatches: {
 		from: '5.0',
-		to: '5.01',
+		to: '5.05',
 	},
 
 	contributors: [


### PR DESCRIPTION
As there were no battle system changes to GNB in 5.05, I believe this is safe to bump.

Probably wasn't bumped since no-one was watching this? Working as intended!