### PR TITLE
Mark WAR as supported through 5.08 

### DIFF
--- a/src/parser/jobs/war/TODO.md
+++ b/src/parser/jobs/war/TODO.md
@@ -1,0 +1,15 @@
+# WAR TODOs
+
+## Known Bugs
+- [ ] Storm's Eye uptime can go over 100% because the denominator of uptime
+      subtracts out invuln time, but the numerator doesn't. Likely to be fixed
+      in core, rather than in this module specifically.
+
+## Offensive Cooldown Usage
+
+- [ ] Track how often offensive cooldowns were available but unused for.
+- [ ] Upheaval tracking (maybe count the drift in seconds, as well as percent
+      usage?)
+- [ ] Infuriate tracking (Depends on having something for charge actions)
+- [ ] Maybe IR tracking? A lack of IRs should be obvious from its own module,
+      but downtime could make things look weird when they're actually ok.

--- a/src/parser/jobs/war/index.js
+++ b/src/parser/jobs/war/index.js
@@ -44,5 +44,12 @@ export default new Meta({
 				</ul>
 			</>,
 		},
+		{
+			date: new Date('2019-08-11'),
+			contributors: [],
+			Changes: () => <>
+				Updated the Gauge module to track Infuriate reduction with all of Inner Chaos, Chaotic Cyclone, Fell Cleave, and Decimate
+			</>,
+		},
 	],
 })

--- a/src/parser/jobs/war/index.js
+++ b/src/parser/jobs/war/index.js
@@ -23,24 +23,26 @@ export default new Meta({
 			</Message.Content>
 		</Message>
 	</>,
-	// supportedPatches: {
-	// 	from: '4.2',
-	// 	to: '4.5',
-	// },
+	supportedPatches: {
+		from: '5.0',
+		to: '5.08',
+	},
 	contributors: [
 		{user: CONTRIBUTORS.SKYE, role: ROLES.MAINTAINER},
 	],
 
-	changelog: [{
-		date: new Date('2019-07-30'),
-		contributors: [CONTRIBUTORS.SKYE],
-		Changes: () => <>
-			Initial changes for Shadowbringers:
-			<ul>
-				<li>Updated the Inner Release module to account for Inner Chaos and Chaotic Cyclone</li>
-				<li>Changed the Storms Eye Module buffer to 7 seconds instead of the old 10 seconds</li>
-				<li>Changed the Gauge module to track the Infuriate reduction through Inner Chaos and Chaotic Cyclone instead of Fell Cleave and Decimate</li>
-			</ul>
-		</>,
-	}],
+	changelog: [
+		{
+			date: new Date('2019-07-30'),
+			contributors: [CONTRIBUTORS.SKYE],
+			Changes: () => <>
+				Initial changes for Shadowbringers:
+				<ul>
+					<li>Updated the Inner Release module to account for Inner Chaos and Chaotic Cyclone</li>
+					<li>Changed the Storms Eye Module buffer to 7 seconds instead of the old 10 seconds</li>
+					<li>Changed the Gauge module to track the Infuriate reduction through Inner Chaos and Chaotic Cyclone instead of Fell Cleave and Decimate</li>
+				</ul>
+			</>,
+		},
+	],
 })


### PR DESCRIPTION
This PR marks WAR as supported for 5.0-5.08 and updates the TODO list for WAR.

I haven't been able to dig up any bugs in the WAR modules that aren't core and equally present in other jobs that are marked as supported, and so it seems like there's no current reason to not mark WAR as supported. Some features (listed in the new TODO) would be nice to have, but again shouldn't be blocking of support.