### PR TITLE
WIP: Adjust CooldownDowntime calculation method

### DIFF
--- a/src/data/STATUSES/RDM.js
+++ b/src/data/STATUSES/RDM.js
@@ -20,6 +20,7 @@ export default {
 		id: 1238,
 		name: 'Acceleration',
 		icon: 'https://xivapi.com/i/013000/013405.png',
+		actionId: 7518,
 	},
 	EMBOLDEN_PHYSICAL: {//Note that this is the Embolden that boosts Physical Damage - what other people receive from RDM
 		id: 1297,

--- a/src/parser/core/modules/Cooldowns.js
+++ b/src/parser/core/modules/Cooldowns.js
@@ -188,7 +188,12 @@ export default class Cooldowns extends Module {
 		// If there's a current object, move it into the history
 		// TODO: handle errors on CD overlap
 		if (cd.current) {
-			cd.history.push(cd.current)
+			if (cd.current.timestamp < this.parser.fight.start_time) {
+				// Pre-pull usage, reset the cooldown to prevent overlap on timeline since we don't know exactly when cooldown was used pre-pull
+				this.resetCooldown(actionId)
+			} else {
+				cd.history.push(cd.current)
+			}
 		}
 
 		cd.current = {

--- a/src/parser/core/modules/PrecastStatus.js
+++ b/src/parser/core/modules/PrecastStatus.js
@@ -1,4 +1,7 @@
 import Module from 'parser/core/Module'
+import {getDataBy} from 'data'
+import ACTIONS from 'data/ACTIONS'
+import STATUSES from 'data/STATUSES'
 
 // Statuses applied before the pull won't have an apply(de)?buff event
 // Fake buff applications so modules don't need to take it into account
@@ -40,6 +43,20 @@ export default class PrecastStatus extends Module {
 					timestamp: startTime - 1,
 					type: 'applybuff',
 				})
+
+				// Determine if this buff comes from a known action, fab a cast event
+				const statusInfo = getDataBy(STATUSES, 'id', event.ability.guid)
+				if (statusInfo && statusInfo.actionId) {
+					const castAbility = getDataBy(ACTIONS, 'id', statusInfo.actionId)
+					if (castAbility) {
+						const castEvent = event
+						castEvent.timestamp = startTime - 2
+						castEvent.type = 'cast'
+						castEvent.ability.guid = castAbility.id
+
+						events.splice(0, 0, castEvent)
+					}
+				}
 
 				this._combatantStatuses[targetId].push(statusId)
 			}


### PR DESCRIPTION
The current calculation method for oGCD cooldown downtime results in several unexpected behaviors around fights that are just longer than an even number of cooldown usages, especially when the player is really bad at using a particular tracked cooldown.  

Currently, the CooldownDowntime module calculates as:
- Determine max possible uses based on fight duration - a 60 second cooldown in a 10:02 fight will have 11 possible uses max
- Determine how long the skill was off cooldown between each use, and reduce those "downtime"s by defined allowable amounts or time the boss was invulnerable while skill was off cooldown
- Calculate how many skills we think they used by taking max possible and subtracting (downtime/cooldown), with an adjustment for end of fight leftover time.

The specific way the calculation is being handled means that a 60 second cooldown in a 10:02 fight will calculate 10/11 uses if one use was missed, even though only 9 uses were actually recorded (leading to "bad" percentages), and the calculated number of uses can go negative if the skill is never used and there's the right combination of fightDuration compared to skillCooldown with the calling module providing no defined firstUseOffset delay.

Proposed change is two parts:
- Synthesize cast events for pre-pull statuses, so we can count those uses.  This resolves the primary blocker to counting actual uses, for skills like Acceleration which are routinely used pre-pull.  
- Change to counting actual uses, and adjusting the computation for max uses to account for allowable drift between uses.  In order to simplify the calculation and presentation for this drift calculation, change the allocation of "invulnerable time" to the cooldown usage _after_ the one that came off cooldown before the boss went invulnerable.

The only other consumer of the getTimeOnCooldown method is the SCH Aetherflow module, which is not passing a true value to considerInvulnTime, so will not be effected by the change to the invulnerable time calculations.

For purposes of WIP, I've only added a cross-reference ID between the status and the action for RDM's Acceleration.  Assuming these changes are determined to be viable overall, I'll go through the other data files and add appropriate cross-reference IDs where necessary.