### PR TITLE
Marked SMN as supported.

### DIFF
--- a/src/parser/jobs/smn/index.js
+++ b/src/parser/jobs/smn/index.js
@@ -29,10 +29,10 @@ export default new Meta({
 			</Message.Content>
 		</Message>
 	</>,
-	// supportedPatches: {
-	// 	from: '5.0',
-	// 	to: '5.05',
-	// },
+	supportedPatches: {
+		from: '5.0',
+		to: '5.08',
+	},
 	contributors: [
 		{user: CONTRIBUTORS.ACKWELL, role: ROLES.MAINTAINER},
 		{user: CONTRIBUTORS.NEMEKH, role: ROLES.THEORYCRAFT},


### PR DESCRIPTION
No known remaining inaccuracies/misinformation, so marking supported.