### PR TITLE
Don't penalize for rushed Requiescat windows.

### DIFF
--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -71,6 +71,12 @@ export default new Meta({
 			</>,
 			contributors: [CONTRIBUTORS.QAPHLA],
 		},
-
+		{
+			date: new Date('2019-08-21'),
+			Changes: () => <>
+				Don't penalize for rushed Requiescat windows due to expected downtime or end-of-fight.
+			</>,
+			contributors: [CONTRIBUTORS.LHEA],
+		},
 	],
 })


### PR DESCRIPTION
Verified this with one of my own Titan logs: https://www.fflogs.com/reports/cJmALtK2zX1CZwjf#fight=13&type=damage-done

Live: https://xivanalysis.com/analyse/cJmALtK2zX1CZwjf/13/7/

This is important to start checking because the duration of the downtime in Titan means that it is potency-positive to slam that mf Requiescat button before he transitions from small to big. You only get a Confiteor out of it, but the next Req comes up on time anyways.

This should theoretically also work for Maelstrom in Leviathan, but the potency-positive solution there is a FoF window, not a Req window. I'll update that one later, since it'll require a rewrite of how FoF is analyzed.