### PR TITLE
SCH 5.1 support and a minor nit from balance fix

### DIFF
--- a/src/data/ACTIONS/SCH.js
+++ b/src/data/ACTIONS/SCH.js
@@ -63,7 +63,7 @@ export default {
 		id: 16546,
 		name: 'Consolation',
 		icon: 'https://xivapi.com/i/002000/002851.png',
-		cooldown: 20,
+		cooldown: 30,
 	},
 
 	SUCCOR: {

--- a/src/parser/jobs/sch/index.js
+++ b/src/parser/jobs/sch/index.js
@@ -34,7 +34,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.08',
+		to: '5.1',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.LIMA, role: ROLES.MAINTAINER},
@@ -43,6 +43,11 @@ export default new Meta({
 		{user: CONTRIBUTORS.NONO, role: ROLES.DEVELOPER},
 	],
 	changelog: [{
+		date: new Date('2019-10-29'),
+		Changes: () => <>Support for 5.1; additionally, only warn on faerie gauge overcap starting at 50</>,
+		contributors: [CONTRIBUTORS.NONO],
+	},
+	{
 		date: new Date('2019-09-19'),
 		Changes: () => <>Track interrupts; a big thanks to Tonto Draksbane and Yuni in the balance for help with this feature</>,
 		contributors: [CONTRIBUTORS.NONO],

--- a/src/parser/jobs/sch/modules/FaerieGauge.js
+++ b/src/parser/jobs/sch/modules/FaerieGauge.js
@@ -57,14 +57,14 @@ export default class FaerieGauge extends Module {
 		super(...args)
 
 		// consumers
-		this.addHook('heal', {by: 'pet', abilityId: STATUSES.FEY_UNION.id}, this._onGaugeSpend)
-		this.addHook('cast', {by: 'player', abilityId: ACTIONS.SCH_FEY_BLESSING.id}, this._onGaugeSpend)
-		this.addHook('death', {to: 'player'}, this._onDeath) // I mean.. it does consume all your gauge..
+		this.addEventHook('heal', {by: 'pet', abilityId: STATUSES.FEY_UNION.id}, this._onGaugeSpend)
+		this.addEventHook('cast', {by: 'player', abilityId: ACTIONS.SCH_FEY_BLESSING.id}, this._onGaugeSpend)
+		this.addEventHook('death', {to: 'player'}, this._onDeath) // I mean.. it does consume all your gauge..
 		// generators
-		this.addHook('cast', {by: 'player', abilityId: GAUGE_GENERATORS}, this._onGaugeGenerate)
-		this.addHook('complete', this._onComplete)
+		this.addEventHook('cast', {by: 'player', abilityId: GAUGE_GENERATORS}, this._onGaugeGenerate)
+		this.addEventHook('complete', this._onComplete)
 		// summoning a fairy
-		this.addHook('cast', {by: 'player', abilityId: SUMMON_ACTIONS}, this._onSummon)
+		this.addEventHook('cast', {by: 'player', abilityId: SUMMON_ACTIONS}, this._onSummon)
 	}
 
 	// Search through the events to figure out if there was a fairy out before logs started

--- a/src/parser/jobs/sch/modules/FaerieGauge.js
+++ b/src/parser/jobs/sch/modules/FaerieGauge.js
@@ -35,8 +35,7 @@ const BORDER_COLOR_FADE = 0.5
 // Severity markers for overcap
 // Start at 30 because you can overcap when seraph is out and you can't drain the gauge
 const GAUGE_WASTE_SEVERITY = {
-	30: SEVERITY.MINOR,
-	50: SEVERITY.MEDIUM,
+	50: SEVERITY.MINOR,
 }
 
 export default class FaerieGauge extends Module {


### PR DESCRIPTION
My death has been greatly exaggerated.

* Change the faerie gauge warning to start at 50 overcap (and only a minor warning only) per balance request and discussion
* Change consolation cooldown time to match with patch update
* Since I touched a module, I went ahead and updated `addHook` to `addEventHook` in there.

Happy 5.1 everyone!