### PR TITLE
Update DRK CDDT

### DIFF
--- a/src/parser/jobs/drk/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drk/modules/OGCDDowntime.ts
@@ -1,14 +1,26 @@
 import ACTIONS from 'data/ACTIONS'
 import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 
+const DEFAULT_FIRST_USE_OFFSET = 17500
+
 export default class OGCDDowntime extends CooldownDowntime {
+	defaultFirstUseOffset = DEFAULT_FIRST_USE_OFFSET
 	trackedCds = [
-		{cooldowns: [ACTIONS.BLOOD_WEAPON]},
-		{cooldowns: [ACTIONS.DELIRIUM]},
+		{
+			cooldowns: [ACTIONS.BLOOD_WEAPON],
+			firstUseOffset: 2500,
+		},
+		{
+			cooldowns: [ACTIONS.DELIRIUM],
+			firstUseOffset: 15000,
+		},
 		{cooldowns: [ACTIONS.PLUNGE]},
 		{cooldowns: [ACTIONS.SALTED_EARTH]},
 		{cooldowns: [ACTIONS.CARVE_AND_SPIT]},
 		{cooldowns: [ACTIONS.ABYSSAL_DRAIN]},
-		{cooldowns: [ACTIONS.LIVING_SHADOW]},
+		{
+			cooldowns: [ACTIONS.LIVING_SHADOW],
+			firstUseOffset: 10000,
+		},
 	]
 }


### PR DESCRIPTION
Per discussion with Demon on the Balance discord, in light of the changes made to the CDDT module.  It was noted that initial usage timing and order of Plunge, C&S, Salted Earth, and Abyssal Drain can vary by comp, with a "worst case" of 12th-13th GCD.  For initial tuning, I'm setting this 8th GCD and will adjust further if necessary.