### PR TITLE
[BUGFIX] AST Horoscope reworked for accuracy (._.)

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -45,7 +45,7 @@
   "ast.earthyl-star.suggestion.missed-use.content": "Use <0/> more frequently. It may save a healing GCD and results in more damage output.",
   "ast.earthyl-star.suggestion.missed-use.why": "About {_usesMissed} uses of Earthly Star were missed by holding it for at least a total of {0}.",
   "ast.horoscope.suggestion.expired.content": "<0/> does not activate by itself, so don't forget to use it again or it will expire for no potency.",
-  "ast.horoscope.suggestion.expired.why": "{0, plural, one {# expiration} other {# expirations}}  of Horoscope without reading fortunes again.",
+  "ast.horoscope.suggestion.expired.why": "{missedActivations, plural, one {# expiration} other {# expirations}}  of Horoscope without reading fortunes again.",
   "ast.horoscope.title": "Horoscope",
   "ast.lightspeed.messages.explanation": "The main use of <0/> should be for weaving card actions during <1/> and <2/> windows.<3/>It can also be used for MP savings on heavy healing segments, keeping casts up while on the move and other specific scenarios.<4/>Each fight calls for a different strategy, but try to utilize it as much as possible.<5/><6/>Unless it's being used for <7/>, lightspeed should fit at least 6 GCDs.",
   "ast.lightspeed.messages.no-casts": "There were no casts recorded for <0/>",

