### PR TITLE
Update Scholar Actions to Match 5.05 Job Guide

### DIFF
--- a/src/data/ACTIONS/SCH.js
+++ b/src/data/ACTIONS/SCH.js
@@ -8,7 +8,6 @@ export default {
 		name: 'Biolysis',
 		icon: 'https://xivapi.com/i/002000/002820.png',
 		onGcd: true,
-		castTime: 2.5,
 	},
 
 	ADLOQUIUM: {
@@ -68,7 +67,7 @@ export default {
 		name: 'Succor',
 		icon: 'https://xivapi.com/i/002000/002802.png',
 		onGcd: true,
-		castTime: 2.5,
+		castTime: 2,
 	},
 
 	SACRED_SOIL: {
@@ -90,7 +89,6 @@ export default {
 		name: 'Art of War',
 		icon: 'https://xivapi.com/i/002000/002819.png',
 		onGcd: true,
-		castTime: 2.5,
 	},
 
 	INDOMITABILITY: {
@@ -190,12 +188,16 @@ export default {
 		id: 17215,
 		name: 'Summon Eos',
 		icon: 'https://xivapi.com/i/002000/002823.png',
+		onGcd: true,
+		castTime: 2.5,
 	},
 
 	SUMMON_SELENE: {
 		id: 17216,
 		name: 'Summon Selene',
 		icon: 'https://xivapi.com/i/002000/002824.png',
+		onGcd: true,
+		castTime: 2.5,
 	},
 
 	// -----
@@ -213,7 +215,6 @@ export default {
 		id: 16544,
 		name: 'Fey Blessing',
 		icon: 'https://xivapi.com/i/002000/002855.png',
-		cooldown: 60,
 		pet: true,
 	},
 
@@ -228,7 +229,6 @@ export default {
 		id: 16547,
 		name: 'Consolation',
 		icon: 'https://xivapi.com/i/002000/002846.png',
-		cooldown: 20,
 		pet: true,
 	},
 


### PR DESCRIPTION
Update Scholar actions to match values listed in the 5.05 job guide.

 - Remove erroneous cast times from Biolysis and Art of War.
 - Update Succor's cast time to 2s to reflect 5.05 job changes.
 - Update fairy summon actions to be on the GCD with a 2.5s cast time.
 - Remove fairy action cooldowns.

Signed-off-by: Panic Stevenson <Panic.Stevenson@gmail.com>