### PR TITLE
Clone parent dependency array into child classes

### DIFF
--- a/src/parser/core/Module.ts
+++ b/src/parser/core/Module.ts
@@ -22,8 +22,8 @@ export function dependency(target: Module, prop: string) {
 	const constructor = target.constructor as typeof Module
 
 	// Make sure we're not modifying every single module
-	if (constructor.dependencies === Module.dependencies) {
-		constructor.dependencies = []
+	if (!constructor.hasOwnProperty('dependencies')) {
+		constructor.dependencies = [...constructor.dependencies]
 	}
 
 	// If the dep is Object, it's _probably_ from a JS file. Fall back to simple handling


### PR DESCRIPTION
Fixes issue with an "unknown node" error when navigating to a different report/class after viewing a report for a class that extended a core module to add a class specific dependency (e.g. DNC Combos, MNK Speedmod)