--- a/src/parser/jobs/ast/index.tsx
+++ b/src/parser/jobs/ast/index.tsx
@@ -46,6 +46,14 @@ export default new Meta({
 	changelog: [
 		{
 
+			date: new Date('2019-08-10'),
+			Changes: () => <>
+				<ActionLink {...ACTIONS.HOROSCOPE} /> reworked tracking for accuracy
+			</>,
+			contributors: [CONTRIBUTORS.SUSHIROU],
+		},
+		{
+
 			date: new Date('2019-08-08'),
 			Changes: () => <>
 				<strong>Get more of those cards</strong>:

--- a/src/parser/jobs/ast/modules/Horoscope.tsx
+++ b/src/parser/jobs/ast/modules/Horoscope.tsx
@@ -15,9 +15,10 @@ import React from 'react'
 
 const SEVERETIES = {
 	ACTIVATES_MISSED: {
-		1: SEVERITY.MEDIUM,
+		1: SEVERITY.MINOR,
+		2: SEVERITY.MEDIUM,
 	},
-	NO_HOROSCOPE_HELIOS: {
+	NOHOROSCOPE_HELIOS: {
 		1: SEVERITY.MEDIUM,
 	},
 }
@@ -44,103 +45,39 @@ export default class Horoscope extends Module {
 
 	@dependency private suggestions!: Suggestions
 
-	_active = false
-	_uses = 0
-	_missedActivations = 0
-	_horoscope: HoroscopeWindow = {
-		start: 0,
-		end: null,
-		casts: [],
-	}
-	_history: HoroscopeWindow[] = []
+	private uses = 0
+	private activations = 0
 
 	protected init() {
-		this.addHook('cast', {abilityId: ACTIONS.HOROSCOPE.id, by: 'player'}, this._onHoroscope)
-
-		this.addHook('applybuff', {abilityId: HOROSCOPE_STATUSES, by: 'player', to: 'player'}, this._onApplyBuff)
-		this.addHook('removebuff', {abilityId: HOROSCOPE_STATUSES, by: 'player', to: 'player'}, this._onRemoveBuff)
-		this.addHook('cast', {abilityId: ACTIONS.HOROSCOPE_ACTIVATION.id, by: 'player'}, this._onActivate)
-		this.addHook('cast', {abilityId: HELIOS_CASTS, by: 'player'}, this._onHelios)
-
-		this.addHook('complete', this._onComplete)
+		this.addHook('cast', {abilityId: ACTIONS.HOROSCOPE.id, by: 'player'}, this.onHoroscope)
+		this.addHook('cast', {abilityId: ACTIONS.HOROSCOPE_ACTIVATION.id, by: 'player'}, this.onActivate)
+		this.addHook('complete', this.onComplete)
 	}
 
-	_onHoroscope(event: CastEvent) {
-		this._uses++
-		// If it's a LIGHTSPEED cast, start tracking
-		this._startHoroscope(event.timestamp)
+	private onHoroscope(event: CastEvent) {
+		console.log(event)
+		this.uses++
+	}
+	private onActivate(event: CastEvent) {
+		console.log(event)
+		this.activations++
 	}
 
-	_onApplyBuff(event: BuffEvent) {
-		if (event.ability.guid === STATUSES.HOROSCOPE.id) {
-			if (this._active) { return }
-			this._startHoroscope(event.timestamp)
-		}
-	}
-	_onRemoveBuff(event: BuffEvent) {
-		if (event.ability.guid === STATUSES.HOROSCOPE_HELIOS.id && this._active) {
-			// Dropped Horoscope without activating
-			this._missedActivations++
-			this._stopAndSave(event.timestamp)
-		}
-		if (event.ability.guid === STATUSES.HOROSCOPE.id && this._active) {
-			// Dropped Horoscope without activating
-		if (this._horoscope.casts.length === 0) {
-				this._missedActivations++
-				this._stopAndSave(event.timestamp)
-			}
-		}
-	}
-	_onHelios(event: CastEvent) {
-		if (!this._active) {
-			return
-		}
-		this._horoscope.casts.push(event)
-	}
-	_onActivate(event: CastEvent) {
-		this._horoscope.casts.push(event)
-		this._stopAndSave(event.timestamp)
-	}
-
-	_startHoroscope(start: number) {
-		this._active = true
-		this._horoscope = {
-			start,
-			end: null,
-			casts: [],
-		}
-	}
-
-	_stopAndSave(endTime = this.parser.currentTimestamp) {
-		// Make sure we've not already stopped this one
-		if (!this._active) {
-			return
-		}
-		this._active = false
-		this._horoscope.end = endTime
-
-		this._history.push(this._horoscope)
-	}
-
-	_onComplete() {
-		// Clean up any existing casts
-		if (this._active) {
-			this._stopAndSave()
-		}
-
+	onComplete() {
 		/*
 			SUGGESTION: Didn't activate
 		*/
+		const missedActivations = this.uses - this.activations
 		this.suggestions.add(new TieredSuggestion({
 			icon: ACTIONS.HOROSCOPE_ACTIVATION.icon,
 			content: <Trans id="ast.horoscope.suggestion.expired.content">
 				<ActionLink {...ACTIONS.HOROSCOPE} /> does not activate by itself, so don't forget to use it again or it will expire for no potency.
 			</Trans>,
 			why: <Trans id="ast.horoscope.suggestion.expired.why">
-				<Plural value={this._missedActivations} one="# expiration" other="# expirations" />  of Horoscope without reading fortunes again.
+				<Plural value={missedActivations} one="# expiration" other="# expirations" />  of Horoscope without reading fortunes again.
 			</Trans>,
 			tiers: SEVERETIES.ACTIVATES_MISSED,
-			value: this._missedActivations,
+			value: missedActivations,
 		}))
 
 	}

--- a/src/parser/jobs/ast/modules/Horoscope.tsx
+++ b/src/parser/jobs/ast/modules/Horoscope.tsx
@@ -18,9 +18,6 @@ const SEVERETIES = {
 		1: SEVERITY.MINOR,
 		2: SEVERITY.MEDIUM,
 	},
-	NOHOROSCOPE_HELIOS: {
-		1: SEVERITY.MEDIUM,
-	},
 }
 
 const HELIOS_CASTS = [
@@ -55,11 +52,9 @@ export default class Horoscope extends Module {
 	}
 
 	private onHoroscope(event: CastEvent) {
-		console.log(event)
 		this.uses++
 	}
 	private onActivate(event: CastEvent) {
-		console.log(event)
 		this.activations++
 	}
 


### PR DESCRIPTION
It just wasn't working. Original intent was to track the entire cycle:
1. Used horoscope, track the 10s buff
2. Did they use a helios cast to upgrade it?
3. Track the upgraded 30s buff
4. Spit out warning if either buff expired.

Unfortunately, `removebuff` comes before activation in the logs whether or not they activated in time. 
For now, we're just going to go with this very sad implementation that works accurately for the suggestion we're trying to make.