### PR TITLE
Throw error if accessing normalised data before normalisation

### DIFF
--- a/src/parser/core/modules/FFLogsEventNormaliser.ts
+++ b/src/parser/core/modules/FFLogsEventNormaliser.ts
@@ -14,21 +14,26 @@ const BASELINE_EVENTS: Array<Event['type']> = [
 export class FFLogsEventNormaliser extends Module {
 	static handle: string = 'fflogsEvents'
 
-	private _hasCalculatedEvents: boolean = false
+	private _hasCalculatedEvents?: boolean
 
 	get hasCalculatedEvents() {
+		if (this._hasCalculatedEvents == null) {
+			throw new Error('Attempted to check presence of calculated events before normaliser execution.')
+		}
 		return this._hasCalculatedEvents
 	}
 
 	get damageEventName() {
-		return (this._hasCalculatedEvents ? 'calculateddamage': 'damage')
+		return (this.hasCalculatedEvents ? 'calculateddamage': 'damage')
 	}
 
 	get healEventName() {
-		return (this._hasCalculatedEvents ? 'calculatedheal': 'heal')
+		return (this.hasCalculatedEvents ? 'calculatedheal': 'heal')
 	}
 
 	normalise(events: Event[]): Event[] {
+		this._hasCalculatedEvents = false
+
 		for (const event of events) {
 			// Check to see if this is a calculated damage/heal event and set the _hasCalculated events flag if it is
 			// Once we've seen one, return


### PR DESCRIPTION
Title, as per braindump last night. I checked existing usages - with the steppies change, this shouldn't hit any _existing_ code. Hopefully it makes the issue waaaaayyyy more obvious to other devs.