### PR TITLE
[Fix]: Move core Entities and AOE to calculateddamage events for compatibility

### DIFF
--- a/src/parser/core/modules/AoE.js
+++ b/src/parser/core/modules/AoE.js
@@ -10,8 +10,8 @@ const DEFAULT_AOE_THRESHOLD = 20
 const STATUS_AOE_THRESHOLD = 200
 
 const SUPPORTED_EVENTS = [
-	'damage',
-	'heal',
+	'calculateddamage',
+	'calculatedheal',
 	'refreshbuff',
 	'applybuff',
 ]
@@ -170,7 +170,7 @@ export default class AoE extends Module {
 			}, {})
 
 			const fabricatedEvent = {
-				type: 'aoe' + eventType,
+				type: 'aoe' + eventType.replace('calculated', ''),
 				timestamp: event.events[eventType][0].timestamp,
 				ability: event.events[eventType][0].ability,
 				hits: Object.values(hitsByTarget),

--- a/src/parser/core/modules/Entities.js
+++ b/src/parser/core/modules/Entities.js
@@ -115,8 +115,8 @@ export default class Entities extends Module {
 		this.addHook('removedebuff', event => this.removeBuff(event, true))
 
 		// Resources
-		this.addHook('damage', this.updateResources)
-		this.addHook('heal', this.updateResources)
+		this.addHook('calculateddamage', this.updateResources)
+		this.addHook('calculatedheal', this.updateResources)
 	}
 
 	// -----

--- a/src/parser/core/modules/HitType.js
+++ b/src/parser/core/modules/HitType.js
@@ -4,6 +4,8 @@ import {HitType as EventHitType} from 'fflogs'
 const ACTION_EVENT_TYPES = [
 	'damage',
 	'heal',
+	'calculateddamage',
+	'calculatedheal',
 ]
 
 const FAILED_HITS = [


### PR DESCRIPTION
This fixes:
- SAM events showing broken combo for the last GCD used under Meikyo Shisui: https://xivanalysis.com/analyse/1W3bkrcGFBtNKvHn/1/8/
After:
![image](https://user-images.githubusercontent.com/26804378/64462059-2a6a6680-d0cd-11e9-8ceb-52919edb57f5.png)

- DRG (and probably other classes) showing incorrectly broken combos when overkilling the target: https://xivanalysis.com/analyse/zVd9Zt4ynKXa7jYQ/1/1/
After:
![image](https://user-images.githubusercontent.com/26804378/64462093-4c63e900-d0cd-11e9-8295-20316507ac93.png)

- DRK MP graph not showing correct MP values: https://xivanalysis.com/analyse/AG1wtcnXWLVKZmkv/2/6/
After: 
![image](https://user-images.githubusercontent.com/26804378/64462181-9ea50a00-d0cd-11e9-8171-2e89d303b6d3.png)
