### PR TITLE
Add module debug logging fn

### DIFF
--- a/src/parser/core/Module.ts
+++ b/src/parser/core/Module.ts
@@ -259,7 +259,7 @@ export default class Module {
 	 * Log a debug console message. Will only be printed if built in a non-production
 	 * environment, with `static debug = true` in the module it's being executed in.
 	 */
-	protected debug(...messages: string[]) {
+	protected debug(...messages: Parameters<typeof console.log>) {
 		const module = this.constructor as typeof Module
 
 		if (!module.debug || process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
Inspired by #713

![image](https://user-images.githubusercontent.com/534235/69244250-bc780a80-0bf8-11ea-81b8-38293a146c30.png)

Color is derived from the module handle. I've _tried_ to make it readable on both light and dark themes. No promises for yellow though - try renaming your module? :^)

I slep now