### PR TITLE
Capture broken log triggers on sentry

### DIFF
--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -268,7 +268,7 @@ class Parser {
 				Sentry.withScope(scope => {
 					scope.setTags(tags)
 					scope.setExtras(extra)
-					Sentry.captureException(extra)
+					Sentry.captureException(error)
 				})
 
 				// Also cascade the error through the dependency tree


### PR DESCRIPTION
As per request. Keep ya fingers on the revert buzzer for this one, I've got no insight on how often these fire, and we might flood sentry.