### PR TITLE
Make time linear again

### DIFF
--- a/src/parser/core/Dispatcher.test.ts
+++ b/src/parser/core/Dispatcher.test.ts
@@ -1,0 +1,169 @@
+import {Event} from 'fflogs'
+import {Dispatcher, EventHook, TimestampHook} from './Dispatcher'
+
+/* tslint:disable:no-magic-numbers */
+
+const event: Event = {
+	timestamp: 50,
+	type: '__test',
+	sourceIsFriendly: false,
+	targetIsFriendly: false,
+
+	targetID: 0xDEADBEEF,
+}
+
+describe('Dispatcher', () => {
+	let dispatcher: Dispatcher
+	let callback: jest.Mock
+	let eventHook: EventHook<Event>
+	let timestampHook: TimestampHook
+
+	beforeEach(() => {
+		dispatcher = new Dispatcher()
+		callback = jest.fn()
+		eventHook = {
+			event: event.type,
+			module: 'test',
+			callback,
+		}
+		timestampHook = {
+			timestamp: 0,
+			module: 'test',
+			callback,
+		}
+	})
+
+	it('can hook an event', () => {
+		dispatcher.addEventHook(eventHook)
+
+		dispatcher.dispatch(event, ['test'])
+
+		expect(callback).toHaveBeenCalledTimes(1)
+		expect(callback).toHaveBeenCalledWith(event)
+	})
+
+	it('does not trigger non-matching hooks', () => {
+		dispatcher.addEventHook({...eventHook, event: '__unused'})
+
+		dispatcher.dispatch(event, ['test'])
+
+		expect(callback).not.toHaveBeenCalled()
+	})
+
+	it('can filter by event keys', () => {
+		dispatcher.addEventHook(eventHook)
+		dispatcher.addEventHook({...eventHook, filter: {targetID: event.targetID}})
+		dispatcher.addEventHook({...eventHook, filter: {targetID: 0xF00}})
+
+		dispatcher.dispatch(event, ['test'])
+
+		expect(callback).toHaveBeenCalledTimes(2)
+	})
+
+	it('reports the event timestamp during event callback execution', () => {
+		let timestamp: number | undefined
+
+		dispatcher.addEventHook({
+			...eventHook,
+			callback: () => timestamp = dispatcher.timestamp,
+		})
+		dispatcher.dispatch(event, ['test'])
+
+		expect(timestamp).toBe(event.timestamp)
+	})
+
+	it('can remove event hooks', () => {
+		dispatcher.addEventHook(eventHook)
+		dispatcher.dispatch(event, ['test'])
+		dispatcher.removeEventHook(eventHook)
+		dispatcher.dispatch(event, ['test'])
+
+		expect(callback).toHaveBeenCalledTimes(1)
+	})
+
+	it('reports errors from event hooks', () => {
+		const error = new Error('test error')
+		dispatcher.addEventHook({
+			...eventHook,
+			callback: () => { throw error },
+		})
+
+		const errors = dispatcher.dispatch(event, ['test'])
+
+		expect(errors).toMatchObject({test: error})
+	})
+
+	it('does not trigger event hooks from unspecified modules', () => {
+		dispatcher.addEventHook(eventHook)
+		dispatcher.dispatch(event, [])
+		expect(callback).not.toHaveBeenCalled()
+	})
+
+	it('can hook a timestamp', () => {
+		dispatcher.addTimestampHook({...timestampHook, timestamp: 50})
+
+		dispatcher.dispatch({...event, timestamp: 1}, ['test'])
+		expect(callback).not.toHaveBeenCalled()
+
+		dispatcher.dispatch({...event, timestamp: 100}, ['test'])
+		expect(callback).toHaveBeenCalledTimes(1)
+	})
+
+	it('will catch up on multiple timestamp hooks in a single event', () => {
+		dispatcher.addTimestampHook({...timestampHook, timestamp: 40})
+		dispatcher.addTimestampHook({...timestampHook, timestamp: 50})
+		dispatcher.addTimestampHook({...timestampHook, timestamp: 60})
+
+		dispatcher.dispatch({...event, timestamp: 100}, ['test'])
+
+		expect(callback).toHaveBeenCalledTimes(3)
+		expect(callback).toHaveBeenNthCalledWith(3, {timestamp: 60})
+	})
+
+	it('does not trigger hooks added to the past', () => {
+		dispatcher.dispatch({...event, timestamp: 100}, ['test'])
+		dispatcher.addTimestampHook({...timestampHook, timestamp: 50})
+		dispatcher.dispatch({...event, timestamp: 200}, ['test'])
+
+		expect(callback).not.toHaveBeenCalled()
+	})
+
+	it('reports the correct timestamp during timestamp hook callback execution', () => {
+		let timestamp: number | undefined
+
+		dispatcher.addTimestampHook({
+			...timestampHook,
+			callback: () => timestamp = dispatcher.timestamp,
+		})
+		dispatcher.dispatch(event, ['test'])
+
+		expect(timestamp).toBe(timestampHook.timestamp)
+	})
+
+	it('can remove timestamp hooks', () => {
+		dispatcher.addTimestampHook(timestampHook)
+		dispatcher.removeTimestampHook(timestampHook)
+
+		dispatcher.dispatch({...event, timestamp: 100}, ['test'])
+
+		expect(callback).not.toHaveBeenCalled()
+	})
+
+	it('reports errors from timestamp hooks', () => {
+		const error = new Error('test error')
+		dispatcher.addTimestampHook({
+			...timestampHook,
+			callback: () => { throw error},
+		})
+
+		const errors = dispatcher.dispatch(event, ['test'])
+
+		expect(errors).toMatchObject({test: error})
+	})
+
+	it('does not trigger timestamp hooks from unspecified modules', () => {
+		dispatcher.addTimestampHook(timestampHook)
+		dispatcher.dispatch(event, [])
+		expect(callback).not.toHaveBeenCalled()
+	})
+})

