### PR TITLE
[Bugfix] Fixed a small sentry error in BotD

### DIFF
--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.js
@@ -30,6 +30,7 @@ export default class BloodOfTheDragon extends Module {
 		'cooldowns',
 		'death',
 		'suggestions',
+		'timeline',
 	]
 
 	// Null assumption, in case they precast. In all likelyhood, this will actually be incorrect, but there's no harm if


### PR DESCRIPTION
Fix for CLIENT-18T; the BotD module was trying to call `timeline.show()` without having `timeline` as a dependency.