### PR TITLE
Extend RotationTable to allow overriding the headerTitle

### DIFF
--- a/src/components/ui/RotationTable.tsx
+++ b/src/components/ui/RotationTable.tsx
@@ -98,6 +98,11 @@ interface RotationTableProps {
 	 * @param scrollTo
 	 */
 	onGoto?: (start: number, end: number, scrollTo?: boolean) => void
+	/**
+	 * Optional property to provide a JSX.Element (translation tag) for the header value.
+	 * Defaults to "Rotation"
+	 */
+	headerTitle?: JSX.Element
 }
 
 interface RotationTableRowProps {
@@ -192,6 +197,7 @@ export class RotationTable extends React.Component<RotationTableProps> {
 			notes,
 			data,
 			onGoto,
+			headerTitle,
 		} = this.props
 
 		return <Table compact unstackable celled>
@@ -208,7 +214,7 @@ export class RotationTable extends React.Component<RotationTableProps> {
 						)
 					}
 					<Table.HeaderCell>
-						<strong><Trans id="core.ui.rotation-table.header.rotation">Rotation</Trans></strong>
+						<strong>{(headerTitle)? headerTitle : <Trans id="core.ui.rotation-table.header.rotation">Rotation</Trans>}</strong>
 					</Table.HeaderCell>
 					{
 						(notes || []).map((note, i) =>

--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -102,6 +102,11 @@ export abstract class BuffWindowModule extends Module {
 	 *     (usually, this number should be 0), and will provide a suggestion if the BadCooldown is being used more than the expected threshold
 	 */
 	protected trackedBadActions?: BuffWindowTrackedActions
+	/**
+	 * Implementing modules MAY provide a value to override the "Rotation" title in the header of the rotation section
+	 * If implementing, you MUST provide a JSX.Element <Trans> or <Fragment> tag (Trans tag preferred)
+	 */
+	protected rotationTableHeader?: JSX.Element
 
 	@dependency private suggestions!: Suggestions
 	@dependency private timeline!: Timeline
@@ -378,6 +383,7 @@ export abstract class BuffWindowModule extends Module {
 			targets={rotationTargets}
 			data={rotationData}
 			onGoto={this.timeline.show}
+			headerTitle={this.rotationTableHeader}
 		/>
 	}
 }


### PR DESCRIPTION
Keeps the current default, but accepts an optional property to specify what the "Rotation" section title should be.  This PR also extends BuffWindowModule to expose override property for RotationTable header