### PR TITLE
[Bugfix] Fix precast status for buffs that apply stacks

### DIFF
--- a/src/data/STATUSES/root/RDM.ts
+++ b/src/data/STATUSES/root/RDM.ts
@@ -23,6 +23,7 @@ export const RDM = ensureStatuses({
 		name: 'Acceleration',
 		icon: 'https://xivapi.com/i/013000/013405.png',
 		duration: 20,
+		stacksApplied: 3,
 	},
 	EMBOLDEN_PHYSICAL: {
 		// Note that this is the Embolden that boosts Physical Damage - what other people receive from RDM

--- a/src/data/STATUSES/type.ts
+++ b/src/data/STATUSES/type.ts
@@ -3,6 +3,7 @@ export interface Status {
 	name: string
 	icon: string
 	duration?: number
+	stacksApplied?: number
 }
 
 export const ensureStatuses = <T extends Record<string, Status>>(statuses: T): {[K in keyof T]: T[K] & Status} => statuses

--- a/src/parser/core/modules/PrecastStatus.js
+++ b/src/parser/core/modules/PrecastStatus.js
@@ -14,64 +14,87 @@ export default class PrecastStatus extends Module {
 
 	_combatantStatuses = {}
 	_combatantActions = []
+	_statusesToSynth = []
+	_actionsToSynth = []
+	_startTime = this.parser.fight.start_time
 
 	normalise(events) {
-		const startTime = this.parser.fight.start_time
-
 		for (let i = 0; i < events.length; i++) {
 			const event = events[i]
 			const targetId = event.targetID
 
+			const statusInfo = getDataBy(STATUSES, 'id', event.ability.guid)
+
 			this._combatantStatuses[targetId] = this._combatantStatuses[targetId] || []
 
-			if (event.type === 'applybuff') {
-				this._combatantStatuses[targetId].push(event.ability.guid)
+			if (event.type === 'applybuff' && !statusInfo.hasOwnProperty('stacksApplied')) {
+				// If status applies stacks, check applybuffstack for applying full stacks before considering this the first application of this status
+				this.markStatusAsTracked(statusInfo.id, targetId)
 			}
 
-			if (['removebuff', 'applybuffstack', 'removebuffstack', 'refreshbuff'].includes(event.type)) {
-				const statusId = event.ability.guid
+			if (event.type === 'applybuffstack' && statusInfo.hasOwnProperty('stacksApplied')) {
+				// Determine if this is applying fewer than the max stacks
+				if (event.stack < statusInfo.stacksApplied) {
+					// Synth the precast status event if this applied fewer than max stacks
+					this.fabricateStatusEvent(event, statusInfo)
+				}
 
+				this.markStatusAsTracked(statusInfo.id, targetId)
+			}
+
+			if (['removebuff', 'removebuffstack', 'refreshbuff'].includes(event.type)) {
 				// If it's already been applied, we don't have to worry about it
-				if (this._combatantStatuses[targetId].includes(statusId)) {
+				if (this._combatantStatuses[targetId].includes(statusInfo.id)) {
 					continue
 				}
 
-				// Fab an event and splice it in at the start of the fight
-				events.splice(0, 0, {
-					// Can inherit most of the event data from the current one
-					...event,
-					// Override a few vals
-					timestamp: startTime - 1,
-					type: 'applybuff',
-				})
-
-				// Determine if this buff comes from a known action, fab a cast event
-				const statusInfo = getDataBy(STATUSES, 'id', event.ability.guid)
-				if (statusInfo) {
-					const actionInfo = getDataBy(ACTIONS, 'statusesApplied', statusInfo)
-					// Action found - push it into _combatantActions array if not already there and synthesize a cast event
-					// If action has already been synthesized (and pushed into _combatantActions array), do nothing
-					if (actionInfo && this._combatantActions.indexOf(actionInfo.id) === -1) {
-						this._combatantActions.push(actionInfo.id)
-
-						events.splice(0, 0, {
-							...event,
-							ability: {
-								...event.ability,
-								name: actionInfo.name,
-								abilityIcon: actionInfo.icon.replace('https://xivapi.com/i', '').replace('/', '-'),
-								guid: actionInfo.id,
-							},
-							timestamp: startTime - 2,
-							type: 'cast',
-						})
-					}
-				}
-
-				this._combatantStatuses[targetId].push(statusId)
+				this.fabricateStatusEvent(event, statusInfo)
+				this.markStatusAsTracked(statusInfo.id, targetId)
 			}
 		}
 
-		return events
+		const synthesizedEvents = this._actionsToSynth.concat(this._statusesToSynth)
+		return synthesizedEvents.concat(events)
+	}
+
+	fabricateStatusEvent(event, statusInfo) {
+		// Fab an event and splice it in at the start of the fight
+		this._statusesToSynth.push({
+			// Can inherit most of the event data from the current one
+			...event,
+			// Override a few vals
+			timestamp: this._startTime - 1,
+			type: 'applybuff',
+		})
+
+		// Determine if this buff comes from a known action, fab a cast event
+		const actionInfo = getDataBy(ACTIONS, 'statusesApplied', statusInfo)
+		if (actionInfo && this._combatantActions.indexOf(actionInfo.id) === -1) {
+			this.fabricateActionEvent(event, actionInfo)
+		}
+	}
+
+	fabricateActionEvent(event, actionInfo) {
+		this._actionsToSynth.push({
+			...event,
+			ability: {
+				...event.ability,
+				name: actionInfo.name,
+				abilityIcon: actionInfo.icon.replace('https://xivapi.com/i', '').replace('/', '-'),
+				guid: actionInfo.id,
+			},
+			timestamp: this._startTime - 2,
+			type: 'cast',
+		})
+
+		this.markActionAsTracked(actionInfo.id)
+	}
+
+	markStatusAsTracked(statusId, targetId) {
+		this._combatantStatuses[targetId].push(statusId)
+	}
+
+	markActionAsTracked(actionId) {
+		this._combatantActions.push(actionId)
 	}
 }


### PR DESCRIPTION
Most noticeable for Acceleration (RDM) - when this was changed to a 3 stack buff in 5.1, we are now getting an `applybuff` event and an `applybuffstack` event with 2 stacks on the RDM's first cast of the pull.

See, for example: https://www.fflogs.com/reports/mphJdArR6vbTHLKj#fight=2&type=auras&source=1&view=events

This fix is just for RDM, but should be extensible to other similar jobs fairly easily.