### PR TITLE
Fixed a check that could error if no OGCDs had been used before Ruin4

### DIFF
--- a/src/parser/jobs/smn/modules/Ruin2.js
+++ b/src/parser/jobs/smn/modules/Ruin2.js
@@ -151,6 +151,6 @@ export default class Ruin2 extends Module {
 	}
 
 	isNotEndOfFightRuin4(cast) {
-		return cast.ability.guid === ACTIONS.SMN_RUIN_II.id || cast.timestamp < this._lastOgcd.timestamp
+		return cast.ability.guid === ACTIONS.SMN_RUIN_II.id || (this._lastOgcd !== null && cast.timestamp < this._lastOgcd.timestamp)
 	}
 }


### PR DESCRIPTION
Addresses the sentry for https://xivanalysis.com/analyse/6XzmWcFPZfGqYCtw/9/1/