### PR TITLE
fix: Use cast time when tracking shadowbite dmg

### DIFF
--- a/src/parser/jobs/brd/modules/Sidewinder.js
+++ b/src/parser/jobs/brd/modules/Sidewinder.js
@@ -46,6 +46,7 @@ export default class Sidewinder extends Module {
 	_singleTargetShadowbitesPotencyLoss = 0
 
 	_badCasts = []
+	_lastShadowbiteCast = 0
 	_shadowbiteDamageTimestamps = new Map()
 
 	constructor(...args) {
@@ -55,6 +56,11 @@ export default class Sidewinder extends Module {
 			by: 'player',
 			abilityId: ACTIONS.SIDEWINDER.id,
 		}, this._onSidewinderCast)
+
+		this.addHook('cast', {
+			by: 'player',
+			abilityId: ACTIONS.SHADOWBITE.id,
+		}, this._onShadowbiteCast)
 
 		this.addHook('damage', {
 			by: 'player',
@@ -76,6 +82,10 @@ export default class Sidewinder extends Module {
 		return dotsApplied
 	}
 
+	_onShadowbiteCast(event) {
+		this._lastShadowbiteCast = event.timestamp
+	}
+
 	//For some reason, shadowbite's cast target doesn't work properly in dungeon trash pulls so we gotta do it the hard way
 	_onShadowbiteDamage(event) {
 		const potencyDamageRatio = this.additionalStats.potencyDamageRatio
@@ -88,7 +98,7 @@ export default class Sidewinder extends Module {
 		// We then infer the amount of stacks
 		const dotsApplied = ACTIONS.SHADOWBITE.potency.indexOf(potency)
 
-		const timestamp = event.timestamp
+		const timestamp = this._lastShadowbiteCast
 		const shadowbiteTimestampArray = this._shadowbiteDamageTimestamps.get(timestamp)
 
 		const shadowbiteDamageEvent = {


### PR DESCRIPTION
Fixing issue with Shadowbite hit detection. Was using the dmg timestamp which is going to be little different for each enemy hit. 

Fix I implemented was just use the last cast timestamp instead of the dmg event timestamp. I tried to write a test but ended up with quite a bit of set up for the events.

Example of log with issue
https://xivanalysis.com/analyse/BdkGL9728rXnWFgN/1/13/