### PR TITLE
Fix normalisation constant for sub-gcd casts

### DIFF
--- a/src/parser/core/modules/GlobalCooldown.js
+++ b/src/parser/core/modules/GlobalCooldown.js
@@ -180,7 +180,7 @@ export default class GlobalCooldown extends Module {
 			? action.gcdRecast
 			: action.cooldown
 
-		const normaliseWith = gcdInfo.isInstant
+		const normaliseWith = gcdInfo.isInstant || castTime < correctedCooldown
 			? correctedCooldown
 			: castTime
 


### PR DESCRIPTION
Time between GCD starts is used for estimation, so excluding instant casts we need the larger of gcd recast and cast time to normalise with.
Currently sub-gcd casts are overestimated by a factor of 2.5/cast time