### PR TITLE
Update Final Fantasy XIV Expansion Title

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 	<a href="https://discord.gg/jVbVe44" title="Discord"><img src="https://img.shields.io/discord/441414116914233364.svg?style=flat-square&amp;logo=discord&amp;colorB=7289DA" alt="Discord"></a>
 </p>
 
-Automated performance analysis and suggestion platform for Final Fantasy XIV: Stormblood, using data sourced from [FF Logs](https://www.fflogs.com/).
+Automated performance analysis and suggestion platform for Final Fantasy XIV: Shadowbringers, using data sourced from [FF Logs](https://www.fflogs.com/).
 
 ## Table of Contents
 


### PR DESCRIPTION
Update the main README.md documentation to have the current Final Fantasy XIV expansion title.