--- a/src/parser/core/Dispatcher.ts
+++ b/src/parser/core/Dispatcher.ts
@@ -1,0 +1,221 @@
+import {Event} from 'fflogs'
+import _ from 'lodash'
+import Module from './Module'
+
+export type FilterPartial<T> = {
+	[K in keyof T]?: T[K] extends object
+		? FilterPartial<T[K]>
+		: FilterPartial<T[K]> | Array<FilterPartial<T[K]>>
+}
+
+export type Filter<T extends Event> = FilterPartial<T>
+
+type ModuleHandle = (typeof Module)['handle']
+
+export type EventHookCallback<T extends Event> = (event: T) => void
+
+export interface EventHook<T extends Event> {
+	event: T['type']
+	filter?: Filter<T>
+	module: ModuleHandle // TODO: Should this be the entire module ref?
+	callback: EventHookCallback<T>
+}
+
+export type TimestampHookCallback = (opts: {timestamp: number}) => void
+
+export interface TimestampHook {
+	timestamp: number
+	module: ModuleHandle
+	callback: TimestampHookCallback
+}
+
+type ModuleErrors = Record<ModuleHandle, Error>
+
+export class Dispatcher {
+	/*
+	TODO: Decide on the responsibilities of this:
+	- event hooks?
+	- timestamp hooks?
+	- error handling?
+	- filtering?
+	- filtering QoL
+
+	- should filtering be here, or remain on the module?
+	- should this be hooking the callback, or firing a generic callback on module?
+	- timestamp hook kind of needs to be handled at this level - so it'd be weird if we didn't at _least_ hook callbacks here
+	- to hook callbacks, we need to filter - can't expect module to intercept that
+
+	- Dispatch probably has the best idea of the current timestamp - should parser defer to it?
+	*/
+
+	private _timestamp = 0
+
+	/** The timestamp of the last hook executed. */
+	get timestamp() {
+		return this._timestamp
+	}
+
+	// eventHooks[eventType][moduleHandle]: Set<Hook>
+	private eventHooks = new Map<Event['type'], Map<ModuleHandle, Set<EventHook<any>>>>()
+
+	// Stored nearest-last so we can use the significantly-faster pop
+	private timestampHookQueue: TimestampHook[] = []
+
+	/**
+	 * Register an event hook. The callback provided on the hook will be executed
+	 * each time a matching event is dispatched.
+	 */
+	addEventHook<T extends Event>(hook: EventHook<T>) {
+		// TODO: Intentionally only accepting single event on hook type
+		// module will need to loop if it gets an array and add one for each (ezpz)
+
+		let eventTypeHooks = this.eventHooks.get(hook.event)
+		if (!eventTypeHooks) {
+			eventTypeHooks = new Map()
+			this.eventHooks.set(hook.event, eventTypeHooks)
+		}
+
+		let moduleHooks = eventTypeHooks.get(hook.module)
+		if (!moduleHooks) {
+			moduleHooks = new Set()
+			eventTypeHooks.set(hook.module, moduleHooks)
+		}
+
+		moduleHooks.add(hook)
+	}
+
+	/**
+	 * Remove an existing event hook, preventing it from executing any further.
+	 * Removal is performed via strict equality, the hookobeing removed must have
+	 * been explicitly added prior.
+	 */
+	removeEventHook(hook: EventHook<any>) {
+		const eventTypeHooks = this.eventHooks.get(hook.event)
+		if (!eventTypeHooks) { return }
+
+		const moduleHooks = eventTypeHooks.get(hook.module)
+		if (!moduleHooks) { return }
+
+		moduleHooks.delete(hook)
+	}
+
+	/** Add a hook for a timestamp. The provided callback will be fired a single time when the parser reaches the specified timestamp. Hooks for a timestamp in the past will be ignored. */
+	addTimestampHook(hook: TimestampHook) {
+		// If we're already past this hook's timestamp, do nothing
+		if (hook.timestamp < this._timestamp) {
+			return
+		}
+
+		const index = this.timestampHookQueue.findIndex(qh => qh.timestamp < hook.timestamp)
+
+		if (index === -1) {
+			this.timestampHookQueue.push(hook)
+		} else {
+			this.timestampHookQueue.splice(index, 0, hook)
+		}
+	}
+
+	/** Remove a previously added timestamp hook. */
+	removeTimestampHook(hook: TimestampHook) {
+		const index = this.timestampHookQueue.indexOf(hook)
+		if (index === -1) { return }
+		this.timestampHookQueue.splice(index, 1)
+	}
+
+	/** Dispatch hooks for the provided event. */
+	dispatch(event: Event, triggerOrder: ModuleHandle[]): ModuleErrors {
+		return {
+			...this.dispatchTimestamp(event.timestamp, triggerOrder),
+			...this.dispatchEvent(event, triggerOrder),
+		}
+	}
+
+	private dispatchTimestamp(timestamp: number, triggerOrder: ModuleHandle[]) {
+		const moduleErrors: ModuleErrors = {}
+
+		// Fire off any timestamp hooks that are ready
+		const thq = this.timestampHookQueue
+		while (thq.length > 0 && thq[thq.length - 1].timestamp <= timestamp) {
+			const hook = thq.pop()!
+
+			// If we're not triggering on this module, skip the hook - removing it entirely
+			if (!triggerOrder.includes(hook.module)) { continue }
+
+			this._timestamp = hook.timestamp
+
+			try {
+				hook.callback({timestamp: hook.timestamp})
+			} catch (error) {
+				moduleErrors[hook.module] = error
+			}
+		}
+
+		return moduleErrors
+	}
+
+	private dispatchEvent(event: Event, triggerOrder: ModuleHandle[]) {
+		// TODO/NOTE: Let's not use 'all' - need to remove the all hook from core/pets
+		// that should be all we need, though. double check
+
+		// Update the internal timestamp to the event we're dispatching
+		this._timestamp = event.timestamp
+
+		// Get registered hooks for this event type, if there are any
+		const eventTypeHooks = this.eventHooks.get(event.type)
+		if (!eventTypeHooks) { return }
+
+		// Check for hooks on each of the modules we're triggering events on
+		return triggerOrder.reduce(
+			(moduleErrors, handle) => {
+				const moduleHooks = eventTypeHooks.get(handle)
+				if (!moduleHooks) { return moduleErrors }
+
+				try {
+					moduleHooks.forEach(hook => {
+						// Ensure the hook's filter matches before triggering
+						if (hook.filter && !this.checkFilterMatches(event, hook.filter)) {
+							return
+						}
+
+						hook.callback(event)
+					})
+				} catch (error) {
+					moduleErrors[handle] = error
+				}
+
+				return moduleErrors
+			},
+			{} as ModuleErrors,
+		)
+	}
+
+	// TODO: Look into using _.isMatchWith for this - it's incorrectly typed in DT at the moment, though.
+	private checkFilterMatches<T extends object, F extends FilterPartial<T>>(
+		object: T,
+		filter: F,
+	): boolean {
+		return Object.keys(filter).every(key => {
+			// If the event doesn't have the key we're looking for, just shortcut out
+			if (!object.hasOwnProperty(key)) {
+				return false
+			}
+
+			// Just trust me 'aite
+			const filterVal: any = filter[key as keyof typeof filter]
+			const objectVal: any = object[key as keyof typeof object]
+
+			// FFLogs doesn't use arrays inside events themselves, so I'm using them to handle multiple possible values
+			if (Array.isArray(filterVal)) {
+				return filterVal.includes(objectVal)
+			}
+
+			// If it's an object, I need to dig down. Mostly for the `ability` key
+			if (typeof filterVal === 'object') {
+				return this.checkFilterMatches(objectVal, filterVal)
+			}
+
+			// Basic value check
+			return filterVal === objectVal
+		})
+	}
+}

