### PR TITLE
BLM - Cycle optimization & downtime enhancements

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -80,7 +80,7 @@
   "blm.about.description": "This analyser aims to identify how you're not actually casting [~action/FIRE_IV] as much as you think you are.",
   "blm.about.description.warning": "This isn't even remotely done.",
   "blm.gauge.suggestions.dropped-enochian.content": "Dropping <0/> may lead to lost <1/> or <2/> casts, more clipping because of additional <3/> casts, unavailability of <4/> and <5/> or straight up missing out on the 15% damage bonus that <6/> provides.",
-  "blm.gauge.suggestions.dropped-enochian.why": "{0} dropped Enochian {1, plural, one {buff} other {buffs}}.",
+  "blm.gauge.suggestions.dropped-enochian.why": "{droppedEno} dropped Enochian {droppedEno, plural, one {buff} other {buffs}}.",
   "blm.gauge.suggestions.lost-polyglot.content": "You lost Polyglot due to dropped <0/>. <1/> and <2/> are your strongest GCDs, so always maximize their casts.",
   "blm.gauge.suggestions.lost-polyglot.why": "{0, plural, one {# Polyglot stack was} other {# Polyglot stacks were}} lost.",
   "blm.gauge.suggestions.overwritten-polyglot.content": "You overwrote Polyglot due to not casting <0/> or <1/> for 30s after gaining a second stack. <2/> and <3/> are your strongest GCDs, so always maximize their casts.",

--- a/src/parser/jobs/blm/index.js
+++ b/src/parser/jobs/blm/index.js
@@ -61,5 +61,10 @@ export default new Meta({
 		date: new Date('2019-09-23'),
 		Changes: () => <>Improved gauge state error handling.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2019-10-22'),
+		Changes: () => <>Enochian buffs lost during extended cutscenes, and certain Astral Fire phase optimizations, will no longer be unintentionally penalized.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
 	}],
 })

--- a/src/parser/jobs/blm/modules/Gauge.js
+++ b/src/parser/jobs/blm/modules/Gauge.js
@@ -31,6 +31,7 @@ export default class Gauge extends Module {
 		'precastAction', // eslint-disable-line @xivanalysis/no-unused-dependencies
 		'suggestions',
 		'brokenLog',
+		'unableToAct',
 	]
 
 	_astralFireStacks = 0
