### PR TITLE
WIP: Fix 6SS definition to use gcdRecast instead of cooldown

### DIFF
--- a/src/data/ACTIONS/MNK.js
+++ b/src/data/ACTIONS/MNK.js
@@ -44,7 +44,7 @@ export default {
 		name: 'Six-Sided Star',
 		icon: 'https://xivapi.com/i/002000/002547.png',
 		onGcd: true,
-		cooldown: 5,
+		gcdRecast: 5,
 	},
 
 	// -----


### PR DESCRIPTION
This is slightly different to how I thought it was, blame Square. I'll redo it correctly and push later.