### PR TITLE
Add rudimentary handling for malformed event responses

### DIFF
--- a/src/fflogs.ts
+++ b/src/fflogs.ts
@@ -275,7 +275,14 @@ export interface ReportEventsQuery {
 	translate?: boolean,
 }
 
-export interface ReportEventsResponse {
+interface CorrectReportEventsResponse {
 	events: Event[]
 	nextPageTimestamp?: number
 }
+
+// Yes, really.
+type MalformedReportEventsResponse = ''
+
+export type ReportEventsResponse =
+	| CorrectReportEventsResponse
+	| MalformedReportEventsResponse


### PR DESCRIPTION
Title. Wasn't going to handle this, but it's been happening more often than I can afford to ignore.

Basically just bypassing the cache on the second try to make sure we've not cached the blank trash, falling back on a better error message.