@@ -47,7 +48,7 @@ export default class Gauge extends Module {
 	//_hasPolyglot = false
 	_polyglotStacks = 0
 
-	_droppedEno = 0
+	_droppedEnoTimestamps = []
 	_lostPolyglot = 0
 	_overwrittenPolyglot = 0
 
@@ -147,7 +148,7 @@ export default class Gauge extends Module {
 			const enoRunTime = event.timestamp - this._enochianTimer
 			//add the time remaining on the eno timer to total downtime
 			this._enochianDownTimer.time += enoRunTime
-			this._droppedEno++
+			this._droppedEnoTimestamps.push(event.timestamp)
 		}
 		this._hasEnochian = false
 		this._enochianTimer = 0
@@ -255,8 +256,10 @@ export default class Gauge extends Module {
 		this._enochianDownTimer.stop = 0
 	}
 
+	// Refund unable-to-act time if the downtime window was longer than the AF/UI timer
 	_countLostPolyglots(time) {
-		return Math.floor(time/ENOCHIAN_DURATION_REQUIRED)
+		const unableToActTime = this.unableToAct.getDowntimes().filter(downtime => Math.max(0, downtime.end - downtime.start) >= ASTRAL_UMBRAL_DURATION).reduce((duration, downtime) => duration + Math.max(0, downtime.end - downtime.start), 0)
+		return Math.floor((time - unableToActTime)/ENOCHIAN_DURATION_REQUIRED)
 	}
 
 	_onCast(event) {
@@ -356,8 +359,9 @@ export default class Gauge extends Module {
 		}
 		this._lostPolyglot = this._countLostPolyglots(this._enochianDownTimer.time)
 
-		// Suggestions for lost eno
-		if (this._droppedEno) {
+		// Find out how many of the enochian drops ocurred during times where the player could not act for longer than the AF/UI buff timer. If they could act, they could've kept it going, so warn about those.
+		const droppedEno = this._droppedEnoTimestamps.filter(drop => this.unableToAct.getDowntimes(drop, drop).filter(downtime => Math.max(0, downtime.end - downtime.start) >= ASTRAL_UMBRAL_DURATION).length === 0).length
+		if (droppedEno) {
 			this.suggestions.add(new Suggestion({
 				icon: ACTIONS.ENOCHIAN.icon,
 				content: <Trans id="blm.gauge.suggestions.dropped-enochian.content">
@@ -365,7 +369,7 @@ export default class Gauge extends Module {
 				</Trans>,
 				severity: SEVERITY.MEDIUM,
 				why: <Trans id="blm.gauge.suggestions.dropped-enochian.why">
-					{this._droppedEno} dropped Enochian <Plural value={this._droppedEno} one="buff" other="buffs"/>.
+					{droppedEno} dropped Enochian <Plural value={droppedEno} one="buff" other="buffs"/>.
 				</Trans>,
 			}))
 		}

--- a/src/parser/jobs/blm/modules/RotationWatchdog.tsx
+++ b/src/parser/jobs/blm/modules/RotationWatchdog.tsx
@@ -17,6 +17,7 @@ import Enemies from 'parser/core/modules/Enemies'
 import Invulnerability from 'parser/core/modules/Invulnerability'
 import Suggestions, {SEVERITY, Suggestion, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import Timeline from 'parser/core/modules/Timeline'
+import UnableToAct from 'parser/core/modules/UnableToAct'
 
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 import {FIRE_SPELLS} from './Elements'
@@ -30,6 +31,7 @@ const FIRE4_FROM_MANAFONT = 1
 
 const MIN_MP_FOR_FULL_ROTATION = 9600
 const THUNDERCLOUD_MILLIS = 18000
+const ASTRAL_UMBRAL_DURATION = 15000
 
 const AF_UI_BUFF_MAX_STACK = 3
 
@@ -107,8 +109,9 @@ class Cycle {
 			return
 		}
 
-		// Account for the no-UH opener when determining the expected count of Fire 4s
-		let expectedCount = this.gaugeStateBeforeFire.umbralHearts === 0 ? NO_UH_EXPECTED_FIRE4 : EXPECTED_FIRE4
+		// Account for the no-UH opener/LeyLines optimization when determining the expected count of Fire 4s
+		let expectedCount = (this.gaugeStateBeforeFire.umbralHearts === 0 && this.casts.filter(cast => cast.ability.guid === ACTIONS.FIRE_I.id).length === 0)
+			? NO_UH_EXPECTED_FIRE4 : EXPECTED_FIRE4
 
 		// Adjust expected count if the cycle included manafont
 		expectedCount += this.hasManafont ? FIRE4_FROM_MANAFONT : 0
@@ -137,6 +140,10 @@ class Cycle {
 		this.startTime = start,
 		// Object.assign because this needs to be a by-value assignment, not by-reference
 		this.gaugeStateBeforeFire = Object.assign(this.gaugeStateBeforeFire, gaugeState)
+	}
+
+	public overrideErrorCode(code: {priority: number, message: TODO}) {
+		this._errorCode = code
 	}
 }
 
@@ -173,6 +180,7 @@ export default class RotationWatchdog extends Module {
 	@dependency private enemies!: Enemies
 	@dependency private timeline!: Timeline
 	@dependency private combatants!: Combatants
+	@dependency private unableToAct!: UnableToAct
 
 	private currentGaugeState: GaugeState = new GaugeState()
 	private currentRotation: Cycle = new Cycle(this.parser.fight.start_time, this.currentGaugeState)
@@ -286,6 +294,15 @@ export default class RotationWatchdog extends Module {
 	// Finish this parse and add the suggestions and checklist items
 	private onComplete() {
 		this.stopRecording(undefined)
+
+		// Override the error code for cycles that dropped enochian, when the cycle contained an unabletoact time long enough to kill it.
+		// Couldn't do this at the time of code assignment, since the downtime data wasn't fully available yet
+		this.history.filter(cycle => cycle.errorCode === CYCLE_ERRORS.DROPPED_ENOCHIAN).forEach(cycle => {
+			if (this.unableToAct.getDowntimes(cycle.startTime, cycle.endTime).filter(downtime => Math.max(0, downtime.end - downtime.start) >= ASTRAL_UMBRAL_DURATION).length > 0) {
+				cycle.overrideErrorCode(CYCLE_ERRORS.FINAL_OR_DOWNTIME)
+			}
+		})
+
 		// Suggestion for skipping B4 on rotations that are cut short by the end of the parse or downtime
 		if (this.missedF4s) {
 			this.suggestions.add(new Suggestion({


### PR DESCRIPTION
- Allow the Astral Fire cycle optimization where, with enough speed (Triple and/or Leylines generally required), the player can skip Blizzard 4 and Fire 1, and just do 5 Fire 4s and a Despair as their Astral Fire phase
- Stop dinging Enochian drops where it occurred during an UnableToAct window longer than the duration of the Astral Fire/Umbral Ice buff. I'm looking at you E1S.