### PR TITLE
Small bugfix and wording update for MCH

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -427,7 +427,7 @@
   "mch.gauge.suggestions.heat-waste.why": "You lost {0} Heat to an overcapped gauge.",
   "mch.gauge.title": "Heat & Battery Gauge",
   "mch.gauge.trigger.negative-heat": "<0/> was used when the simulated Heat gauge was at {0}.",
-  "mch.heat.accordion.message": "Every overheat window should ideally include {OVERHEAT_GCD_TARGET} casts of <0/> ({0} is also okay if you play with high ping) and as many casts of <1/> and <2/> as you can squeeze in between them. Each overheat window below indicates how many GCDs it contained and will display all the casts in the window if expanded.",
+  "mch.heat.accordion.message": "Every overheat window should ideally include {OVERHEAT_GCD_TARGET} casts of <0/> and enough casts of <1/> and <2/> to avoid overcapping their charges. If you clip a lot while weaving, overcapping is still preferable to dropping a Heat Blast. Each overheat window below indicates how many GCDs it contained and will display all the casts in the window if expanded.",
   "mch.heat.panel-count": "{0, plural, one {GCD} other {GCDs}}",
   "mch.heat.title": "Overheat Windows",
   "mch.queen.accordion.message": "The list below contains every <0/> window from the fight, indicating when it started, its Battery cost and duration, and how much total damage the Queen did to its target. Expanding an individual window below will display every cast by the Automaton Queen made during it.",

--- a/src/parser/jobs/mch/modules/Heat.js
+++ b/src/parser/jobs/mch/modules/Heat.js
@@ -106,7 +106,7 @@ export default class Heat extends Module {
 
 		return <Fragment>
 			<Message>
-				<Trans id="mch.heat.accordion.message">Every overheat window should ideally include {OVERHEAT_GCD_TARGET} casts of <ActionLink {...ACTIONS.HEAT_BLAST}/> ({OVERHEAT_GCD_TARGET - 1} is also okay if you play with high ping) and as many casts of <ActionLink {...ACTIONS.GAUSS_ROUND}/> and <ActionLink {...ACTIONS.RICOCHET}/> as you can squeeze in between them. Each overheat window below indicates how many GCDs it contained and will display all the casts in the window if expanded.</Trans>
+				<Trans id="mch.heat.accordion.message">Every overheat window should ideally include {OVERHEAT_GCD_TARGET} casts of <ActionLink {...ACTIONS.HEAT_BLAST}/> and enough casts of <ActionLink {...ACTIONS.GAUSS_ROUND}/> and <ActionLink {...ACTIONS.RICOCHET}/> to avoid overcapping their charges. If you clip a lot while weaving, overcapping is still preferable to dropping a Heat Blast. Each overheat window below indicates how many GCDs it contained and will display all the casts in the window if expanded.</Trans>
 			</Message>
 			<Accordion
 				exclusive={false}

--- a/src/parser/jobs/mch/modules/Reassemble.js
+++ b/src/parser/jobs/mch/modules/Reassemble.js
@@ -77,7 +77,7 @@ export default class Reassemble extends Module {
 			},
 			value: this._droppedReassembles,
 			why: <Trans id="mch.reassemble.suggestions.dropped.why">
-				You allowed Reassemble to fall off unused <Plural value={this._badReassembles} one="# time" other="# times"/>.
+				You allowed Reassemble to fall off unused <Plural value={this._droppedReassembles} one="# time" other="# times"/>.
 			</Trans>,
 		}))
 	}


### PR DESCRIPTION
Fixed a bug (that no one ever noticed because dropping Reassemble is rare) and updated the wording on the Overheat section of the page per discussion yesterday in #dev-ranged. I figured I'd just lump that in here so I don't forget.