### PR TITLE
Set baseline CT uptime to 90%.

### DIFF
--- a/src/parser/jobs/drg/modules/Debuffs.js
+++ b/src/parser/jobs/drg/modules/Debuffs.js
@@ -27,6 +27,7 @@ export default class Debuffs extends DoTs {
 				<ActionLink {...ACTIONS.CHAOS_THRUST}/> provides a potent DoT which should be maintained at all times.
 			</Trans>,
 			displayOrder: DISPLAY_ORDER.DEBUFFS,
+			target: 90,
 			requirements: [
 				new Requirement({
 					name: <Trans id="drg.debuffs.checklist.requirement.chaos-thrust.name"><ActionLink {...ACTIONS.CHAOS_THRUST}/> uptime</Trans>,


### PR DESCRIPTION
Chaos Thrust's DoT is 24s duration, so it's impossible to keep it up 100% of the time. It actually drops a lot naturally as the rotation lines up.

90% is what we use for Goring Blade on PLD, so I figure this is a good enough baseline to catch most cases.