--- a/src/parser/core/Dispatcher.ts
+++ b/src/parser/core/Dispatcher.ts
@@ -32,22 +32,6 @@ export interface TimestampHook {
 type ModuleErrors = Record<ModuleHandle, Error>
 
 export class Dispatcher {
-	/*
-	TODO: Decide on the responsibilities of this:
-	- event hooks?
-	- timestamp hooks?
-	- error handling?
-	- filtering?
-	- filtering QoL
-
-	- should filtering be here, or remain on the module?
-	- should this be hooking the callback, or firing a generic callback on module?
-	- timestamp hook kind of needs to be handled at this level - so it'd be weird if we didn't at _least_ hook callbacks here
-	- to hook callbacks, we need to filter - can't expect module to intercept that
-
-	- Dispatch probably has the best idea of the current timestamp - should parser defer to it?
-	*/
-
 	private _timestamp = 0
 
 	/** The timestamp of the last hook executed. */
@@ -66,9 +50,6 @@ export class Dispatcher {
 	 * each time a matching event is dispatched.
 	 */
 	addEventHook<T extends Event>(hook: EventHook<T>) {
-		// TODO: Intentionally only accepting single event on hook type
-		// module will need to loop if it gets an array and add one for each (ezpz)
-
 		let eventTypeHooks = this.eventHooks.get(hook.event)
 		if (!eventTypeHooks) {
 			eventTypeHooks = new Map()
@@ -86,7 +67,7 @@ export class Dispatcher {
 
 	/**
 	 * Remove an existing event hook, preventing it from executing any further.
-	 * Removal is performed via strict equality, the hookobeing removed must have
+	 * Removal is performed via strict equality, the hook being removed must have
 	 * been explicitly added prior.
 	 */
 	removeEventHook(hook: EventHook<any>) {
@@ -99,7 +80,11 @@ export class Dispatcher {
 		moduleHooks.delete(hook)
 	}
 
-	/** Add a hook for a timestamp. The provided callback will be fired a single time when the parser reaches the specified timestamp. Hooks for a timestamp in the past will be ignored. */
+	/**
+	 * Add a hook for a timestamp. The provided callback will be fired a single
+	 * time when the parser reaches the specified timestamp. Hooks for a timestamp
+	 * in the past will be ignored.
+	 */
 	addTimestampHook(hook: TimestampHook) {
 		// If we're already past this hook's timestamp, do nothing
 		if (hook.timestamp < this._timestamp) {
@@ -154,9 +139,6 @@ export class Dispatcher {
 	}
 
 	private dispatchEvent(event: Event, triggerOrder: ModuleHandle[]) {
-		// TODO/NOTE: Let's not use 'all' - need to remove the all hook from core/pets
-		// that should be all we need, though. double check
-
 		// Update the internal timestamp to the event we're dispatching
 		this._timestamp = event.timestamp
 

--- a/src/parser/core/Module.test.js
+++ b/src/parser/core/Module.test.js
@@ -147,43 +147,23 @@ describe('Module', () => {
 			.toHaveBeenCalledWith(hookRefs[0])
 	})
 
-	// TODO: BENEATH HERE ---
+	it('adds timestamp hooks to the dispatcher', () => {
+		const timestamp = 50
+		module.addTimestampHook(timestamp, hook)
 
-	it('can hook a timestamp', () => {
-		module.addTimestampHook(50, hook)
-
-		module.triggerEvent({...event, timestamp: 1})
-		expect(hook).not.toHaveBeenCalled()
-
-		module.triggerEvent({...event, timestamp: 100})
-		expect(hook).toHaveBeenCalledTimes(1)
+		expect(dispatcher.addTimestampHook).toHaveBeenCalledTimes(1)
+		expect(dispatcher.addTimestampHook.mock.calls[0][0]).toMatchObject({
+			module: module.constructor.handle,
+			timestamp,
+		})
 	})
 
-	it('will catch up on multiple timestamp hooks in a single event', () => {
-		module.addTimestampHook(40, hook)
-		module.addTimestampHook(50, hook)
-		module.addTimestampHook(60, hook)
-
-		module.triggerEvent({...event, timestamp: 100})
-		expect(hook)
-			.toHaveBeenCalledTimes(3)
-			.toHaveBeenNthCalledWith(3, {timestamp: 60})
-	})
-
-	it('can remove timestamp hooks', () => {
+	it('removes timestamp hooks from the dispatcher', () => {
 		const hookRef = module.addTimestampHook(50, hook)
 		module.removeTimestampHook(hookRef)
-		module.triggerEvent({...event, timestamp: 100})
-		expect(hook).not.toHaveBeenCalled()
-	})
 
-	it('reports the correct timestamp while executing timestamp hooks', () => {
-		let hookTimestamp = -1
-		const testHook = () => hookTimestamp = parser.currentTimestamp
-		module.addTimestampHook(50, testHook)
-
-		parser.parseEvents([{...event, timestamp: 100}])
-
-		expect(hookTimestamp).toBe(50)
+		expect(dispatcher.removeTimestampHook)
+			.toHaveBeenCalledTimes(1)
+			.toHaveBeenCalledWith(hookRef)
 	})
 })

--- a/src/parser/core/Module.test.js
+++ b/src/parser/core/Module.test.js
@@ -77,15 +77,6 @@ describe('Module', () => {
 		expect(result).toBe(events)
 	})
 
-	it('can hook all events', () => {
-		// TODO: Remove the last all hook
-		module.addEventHook('all', hook)
-		module.triggerEvent(event)
-		expect(hook)
-			.toHaveBeenCalledTimes(1)
-			.toHaveBeenCalledWith(event)
-	})
-
 	it('adds event hooks to the dispatcher', () => {
 		module.addEventHook(event.type, hook)
 
@@ -102,16 +93,6 @@ describe('Module', () => {
 
 		expect(dispatcher.addEventHook).toHaveBeenCalledTimes(2)
 		expect(dispatcher.addEventHook.mock.calls.map(params => params[0].event)).toEqual([event.type, '__unused'])
-	})
-
-	it('does not trigger \'all\' hooks on symbols', () => {
-		// TODO: Remove 'all'
-		const type = Symbol('test')
-		const symbolEvent = {...event, type}
-		module.addEventHook('all', hook)
-		module.addEventHook(type, hook)
-		module.triggerEvent(symbolEvent)
-		expect(hook).toHaveBeenCalledTimes(1)
 	})
 
 	describe('QoL filter helpers', () => {

--- a/src/parser/core/Module.test.js
+++ b/src/parser/core/Module.test.js
@@ -11,7 +11,6 @@ class TestModule extends Module {
 	static handle = 'test'
 }
 
-let parser
 let module
 let hook
 
@@ -49,7 +48,7 @@ describe('Module', () => {
 		const meta = new Meta({
 			modules: () => Promise.resolve({default: [TestModule]}),
 		})
-		parser = new Parser({
+		const parser = new Parser({
 			meta,
 			report,
 			fight,

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -38,7 +38,6 @@ class Parser {
 	readonly patch: Patch
 
 	readonly meta: Meta
-	// _timestamp = 0
 
 	modules: Record<string, Module> = {}
 	_constructors: Record<string, typeof Module> = {}
@@ -86,14 +85,9 @@ class Parser {
 	}) {
 		this.dispatcher = opts.dispatcher || new Dispatcher()
 
-		// TODO: Pass this down?
 		this.meta = opts.meta
 		this.report = opts.report
 		this.fight = opts.fight
-
-		// Set initial timestamp
-		// TODO: Remove?
-		// this._timestamp = opts.fight.start_time
 
 		// Get a list of the current player's pets and set it on the player instance for easy reference
 		const pets = opts.report.friendlyPets

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -251,6 +251,7 @@ class Parser {
 		// Set the error for the current module
 		const moduleIndex = this._triggerModules.indexOf(mod)
 		if (moduleIndex !== -1 ) {
+			this._triggerModules = this._triggerModules.slice(0)
 			this._triggerModules.splice(moduleIndex, 1)
 		}
 		this._moduleErrors[mod] = error

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -9,6 +9,7 @@ import React from 'react'
 import {Report} from 'store/report'
 import toposort from 'toposort'
 import {extractErrorContext} from 'utilities'
+import {Dispatcher} from './Dispatcher'
 import {Meta} from './Meta'
 import Module, {DISPLAY_MODE, MappedDependency} from './Module'
 import {Patch} from './Patch'
@@ -29,13 +30,15 @@ class Parser {
 	// -----
 	// Properties
 	// -----
+	readonly dispatcher = new Dispatcher()
+
 	readonly report: Report
 	readonly fight: Fight
 	readonly player: Player
 	readonly patch: Patch
 
-	meta: Meta
-	_timestamp = 0
+	readonly meta: Meta
+	// _timestamp = 0
 
 	modules: Record<string, Module> = {}
 	_constructors: Record<string, typeof Module> = {}
@@ -47,8 +50,8 @@ class Parser {
 	_fabricationQueue: Event[] = []
 
 	get currentTimestamp() {
-		// TODO: this.finished?
-		return Math.min(this.fight.end_time, this._timestamp)
+		const {end_time, start_time} = this.fight
+		return Math.min(end_time, Math.max(start_time, this.dispatcher.timestamp))
 	}
 
 	get fightDuration() {
@@ -79,12 +82,14 @@ class Parser {
 		fight: Fight,
 		actor: Actor,
 	}) {
+		// TODO: Pass this down?
 		this.meta = opts.meta
 		this.report = opts.report
 		this.fight = opts.fight
 
 		// Set initial timestamp
-		this._timestamp = opts.fight.start_time
+		// TODO: Remove?
+		// this._timestamp = opts.fight.start_time
 
 		// Get a list of the current player's pets and set it on the player instance for easy reference
 		const pets = opts.report.friendlyPets
@@ -176,8 +181,22 @@ class Parser {
 
 		// Loop & trigger all the events & fabrications
 		for (const event of this.iterateEvents(events)) {
-			this._timestamp = event.timestamp
-			this.triggerEvent(event)
+			// TODO: Do I need to keep a history?
+			const moduleErrors = this.dispatcher.dispatch(event, this._triggerModules)
+
+			for (const handle in moduleErrors) {
+				if (!moduleErrors.hasOwnProperty(handle)) { continue }
+				const error = moduleErrors[handle]
+
+				this.captureError({
+					error,
+					type: 'event',
+					module: handle,
+					event,
+				})
+
+				this._setModuleError(handle, error)
+			}
 		}
 	}
 
@@ -224,28 +243,12 @@ class Parser {
 		this._fabricationQueue.push(this.hydrateFabrication(event))
 	}
 
-	triggerEvent(event: Event) {
-		// TODO: Do I need to keep a history?
-		this._triggerModules.forEach(mod => {
-			try {
-				this.modules[mod].triggerEvent(event)
-			} catch (error) {
-				this.captureError({
-					error,
-					type: 'event',
-					module: mod,
-					event,
-				})
-
-				// Also cascade the error through the dependency tree
-				this._setModuleError(mod, error)
-			}
-		})
-	}
-
 	_setModuleError(mod: string, error: Error) {
 		// Set the error for the current module
-		this._triggerModules.splice(this._triggerModules.indexOf(mod), 1)
+		const moduleIndex = this._triggerModules.indexOf(mod)
+		if (moduleIndex !== -1 ) {
+			this._triggerModules.splice(moduleIndex, 1)
+		}
 		this._moduleErrors[mod] = error
 
 		// Cascade via dependencies
@@ -407,7 +410,7 @@ class Parser {
 		}
 
 		// Gather extra data for the error report.
-		const [data, errors] = this._gatherErrorContext(opts.module, 'output', opts.error)
+		const [data, errors] = this._gatherErrorContext(opts.module, opts.type, opts.error)
 		extra.modules = data
 
 		for (const [m, err] of errors) {

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -30,7 +30,7 @@ class Parser {
 	// -----
 	// Properties
 	// -----
-	readonly dispatcher = new Dispatcher()
+	readonly dispatcher: Dispatcher
 
 	readonly report: Report
 	readonly fight: Fight
@@ -81,7 +81,11 @@ class Parser {
 		report: Report,
 		fight: Fight,
 		actor: Actor,
+
+		dispatcher?: Dispatcher,
 	}) {
+		this.dispatcher = opts.dispatcher || new Dispatcher()
+
 		// TODO: Pass this down?
 		this.meta = opts.meta
 		this.report = opts.report

--- a/src/parser/core/modules/Gauge/TimerGauge.ts
+++ b/src/parser/core/modules/Gauge/TimerGauge.ts
@@ -1,6 +1,6 @@
-import {ChartDataSets, ChartPoint} from 'chart.js'
+import {ChartDataSets} from 'chart.js'
 import Color from 'color'
-import Module, {TimestampHook} from 'parser/core/Module'
+import Module from 'parser/core/Module'
 import {AbstractGauge, AbstractGaugeOptions} from './AbstractGauge'
 
 function expectExist<T>(value?: T) {
@@ -44,7 +44,7 @@ export class TimerGauge extends AbstractGauge {
 	private readonly expirationCallback?: () => void
 	private readonly chartOptions?: TimerChartOptions
 
-	private hook?: TimestampHook
+	private hook?: ReturnType<Module['addTimestampHook']>
 	private history: State[] = []
 
 	// TODO: Work out how to remove this reliance on having it passed down


### PR DESCRIPTION
Or at least _less_ wibbly wobbly timey wimey.

Moved hooking logic out of `Module` into a new single-ish-ton `Dispatcher`. Filter QoL remains in modules to keep the dispatcher simple(r).