### PR TITLE
Paladin/Gunbreaker buff downtime tracking

### DIFF
--- a/src/data/CONTRIBUTORS.ts
+++ b/src/data/CONTRIBUTORS.ts
@@ -141,6 +141,11 @@ const CONTRIBUTORS = {
 		avatar: require('./avatar/nono.png'),
 		jobs: [JOBS.SCHOLAR],
 	},
+	QAPHLA: {
+		name: 'qaphla',
+		jobs: [JOBS.PALADIN, JOBS.GUNBREAKER],
+	},
+
 }
 export default CONTRIBUTORS as Record<keyof typeof CONTRIBUTORS, Contributor>
 

--- a/src/parser/jobs/gnb/changelog.tsx
+++ b/src/parser/jobs/gnb/changelog.tsx
@@ -10,6 +10,13 @@ export const changelog = [
 		</>,
 		contributors: [CONTRIBUTORS.LHEA],
 	},
+	{
+		date: new Date('2019-08-20'),
+		Changes: () => <>
+			Added usage tracking for No Mercy and Bloodfest.
+		</>,
+		contributors: [CONTRIBUTORS.QAPHLA],
+	},
 	// {
 	// 	date: new Date('2020-04-20'),
 	// 	Changes: () => <>The changes you made</>,

--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -27,6 +27,7 @@ export default new Meta({
 
 	contributors: [
 		{user: CONTRIBUTORS.LHEA, role: ROLES.DEVELOPER},
+		{user: CONTRIBUTORS.QAPHLA, role: ROLES.DEVELOPER},
 	],
 
 	changelog,

--- a/src/parser/jobs/gnb/modules/OGCDDowntime.tsx
+++ b/src/parser/jobs/gnb/modules/OGCDDowntime.tsx
@@ -1,9 +1,21 @@
 import ACTIONS from 'data/ACTIONS'
 import CooldownDowntime from 'parser/core/modules/CooldownDowntime'
 
+/* This offset allows for four weaponskills to be used before No Mercy in the
+ * opener, as is currently recommended. Should be updated if openers change to
+ * have later No Mercy.
+ */
+const FIRST_USE_OFFSET_NO_MERCY = 10000
+
 export default class AbilityDowntime extends CooldownDowntime {
 	allowedDowntime = 2500
+
+	firstUseOffsetPerOgcd = {
+		[ACTIONS.NO_MERCY.id]: FIRST_USE_OFFSET_NO_MERCY,
+	}
+
 	trackedCds = [
+		ACTIONS.NO_MERCY.id,
 		ACTIONS.BLASTING_ZONE.id, // Only track this one for now, assume level 80
 		ACTIONS.ROUGH_DIVIDE.id,
 		ACTIONS.BOW_SHOCK.id,

--- a/src/parser/jobs/gnb/modules/OGCDDowntime.tsx
+++ b/src/parser/jobs/gnb/modules/OGCDDowntime.tsx
@@ -6,16 +6,22 @@ import CooldownDowntime from 'parser/core/modules/CooldownDowntime'
  * have later No Mercy.
  */
 const FIRST_USE_OFFSET_NO_MERCY = 10000
+/* This offset is large to account for the (mostly) single-weave opener, in
+ * which Bloodfest is used after nine weaponskills.
+ */
+const FIRST_USE_OFFSET_BLOODFEST = 22000
 
 export default class AbilityDowntime extends CooldownDowntime {
 	allowedDowntime = 2500
 
 	firstUseOffsetPerOgcd = {
 		[ACTIONS.NO_MERCY.id]: FIRST_USE_OFFSET_NO_MERCY,
+		[ACTIONS.BLOODFEST.id]: FIRST_USE_OFFSET_BLOODFEST,
 	}
 
 	trackedCds = [
 		ACTIONS.NO_MERCY.id,
+		ACTIONS.BLOODFEST.id,
 		ACTIONS.BLASTING_ZONE.id, // Only track this one for now, assume level 80
 		ACTIONS.ROUGH_DIVIDE.id,
 		ACTIONS.BOW_SHOCK.id,

--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -39,6 +39,7 @@ export default new Meta({
 	contributors: [
 		{user: CONTRIBUTORS.MIKEMATRIX, role: ROLES.MAINTAINER},
 		{user: CONTRIBUTORS.LHEA, role: ROLES.MAINTAINER},
+		{user: CONTRIBUTORS.QAPHLA, role: ROLES.DEVELOPER},
 	],
 
 	changelog: [
@@ -63,5 +64,13 @@ export default new Meta({
 			</>,
 			contributors: [CONTRIBUTORS.LHEA],
 		},
+		{
+			date: new Date('2019-08-20'),
+			Changes: () => <>
+				Added usage tracking for Fight or Flight and Requiescat.
+			</>,
+			contributors: [CONTRIBUTORS.QAPHLA],
+		},
+
 	],
 })

--- a/src/parser/jobs/pld/modules/OGCDDowntime.tsx
+++ b/src/parser/jobs/pld/modules/OGCDDowntime.tsx
@@ -1,9 +1,34 @@
 import ACTIONS from 'data/ACTIONS'
 import CooldownDowntime from 'parser/core/modules/CooldownDowntime'
 
+// Allowed downtime set to 4s to account for PLD's natural rotation drift.
+const ALLOWED_DOWNTIME_FOF = 4000
+const ALLOWED_DOWNTIME_REQ = 4000
+
+/* These first use offsets are large to allow for both Requiescat-first and
+ * Fight or Flight-first openers --- the former delays Fight or Flight to
+ * 23-24s, and the latter delays Requiescat to 30-31s, depending on whether
+ * or not a holy spirit was used on pull.
+ */
+const FIRST_USE_OFFSET_FOF = 24000
+const FIRST_USE_OFFSET_REQ = 31000
+
 export default class OGCDDowntime extends CooldownDowntime {
 	allowedDowntime = 2500
+
+	allowedDowntimePerOgcd = {
+		[ACTIONS.FIGHT_OR_FLIGHT.id]: ALLOWED_DOWNTIME_FOF,
+		[ACTIONS.REQUIESCAT.id]: ALLOWED_DOWNTIME_REQ,
+	}
+
+	firstUseOffsetPerOgcd = {
+		[ACTIONS.FIGHT_OR_FLIGHT.id]: FIRST_USE_OFFSET_FOF,
+		[ACTIONS.REQUIESCAT.id]: FIRST_USE_OFFSET_REQ,
+	}
+
 	trackedCds = [
+		ACTIONS.FIGHT_OR_FLIGHT.id,
+		ACTIONS.REQUIESCAT.id,
 		ACTIONS.SPIRITS_WITHIN.id,
 		ACTIONS.CIRCLE_OF_SCORN.id,
 		ACTIONS.INTERVENE.id,


### PR DESCRIPTION
This PR adds the PLD self-buffs Fight or Flight and Requiescat, the GNB self-buff No Mercy, and the GNB resource-generator Bloodfest to the list of oGCDs that xivanalysis tracks the downtime for.