### PR TITLE
[Bugfix] Fixed improper combo break warnings

### DIFF
--- a/src/parser/core/modules/Combos.tsx
+++ b/src/parser/core/modules/Combos.tsx
@@ -165,7 +165,8 @@ export default class Combos extends Module {
 			return
 		}
 
-		if (action.onGcd) {
+		// Only track GCDs that either progress or break combos so actions like Drill and Shadow Fang don't falsely extend the simulated combo timer
+		if (action.onGcd && (action.combo || action.breaksCombo)) {
 			if (event.timestamp - this.lastGcdTime > GCD_TIMEOUT_MILLIS) {
 				// If we've had enough downtime between GCDs to let the combo expire, reset the state so we don't count erroneous combo breaks
 				this.currentComboChain = []


### PR DESCRIPTION
Small fix for the issue that presents here: https://xivanalysis.com/analyse/3X9TbDyqKMLkf6G2/25/2/
Basically what's happening is that non-combo-breaking-but-not-combo-continuing GCDs (e.g. Shadow Fang, Drill, Air Anchor, and in this case, Flamethrower) are artificially extending the simulated combo timer, which can lead to erroneous broken combo warnings after downtime. In the log linked above, a FT during downtime resets the timer so it yells about a broken combo despite the fact that it had already fallen off during the transition.