### PR TITLE
Update Warrior Actions to Match 5.05 Job Guide

### DIFF
--- a/src/data/ACTIONS/MRD.js
+++ b/src/data/ACTIONS/MRD.js
@@ -7,7 +7,7 @@ export default {
 		id: 31,
 		name: 'Heavy Swing',
 		icon: 'https://xivapi.com/i/000000/000260.png',
-		potency: 160,
+		potency: 200,
 		onGcd: true,
 		combo: {
 			start: true,
@@ -40,7 +40,7 @@ export default {
 		potency: 100,
 		combo: {
 			from: 31,
-			potency: 200,
+			potency: 300,
 		},
 	},
 
@@ -52,7 +52,7 @@ export default {
 		potency: 100,
 		combo: {
 			from: 37,
-			potency: 280,
+			potency: 380,
 			end: true,
 		},
 	},
@@ -65,7 +65,7 @@ export default {
 		potency: 100,
 		combo: {
 			from: 37,
-			potency: 280,
+			potency: 380,
 			end: true,
 		},
 	},
@@ -78,7 +78,7 @@ export default {
 		id: 40,
 		name: 'Thrill of Battle',
 		icon: 'https://xivapi.com/i/000000/000263.png',
-		cooldown: 120,
+		cooldown: 90,
 		onGcd: false,
 	},
 
@@ -86,7 +86,7 @@ export default {
 		id: 43,
 		name: 'Holmgang',
 		icon: 'https://xivapi.com/i/000000/000266.png',
-		cooldown: 180,
+		cooldown: 240,
 		onGcd: false,
 	},
 

--- a/src/data/ACTIONS/WAR.js
+++ b/src/data/ACTIONS/WAR.js
@@ -8,6 +8,7 @@ export default {
 		name: 'Steel Cyclone',
 		icon: 'https://xivapi.com/i/002000/002552.png',
 		onGcd: true,
+		potency: 220,
 		breaksCombo: false,
 	},
 
@@ -16,6 +17,7 @@ export default {
 		name: 'Decimate',
 		icon: 'https://xivapi.com/i/002000/002558.png',
 		onGcd: true,
+		potency: 250,
 		breaksCombo: false,
 	},
 
@@ -36,6 +38,7 @@ export default {
 		name: 'Fell Cleave',
 		icon: 'https://xivapi.com/i/002000/002557.png',
 		onGcd: true,
+		potency: 590,
 		breaksCombo: false,
 	},
 
@@ -44,6 +47,7 @@ export default {
 		name: 'Inner Beast',
 		icon: 'https://xivapi.com/i/002000/002553.png',
 		onGcd: true,
+		potency: 350,
 		breaksCombo: false,
 	},
 
@@ -52,6 +56,7 @@ export default {
 		name: 'Inner Chaos',
 		icon: 'https://xivapi.com/i/002000/002568.png',
 		onGcd: true,
+		potency: 920,
 		breaksCombo: false,
 	},
 
@@ -60,6 +65,7 @@ export default {
 		name: 'Chaotic Cyclone',
 		icon: 'https://xivapi.com/i/002000/002566.png',
 		onGcd: true,
+		potency: 400,
 		breaksCombo: false,
 	},
 
@@ -71,7 +77,7 @@ export default {
 		id: 3551,
 		name: 'Raw Intuition',
 		icon: 'https://xivapi.com/i/002000/002559.png',
-		cooldown: 90,
+		cooldown: 25,
 		onGcd: false,
 	},
 
@@ -87,7 +93,8 @@ export default {
 		id: 7386,
 		name: 'Onslaught',
 		icon: 'https://xivapi.com/i/002000/002561.png',
-		cooldown: 15,
+		cooldown: 10,
+		potency: 100,
 		onGcd: false,
 	},
 
@@ -96,6 +103,7 @@ export default {
 		name: 'Upheaval',
 		icon: 'https://xivapi.com/i/002000/002562.png',
 		cooldown: 30,
+		potency: 450,
 		onGcd: false,
 	},
 
@@ -104,14 +112,6 @@ export default {
 		name: 'Equilibrium',
 		icon: 'https://xivapi.com/i/002000/002560.png',
 		cooldown: 60,
-		onGcd: false,
-	},
-
-	UNCHAINED: {
-		id: 50,
-		name: 'Unchained',
-		icon: 'https://xivapi.com/i/002000/002554.png',
-		cooldown: 90,
 		onGcd: false,
 	},
 

--- a/src/data/STATUSES/WAR.js
+++ b/src/data/STATUSES/WAR.js
@@ -34,14 +34,14 @@ export default {
 	},
 
 	SHAKE_IT_OFF: {
-		id: 7388,
+		id: 1457,
 		name: 'Shake It Off',
 		icon: 'https://xivapi.com/i/002000/002563.png',
 		duration: 15,
 	},
 
 	HOLMGANG: {
-		id: 43,
+		id: 409,
 		name: 'Holmgang',
 		icon: 'https://xivapi.com/i/000000/000266.png',
 		duration: 6,

--- a/src/data/STATUSES/WAR.js
+++ b/src/data/STATUSES/WAR.js
@@ -10,24 +10,21 @@ export default {
 		id: 87,
 		name: 'Thrill Of Battle',
 		icon: 'https://xivapi.com/i/010000/010254.png',
+		duration: 10,
 	},
 
 	RAW_INTUITION: {
 		id: 735,
 		name: 'Raw Intuition',
 		icon: 'https://xivapi.com/i/012000/012555.png',
+		duration: 5,
 	},
 
 	VENGEANCE: {
 		id: 89,
 		name: 'Vengeance',
 		icon: 'https://xivapi.com/i/010000/010256.png',
-	},
-
-	UNCHAINED: {
-		id: 92,
-		name: 'Unchained',
-		icon: 'https://xivapi.com/i/012000/012552.png',
+		duration: 10,
 	},
 
 	DEFIANCE: {
@@ -36,21 +33,38 @@ export default {
 		icon: 'https://xivapi.com/i/012000/012551.png',
 	},
 
+	SHAKE_IT_OFF: {
+		id: 7388,
+		name: 'Shake It Off',
+		icon: 'https://xivapi.com/i/002000/002563.png',
+		duration: 15,
+	},
+
+	HOLMGANG: {
+		id: 43,
+		name: 'Holmgang',
+		icon: 'https://xivapi.com/i/000000/000266.png',
+		duration: 6,
+	},
+
 	STORMS_EYE: {
 		id: 90,
 		name: 'Storm\'s Eye',
 		icon: 'https://xivapi.com/i/010000/010263.png',
+		duration: 30,
 	},
 
 	NASCENT_CHAOS: {
 		id: 1897,
 		name: 'Nascent Chaos',
 		icon: 'https://xivapi.com/i/012000/012560.png',
+		duration: 30,
 	},
 
 	NASCENT_FLASH: {
 		id: 1857,
 		name: 'Nascent Flash',
 		icon: 'https://xivapi.com/i/012000/012558.png',
+		duration: 6,
 	},
 }


### PR DESCRIPTION
Update Warrior actions to match values listed in the 5.05 job guide.

 - Remove Unchained.
 - Add Shake It Off and Holmgang to Warrior statuses.
 - Add and update Warrior status durations.
 - Add and update Warrior action potencies.
 - Update Marauder and Warrior action cooldowns.

Signed-off-by: Panic Stevenson <panic.stevenson@gmail.com>