### PR TITLE
Backwards compatibility for FFLogs calculated events change

### DIFF
--- a/src/parser/core/modules/AoE.js
+++ b/src/parser/core/modules/AoE.js
@@ -10,10 +10,6 @@ const DEFAULT_AOE_THRESHOLD = 20
 const STATUS_AOE_THRESHOLD = 200
 
 const SUPPORTED_EVENTS = [
-	'calculateddamage',
-	'calculatedheal',
-	'damage',
-	'heal',
 	'refreshbuff',
 	'applybuff',
 ]
@@ -25,6 +21,7 @@ export default class AoE extends Module {
 		'precastAction', // eslint-disable-line @xivanalysis/no-unused-dependencies
 		'precastStatus', // eslint-disable-line @xivanalysis/no-unused-dependencies
 		'enemies',
+		'fflogsEvents',
 	]
 
 	_calculatedEventsExist = false;
@@ -37,6 +34,9 @@ export default class AoE extends Module {
 
 	// Need to normalise so the final events can go out at the right time
 	normalise(events) {
+		// Determine which name to use for damage and heal events (calculated vs normal)
+		SUPPORTED_EVENTS.push(this.fflogsEvents.damageEventName, this.fflogsEvents.healEventName)
+
 		// Track hits by source
 		const trackers = {}
 		function getTracker(event) {
@@ -78,14 +78,6 @@ export default class AoE extends Module {
 			const event = events[i]
 
 			if (!SUPPORTED_EVENTS.includes(event.type)) {
-				continue
-			}
-
-			if (event.type.includes('calculated')) {
-				this._calculatedEventsExist = true
-			}
-
-			if (this._calculatedEventsExist && (event.type === 'damage' || event.type ==='heal')) {
 				continue
 			}
 

--- a/src/parser/core/modules/AoE.js
+++ b/src/parser/core/modules/AoE.js
@@ -24,8 +24,6 @@ export default class AoE extends Module {
 		'fflogsEvents',
 	]
 
-	_calculatedEventsExist = false;
-
 	constructor(...args) {
 		super(...args)
 		// Listen to our own event from normalisation

--- a/src/parser/core/modules/AoE.js
+++ b/src/parser/core/modules/AoE.js
@@ -12,6 +12,8 @@ const STATUS_AOE_THRESHOLD = 200
 const SUPPORTED_EVENTS = [
 	'calculateddamage',
 	'calculatedheal',
+	'damage',
+	'heal',
 	'refreshbuff',
 	'applybuff',
 ]
@@ -24,6 +26,8 @@ export default class AoE extends Module {
 		'precastStatus', // eslint-disable-line @xivanalysis/no-unused-dependencies
 		'enemies',
 	]
+
+	_calculatedEventsExist = false;
 
 	constructor(...args) {
 		super(...args)
@@ -74,6 +78,14 @@ export default class AoE extends Module {
 			const event = events[i]
 
 			if (!SUPPORTED_EVENTS.includes(event.type)) {
+				continue
+			}
+
+			if (event.type.includes('calculated')) {
+				this._calculatedEventsExist = true
+			}
+
+			if (this._calculatedEventsExist && (event.type === 'damage' || event.type ==='heal')) {
 				continue
 			}
 

--- a/src/parser/core/modules/Entities.js
+++ b/src/parser/core/modules/Entities.js
@@ -115,9 +115,11 @@ export default class Entities extends Module {
 		this.addHook('removebuff', this.removeBuff)
 		this.addHook('removedebuff', event => this.removeBuff(event, true))
 
-		// Resources
-		this.addHook(this.fflogsEvents.damageEventName, this.updateResources)
-		this.addHook(this.fflogsEvents.healEventName, this.updateResources)
+		// Resources - hooked to init to make sure normaliser runs to determine damage event before hooking events
+		this.addHook('init', () => {
+			this.addHook(this.fflogsEvents.damageEventName, this.updateResources)
+			this.addHook(this.fflogsEvents.healEventName, this.updateResources)
+		})
 	}
 
 	// -----

--- a/src/parser/core/modules/Entities.js
+++ b/src/parser/core/modules/Entities.js
@@ -117,6 +117,8 @@ export default class Entities extends Module {
 		// Resources
 		this.addHook('calculateddamage', this.updateResources)
 		this.addHook('calculatedheal', this.updateResources)
+		this._damageListener = this.addHook('damage', this.updateResources)
+		this._healListener = this.addHook('heal', this.updateResources)
 	}
 
 	// -----
@@ -229,6 +231,10 @@ export default class Entities extends Module {
 	}
 
 	updateResources(event) {
+		if (event.type.includes('calculated')) {
+			this.removeHook(this._damageListener)
+			this.removeHook(this._healListener)
+		}
 		// Try to update both source and target
 		const source = this.getEntity(event.sourceID)
 		if (source && event.sourceResources) {

--- a/src/parser/core/modules/Entities.js
+++ b/src/parser/core/modules/Entities.js
@@ -6,6 +6,7 @@ const REMOVE = 'remove'
 export default class Entities extends Module {
 	static dependencies = [
 		'invuln',
+		'fflogsEvents',
 	]
 
 	// -----
@@ -115,10 +116,8 @@ export default class Entities extends Module {
 		this.addHook('removedebuff', event => this.removeBuff(event, true))
 
 		// Resources
-		this.addHook('calculateddamage', this.updateResources)
-		this.addHook('calculatedheal', this.updateResources)
-		this._damageListener = this.addHook('damage', this.updateResources)
-		this._healListener = this.addHook('heal', this.updateResources)
+		this.addHook(this.fflogsEvents.damageEventName, this.updateResources)
+		this.addHook(this.fflogsEvents.healEventName, this.updateResources)
 	}
 
 	// -----
@@ -231,10 +230,6 @@ export default class Entities extends Module {
 	}
 
 	updateResources(event) {
-		if (event.type.includes('calculated')) {
-			this.removeHook(this._damageListener)
-			this.removeHook(this._healListener)
-		}
 		// Try to update both source and target
 		const source = this.getEntity(event.sourceID)
 		if (source && event.sourceResources) {

--- a/src/parser/core/modules/FFLogsEventNormaliser.ts
+++ b/src/parser/core/modules/FFLogsEventNormaliser.ts
@@ -1,0 +1,47 @@
+import {Event} from 'fflogs'
+import Module from 'parser/core/Module'
+
+const CALCULATED_EVENTS: Array<Event['type']> = [
+	'calculateddamage',
+	'calculatedheal',
+]
+
+const BASELINE_EVENTS: Array<Event['type']> = [
+	'damage',
+	'heal',
+]
+
+export class FFLogsEventNormaliser extends Module {
+	static handle: string = 'fflogsEvents'
+
+	private _hasCalculatedEvents: boolean = false
+
+	get hasCalculatedEvents() {
+		return this._hasCalculatedEvents
+	}
+
+	get damageEventName() {
+		return (this._hasCalculatedEvents ? 'calculateddamage': 'damage')
+	}
+
+	get healEventName() {
+		return (this._hasCalculatedEvents ? 'heal': 'heal')
+	}
+
+	normalise(events: Event[]): Event[] {
+		for (const event of events) {
+			// Check to see if this is a calculated damage/heal event and set the _hasCalculated events flag if it is
+			// Once we've seen one, return
+			if (CALCULATED_EVENTS.includes(event.type)) {
+				this._hasCalculatedEvents = true
+				return events
+			}
+			// If we see a standard damage/heal event before a calculated event, the log doesn't have any calculated events, return early
+			if (BASELINE_EVENTS.includes(event.type)) {
+				return events
+			}
+		}
+
+		return events
+	}
+}

--- a/src/parser/core/modules/FFLogsEventNormaliser.ts
+++ b/src/parser/core/modules/FFLogsEventNormaliser.ts
@@ -25,7 +25,7 @@ export class FFLogsEventNormaliser extends Module {
 	}
 
 	get healEventName() {
-		return (this._hasCalculatedEvents ? 'heal': 'heal')
+		return (this._hasCalculatedEvents ? 'calculatedheal': 'heal')
 	}
 
 	normalise(events: Event[]): Event[] {

--- a/src/parser/core/modules/index.js
+++ b/src/parser/core/modules/index.js
@@ -12,6 +12,7 @@ import Cooldowns from './Cooldowns'
 import Death from './Death'
 import Downtime from './Downtime'
 import Enemies from './Enemies'
+import {FFLogsEventNormaliser} from './FFLogsEventNormaliser'
 import GlobalCooldown from './GlobalCooldown'
 import HitType from './HitType'
 import Invulnerability from './Invulnerability'
@@ -40,6 +41,7 @@ export default [
 	Death,
 	Downtime,
 	Enemies,
+	FFLogsEventNormaliser,
 	GlobalCooldown,
 	HitType,
 	Invulnerability,


### PR DESCRIPTION
Hook both calculated damage/heal events and "base" damage/heal events.  If we see a calculated event (which occurs at same timestamp as corresponding cast event and will always be before the damage/heal event), stop listening for base events, since this is a new log.