### PR TITLE
Refactor entities.getStatusUptime() into separate module

### DIFF
--- a/src/parser/core/modules/DoTs.js
+++ b/src/parser/core/modules/DoTs.js
@@ -9,6 +9,7 @@ export default class DoTs extends Module {
 	static handle = 'dots'
 	static dependencies = [
 		'enemies',
+		'entityStatuses',
 		'invuln',
 	]
 
@@ -93,7 +94,7 @@ export default class DoTs extends Module {
 
 	// These two functions are helpers for submodules and should be used but not overridden
 	getUptimePercent(statusId) {
-		const statusUptime = this.enemies.getStatusUptime(statusId)
+		const statusUptime = this.entityStatuses.getStatusUptime(statusId, this.enemies.getEntities())
 		const fightDuration = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 		return (statusUptime / fightDuration) * 100
 	}

--- a/src/parser/core/modules/Entities.js
+++ b/src/parser/core/modules/Entities.js
@@ -136,8 +136,8 @@ export default class Entities extends Module {
 		// Update the buff's last refreshed time
 		const oldStacks = buff.stacks
 		buff.lastRefreshed = event.timestamp
-		buff.stacks = event.stack || 1
-		buff.stackHistory.push({stacks: event.stack || 1, timestamp: event.timestamp})
+		buff.stacks = 1
+		buff.stackHistory.push({stacks: 1, timestamp: event.timestamp})
 
 		this.triggerChangeBuffStack(buff, event.timestamp, oldStacks, buff.stacks)
 	}

--- a/src/parser/core/modules/Entities.js
+++ b/src/parser/core/modules/Entities.js
@@ -1,107 +1,10 @@
 import Module from 'parser/core/Module'
 
-const APPLY = 'apply'
-const REMOVE = 'remove'
-
 export default class Entities extends Module {
 	static dependencies = [
-		'invuln',
 		'fflogsEvents',
 	]
 
-	// -----
-	// API
-	// -----
-	// TODO: This implementation which I've shamelessly stolen seems to only track overall
-	//       uptime, ignoring potential gains from multidotting, etc. Should that be in here,
-	//       or is that a somewhere-else sort of thing...
-	getStatusUptime(statusId, sourceId = this.parser.player.id) {
-		const events = []
-
-		// Build up the events array
-		const entities = this.getEntities()
-		Object.values(entities).forEach(entity => {
-			const invulns = this.invuln
-				.getInvulns(entity.id)
-				.filter(invuln => invuln.type === 'invulnerable')
-
-			entity.buffs.forEach(buff => {
-				if (
-					buff.ability.guid !== statusId ||
-					(buff.sourceID !== sourceId && buff.sourceID !== null)
-				) {
-					return
-				}
-
-				// Split the buff over the invulns
-				const ranges = [buff]
-				invulns.forEach(invuln => {
-					// discard invulns outside the span of the buff
-					if (invuln.end < buff.start || invuln.start > buff.end) {
-						return
-					}
-
-					// split ranges
-					for (let i = 0; i < ranges.length; i++) {
-						const range = ranges[i]
-
-						if (invuln.start < range.start && invuln.end > range.start) {
-							// Invuln chops start of range
-							range.start = invuln.end
-						} else if (invuln.start < range.end && invuln.end > range.end) {
-							// Invuln chops end of range
-							range.end = invuln.start
-						}	else if (invuln.start > range.start && invuln.end < range.end) {
-							// Invuln splits the range
-							ranges.splice(i, 1,
-								{start: range.start, end: invuln.start},
-								{start: invuln.end, end: range.end},
-							)
-						}
-					}
-				})
-
-				// Add faked events for all the ranges the buff was up
-				ranges.forEach(range => {
-					events.push({
-						timestamp: range.start,
-						type: APPLY,
-						buff,
-					})
-					events.push({
-						timestamp: range.end || this.parser.currentTimestamp,
-						type: REMOVE,
-						buff,
-					})
-				})
-			})
-		})
-
-		// Reduce the events array into a final uptime
-		let active = 0
-		let start = null
-		return events
-			.sort((a, b) => a.timestamp - b.timestamp)
-			.reduce((uptime, event) => {
-				if (event.type === APPLY) {
-					if (active === 0) {
-						start = event.timestamp
-					}
-					active ++
-				}
-				if (event.type === REMOVE) {
-					active --
-					if (active === 0) {
-						uptime += event.timestamp - start
-					}
-				}
-				return uptime
-			}, 0)
-	}
-
-	// -----
-	// Event handlers
-	// -----
 	constructor(...args) {
 		super(...args)
 

--- a/src/parser/core/modules/EntityStatuses.ts
+++ b/src/parser/core/modules/EntityStatuses.ts
@@ -1,4 +1,4 @@
-import {BuffEvent, BuffStackEvent, Event} from 'fflogs'
+import {BuffEvent} from 'fflogs'
 import Module, {dependency} from 'parser/core/Module'
 import {FFLogsEventNormaliser} from './FFLogsEventNormaliser'
 import Invulnerability from './Invulnerability'
@@ -6,7 +6,7 @@ import Invulnerability from './Invulnerability'
 const APPLY = 'apply'
 const REMOVE = 'remove'
 
-interface StatusTrackingEvent extends BuffEvent {
+interface BuffTrackingEvent extends BuffEvent {
 	start: number,
 	end: number | null,
 	stacks: number,
@@ -28,20 +28,10 @@ interface StatusRangeEndpoint {
 
 export class EntityStatuses extends Module {
 	static handle = 'entityStatuses'
+	static debug = false
 
 	@dependency private invuln!: Invulnerability
 	@dependency private fflogsEvents!: FFLogsEventNormaliser
-
-	private statuses = new Map<number, StatusTrackingEvent[]>()
-	// -----
-	// Event handlers
-	// -----
-	protected init() {
-		// Buffs
-		this.addEventHook(['applybuff', 'applydebuff'], this.applyStatus)
-		this.addEventHook(['applybuffstack', 'applydebuffstack', 'removebuffstack', 'removedebuffstack'], this.updateStatusStack)
-		this.addEventHook(['removebuff', 'removedebuff'], this.removeStatus)
-	}
 
 	// -----
 	// API
@@ -51,161 +41,91 @@ export class EntityStatuses extends Module {
 	//       or is that a somewhere-else sort of thing...
 	getStatusUptime(statusId: number, onTargets: TODO, sourceId = this.parser.player.id) {
 		// Search for status maps on valid targets
-		const statusEvents: StatusTrackingEvent[] = []
-		Object.keys(onTargets).forEach((target: TODO) => {
-			const appliedStatuses = this.getEntityStatuses(Number(target)).filter((statusEvent) => {
-				return statusEvent.ability.guid === statusId && (statusEvent.sourceID === null || statusEvent.sourceID === sourceId)
-			})
-			statusEvents.push.apply(statusEvents, appliedStatuses)
-		})
-
-		const statusRanges: StatusRangeEndpoint[] = []
-		statusEvents.forEach(statusEvent => {
-			statusRanges.push(
-				{timestamp: statusEvent.start, type: APPLY, stackHistory: statusEvent.stackHistory},
-				{timestamp: statusEvent.end || this.parser.currentTimestamp, type: REMOVE, stackHistory: statusEvent.stackHistory},
-			)
-		})
+		const statusEvents: BuffTrackingEvent[] = Object.values(onTargets)
+			.reduce((statusEvents: BuffTrackingEvent[], target: TODO) => {
+				const appliedStatuses = target.buffs?.filter((statusEvent: BuffTrackingEvent) => {
+					return statusEvent.ability.guid === statusId && (statusEvent.sourceID === null || statusEvent.sourceID === sourceId)
+				})
+				return statusEvents.concat(appliedStatuses)
+			}, [])
 
 		let active = 0
 		let start: number | null = null
-		return statusRanges
+		return statusEvents
+			.reduce((statusRanges: StatusRangeEndpoint[], statusEvent) => {
+				return statusRanges.concat(this.getStatusRangesForEvent(statusEvent))
+			}, [])
 			.sort((a, b) => a.timestamp - b.timestamp)
 			.reduce((uptime, rangeEndpoint) => {
+				this.debug(`Status change ${rangeEndpoint.type} at time ${this.parser.formatTimestamp(rangeEndpoint.timestamp, 1)}`)
 				if (rangeEndpoint.type === APPLY) {
-					if (active === 0) { start = rangeEndpoint.timestamp }
+					if (active === 0) {
+						this.debug('Status not currently active on any targets, starting new window')
+						start = rangeEndpoint.timestamp
+					}
 					active++
 				}
 				if (rangeEndpoint.type === REMOVE) {
 					active--
-					if (active === 0) { uptime += rangeEndpoint.timestamp - (start ?? rangeEndpoint.timestamp)}
+					if (active === 0) {
+						uptime += rangeEndpoint.timestamp - (start ?? rangeEndpoint.timestamp)
+						this.debug(`Status ended on all targets.  Total uptime now ${this.parser.formatDuration(uptime, 1)}`)
+					}
 				}
 				return uptime
 			}, 0)
 	}
 
-	// Buff handlers
-	getBuffTarget(event: Event) {
-		// Ignore events that are not relevant to the player
-		if (!this.parser.byPlayer(event) && this.parser.toPlayer(event)) {
-			return null
-		}
-
-		return event.targetID
+	getStatusRangesForEvent(statusEvent: BuffTrackingEvent) {
+		this.debug(`Determining active time range for status ${statusEvent.ability.name} - started at: ${this.parser.formatTimestamp(statusEvent.start, 1)} - ended at: ${(statusEvent.end)? this.parser.formatTimestamp(statusEvent.end, 1) : ''}`)
+		return this.splitStatusEventForInvulns(statusEvent).reduce((statusRanges: StatusRangeEndpoint[], statusEvent) => {
+			statusRanges.push({timestamp: statusEvent.start, type: APPLY, stackHistory: statusEvent.stackHistory})
+			statusRanges.push({timestamp: statusEvent.end ?? this.parser.currentTimestamp, type: REMOVE, stackHistory: statusEvent.stackHistory})
+			return statusRanges
+		}, [])
 	}
 
-	getEntityStatuses(entity: number) {
-		if (!this.statuses.has(entity)) {
-			// No map entry for this entity yet, create a new entry
-			this.statuses.set(entity, [])
-		}
-
-		return this.statuses.get(entity) || []
-	}
-	applyStatus(event: BuffEvent) {
-		const isDebuff = event.type.includes('debuff')
-		const target = this.getBuffTarget(event)
-		if (!target) {
-			// No valid target or not relevant to the player, skip
-			return
-		}
-
-		this.getEntityStatuses(target).push({
-			...event,
-			start: event.timestamp,
-			end: null,
-			stacks: 1,
-			stackHistory: [{stacks: 1, timestamp: event.timestamp, invuln: false}],
-			isDebuff,
-		})
-	}
-
-	updateStatusStack(event: BuffStackEvent) {
-		const target = this.getBuffTarget(event)
-		if (!target) {
-			return
-		}
-
-		const statusEvent = this.getEntityStatuses(target).find(statusEvent =>
-			statusEvent.ability.guid === event.ability.guid &&
-			statusEvent.end === null,
-		)
-
-		if (!statusEvent) {
-			// yoink lmao
-			console.error('Buff stack updated while active buff wasn\'t known. Was this buff applied pre-combat? Maybe we should register the buff with start time as fight start when this happens, but it might also be a basic case of erroneous combatlog ordering.')
-			return
-		}
-
-		statusEvent.stacks = event.stack
-		statusEvent.stackHistory.push({stacks: event.stack, timestamp: event.timestamp, invuln: false})
-	}
-
-	removeStatus(event: BuffEvent) {
-		const isDebuff = event.type.includes('debuff')
-		const target = this.getBuffTarget(event)
-		if (!target) {
-			return
-		}
-
-		const targetStatuses = this.getEntityStatuses(target)
-		let statusEvent = targetStatuses.find(statusEvent =>
-			statusEvent.ability.guid === event.ability.guid &&
-			statusEvent.end === null,
-		)
-
-		// If there's no existing buff, fake one from the start of the fight
-		if (!statusEvent) {
-			const startTime = this.parser.fight.start_time
-			statusEvent = {
-				...event,
-				start: startTime,
-				end: null,
-				stacks: 1,
-				stackHistory: [{stacks: 1, timestamp: startTime, invuln: false}],
-				isDebuff,
-			}
-			targetStatuses.push(statusEvent)
-		}
-
-		// End the buff and trigger a final stack change
-		statusEvent.stacks = 0
-		statusEvent.end = event.timestamp
-		statusEvent.stackHistory.push({stacks: 0, timestamp: event.timestamp, invuln: false})
-
-		this.splitStatusRangeForInvulnEvents(statusEvent, target)
-	}
-
-	splitStatusRangeForInvulnEvents(statusEvent: StatusTrackingEvent, target: number) {
+	splitStatusEventForInvulns(statusEvent: BuffTrackingEvent) {
+		const eventToAdjust = {...statusEvent}
+		const adjustedEvents = [eventToAdjust]
 		if (!statusEvent.end) {
 			console.error(`Unexpected error: Attempting to check invuln events for an incomplete status event.  Event timestamp: ${statusEvent.timestamp} | Ability name: ${statusEvent.ability.name}`)
-			return
+			return adjustedEvents
 		}
-		const statusEnd = statusEvent.end!
-		const invulns = this.invuln.getInvulns(String(target), statusEvent.start, statusEvent.end, 'invulnerable')
+		const target = String(statusEvent.targetID)
+		const invulns = this.invuln.getInvulns(target, statusEvent.start, statusEvent.end, 'invulnerable')
 
 		invulns.forEach((invuln: TODO) => {
-			if (invuln.end < statusEnd) {
-				// Invuln ended before the status ended - create a second status for the time after the invuln ended
-				const newStackHistory = statusEvent.stackHistory.slice(0, -1)
-				const stacksBeforeInvuln = newStackHistory[newStackHistory.length - 1].stacks
-				newStackHistory.splice(-1, 1,
-					{stacks: 0, timestamp: invuln.start, invuln: true},
-					{stacks: stacksBeforeInvuln, timestamp: invuln.end, invuln: false},
-					{stacks: 0, timestamp: statusEnd, invuln: false})
+			this.debug(`Target was detected as invulnerable during duration of status.  Invulnerable from ${this.parser.formatTimestamp(invuln.start, 1)} to ${this.parser.formatTimestamp(invuln.end, 1)}`)
+			if (invuln.start < statusEvent.start && invuln.end >= statusEvent.start) {
+				this.debug('Invuln clipped the start of the range - changing beginning of event')
+				eventToAdjust.start = invuln.end
+			} else {
+				this.debug('Invuln clipped the end of the range or split the range - changing end of event')
+				eventToAdjust.end = invuln.start
+				eventToAdjust.stackHistory.splice(-1, 1, {stacks: 0, timestamp: invuln.start, invuln: true})
 
-				this.getEntityStatuses(target).push({
-					...statusEvent,
-					start: invuln.end,
-					end: statusEvent.end,
-					stackHistory: newStackHistory,
-				})
+				if (invuln.end < eventToAdjust.end!) {
+					this.debug('Invuln split the range - synthesizing second event for status time after invuln')
+					// Invuln ended before the status ended - create a second status for the time after the invuln ended
+					const newStackHistory = statusEvent.stackHistory.slice(0, -1)
+					const stacksBeforeInvuln = newStackHistory[newStackHistory.length - 1].stacks
+					newStackHistory.splice(-1, 1,
+						{stacks: 0, timestamp: invuln.start, invuln: true},
+						{stacks: stacksBeforeInvuln, timestamp: invuln.end, invuln: false},
+						{stacks: 0, timestamp: statusEvent.end!, invuln: false})
 
+					adjustedEvents.push({
+						...statusEvent,
+						start: invuln.end,
+						end: statusEvent.end,
+						stackHistory: newStackHistory,
+					})
+				}
 			}
-
-			// Clip end of original status to beginning of invuln
-			statusEvent.end = invuln.start
-			statusEvent.stackHistory.splice(-1, 1, {stacks: 0, timestamp: invuln.start, invuln: true})
 		})
+
+		adjustedEvents.forEach(event => this.debug(`Active time after adjusting for invulns - start at: ${this.parser.formatTimestamp(event.start)} - end at: ${this.parser.formatTimestamp(event.end!)}`))
+		return adjustedEvents
 	}
 }

--- a/src/parser/core/modules/EntityStatuses.ts
+++ b/src/parser/core/modules/EntityStatuses.ts
@@ -65,9 +65,9 @@ export class EntityStatuses extends Module {
 	}
 
 	getSelectedStatusEvents = (statusId: number, sourceId: number, targetBuffs: BuffTrackingEvent[]) => {
-		return targetBuffs.filter((statusEvent: BuffTrackingEvent) =>
-			statusEvent.ability.guid === statusId && (statusEvent.sourceID === null || statusEvent.sourceID === sourceId)
-		)
+		return targetBuffs.filter((statusEvent: BuffTrackingEvent) => {
+			return statusEvent.ability.guid === statusId && (statusEvent.sourceID === null || statusEvent.sourceID === sourceId)
+		})
 	}
 
 	getUptime = (statusEvents: BuffTrackingEvent[]) => {

--- a/src/parser/core/modules/EntityStatuses.ts
+++ b/src/parser/core/modules/EntityStatuses.ts
@@ -1,0 +1,211 @@
+import {BuffEvent, BuffStackEvent, Event} from 'fflogs'
+import Module, {dependency} from 'parser/core/Module'
+import {FFLogsEventNormaliser} from './FFLogsEventNormaliser'
+import Invulnerability from './Invulnerability'
+
+const APPLY = 'apply'
+const REMOVE = 'remove'
+
+interface StatusTrackingEvent extends BuffEvent {
+	start: number,
+	end: number | null,
+	stacks: number,
+	stackHistory: StackHistoryEvent[],
+	isDebuff: boolean,
+}
+
+interface StackHistoryEvent {
+	stacks: number,
+	timestamp: number,
+	invuln: boolean,
+}
+
+interface StatusRangeEndpoint {
+	timestamp: number,
+	type: 'apply' | 'remove',
+	stackHistory: StackHistoryEvent[],
+}
+
+export class EntityStatuses extends Module {
+	static handle = 'entityStatuses'
+
+	@dependency private invuln!: Invulnerability
+	@dependency private fflogsEvents!: FFLogsEventNormaliser
+
+	private statuses = new Map<number, StatusTrackingEvent[]>()
+	// -----
+	// Event handlers
+	// -----
+	protected init() {
+		// Buffs
+		this.addEventHook(['applybuff', 'applydebuff'], this.applyStatus)
+		this.addEventHook(['applybuffstack', 'applydebuffstack', 'removebuffstack', 'removedebuffstack'], this.updateStatusStack)
+		this.addEventHook(['removebuff', 'removedebuff'], this.removeStatus)
+	}
+
+	// -----
+	// API
+	// -----
+	// TODO: This implementation which I've shamelessly stolen seems to only track overall
+	//       uptime, ignoring potential gains from multidotting, etc. Should that be in here,
+	//       or is that a somewhere-else sort of thing...
+	getStatusUptime(statusId: number, onTargets: TODO, sourceId = this.parser.player.id) {
+		// Search for status maps on valid targets
+		const statusEvents: StatusTrackingEvent[] = []
+		Object.keys(onTargets).forEach((target: TODO) => {
+			const appliedStatuses = this.getEntityStatuses(Number(target)).filter((statusEvent) => {
+				return statusEvent.ability.guid === statusId && (statusEvent.sourceID === null || statusEvent.sourceID === sourceId)
+			})
+			statusEvents.push.apply(statusEvents, appliedStatuses)
+		})
+
+		const statusRanges: StatusRangeEndpoint[] = []
+		statusEvents.forEach(statusEvent => {
+			statusRanges.push(
+				{timestamp: statusEvent.start, type: APPLY, stackHistory: statusEvent.stackHistory},
+				{timestamp: statusEvent.end || this.parser.currentTimestamp, type: REMOVE, stackHistory: statusEvent.stackHistory},
+			)
+		})
+
+		let active = 0
+		let start: number | null = null
+		return statusRanges
+			.sort((a, b) => a.timestamp - b.timestamp)
+			.reduce((uptime, rangeEndpoint) => {
+				if (rangeEndpoint.type === APPLY) {
+					if (active === 0) { start = rangeEndpoint.timestamp }
+					active++
+				}
+				if (rangeEndpoint.type === REMOVE) {
+					active--
+					if (active === 0) { uptime += rangeEndpoint.timestamp - (start ?? rangeEndpoint.timestamp)}
+				}
+				return uptime
+			}, 0)
+	}
+
+	// Buff handlers
+	getBuffTarget(event: Event) {
+		// Ignore events that are not relevant to the player
+		if (!this.parser.byPlayer(event) && this.parser.toPlayer(event)) {
+			return null
+		}
+
+		return event.targetID
+	}
+
+	getEntityStatuses(entity: number) {
+		if (!this.statuses.has(entity)) {
+			// No map entry for this entity yet, create a new entry
+			this.statuses.set(entity, [])
+		}
+
+		return this.statuses.get(entity) || []
+	}
+	applyStatus(event: BuffEvent) {
+		const isDebuff = event.type.includes('debuff')
+		const target = this.getBuffTarget(event)
+		if (!target) {
+			// No valid target or not relevant to the player, skip
+			return
+		}
+
+		this.getEntityStatuses(target).push({
+			...event,
+			start: event.timestamp,
+			end: null,
+			stacks: 1,
+			stackHistory: [{stacks: 1, timestamp: event.timestamp, invuln: false}],
+			isDebuff,
+		})
+	}
+
+	updateStatusStack(event: BuffStackEvent) {
+		const target = this.getBuffTarget(event)
+		if (!target) {
+			return
+		}
+
+		const statusEvent = this.getEntityStatuses(target).find(statusEvent =>
+			statusEvent.ability.guid === event.ability.guid &&
+			statusEvent.end === null,
+		)
+
+		if (!statusEvent) {
+			// yoink lmao
+			console.error('Buff stack updated while active buff wasn\'t known. Was this buff applied pre-combat? Maybe we should register the buff with start time as fight start when this happens, but it might also be a basic case of erroneous combatlog ordering.')
+			return
+		}
+
+		statusEvent.stacks = event.stack
+		statusEvent.stackHistory.push({stacks: event.stack, timestamp: event.timestamp, invuln: false})
+	}
+
+	removeStatus(event: BuffEvent) {
+		const isDebuff = event.type.includes('debuff')
+		const target = this.getBuffTarget(event)
+		if (!target) {
+			return
+		}
+
+		const targetStatuses = this.getEntityStatuses(target)
+		let statusEvent = targetStatuses.find(statusEvent =>
+			statusEvent.ability.guid === event.ability.guid &&
+			statusEvent.end === null,
+		)
+
+		// If there's no existing buff, fake one from the start of the fight
+		if (!statusEvent) {
+			const startTime = this.parser.fight.start_time
+			statusEvent = {
+				...event,
+				start: startTime,
+				end: null,
+				stacks: 1,
+				stackHistory: [{stacks: 1, timestamp: startTime, invuln: false}],
+				isDebuff,
+			}
+			targetStatuses.push(statusEvent)
+		}
+
+		// End the buff and trigger a final stack change
+		statusEvent.stacks = 0
+		statusEvent.end = event.timestamp
+		statusEvent.stackHistory.push({stacks: 0, timestamp: event.timestamp, invuln: false})
+
+		this.splitStatusRangeForInvulnEvents(statusEvent, target)
+	}
+
+	splitStatusRangeForInvulnEvents(statusEvent: StatusTrackingEvent, target: number) {
+		if (!statusEvent.end) {
+			console.error(`Unexpected error: Attempting to check invuln events for an incomplete status event.  Event timestamp: ${statusEvent.timestamp} | Ability name: ${statusEvent.ability.name}`)
+			return
+		}
+		const statusEnd = statusEvent.end!
+		const invulns = this.invuln.getInvulns(String(target), statusEvent.start, statusEvent.end, 'invulnerable')
+
+		invulns.forEach((invuln: TODO) => {
+			if (invuln.end < statusEnd) {
+				// Invuln ended before the status ended - create a second status for the time after the invuln ended
+				const newStackHistory = statusEvent.stackHistory.slice(0, -1)
+				const stacksBeforeInvuln = newStackHistory[newStackHistory.length - 1].stacks
+				newStackHistory.splice(-1, 1,
+					{stacks: 0, timestamp: invuln.start, invuln: true},
+					{stacks: stacksBeforeInvuln, timestamp: invuln.end, invuln: false},
+					{stacks: 0, timestamp: statusEnd, invuln: false})
+
+				this.getEntityStatuses(target).push({
+					...statusEvent,
+					start: invuln.end,
+					end: statusEvent.end,
+					stackHistory: newStackHistory,
+				})
+
+			}
+
+			// Clip end of original status to beginning of invuln
+			statusEvent.end = invuln.start
+			statusEvent.stackHistory.splice(-1, 1, {stacks: 0, timestamp: invuln.start, invuln: true})
+		})
+	}
+}

--- a/src/parser/core/modules/EntityStatuses.ts
+++ b/src/parser/core/modules/EntityStatuses.ts
@@ -36,7 +36,7 @@ interface StatusInfoTracking {
 
 export class EntityStatuses extends Module {
 	static handle = 'entityStatuses'
-	static debug = true
+	static debug = false
 
 	@dependency private invuln!: Invulnerability
 	@dependency private data!: Data

--- a/src/parser/core/modules/EntityStatuses.ts
+++ b/src/parser/core/modules/EntityStatuses.ts
@@ -128,6 +128,7 @@ export class EntityStatuses extends Module {
 					adjustedEvents.push({
 						...statusEvent,
 						start: invuln.end,
+						lastRefreshed: invuln.end,
 						end: statusEvent.end,
 						stackHistory: newStackHistory,
 					})

--- a/src/parser/core/modules/index.js
+++ b/src/parser/core/modules/index.js
@@ -13,6 +13,7 @@ import {Data} from './Data'
 import Death from './Death'
 import Downtime from './Downtime'
 import Enemies from './Enemies'
+import {EntityStatuses} from './EntityStatuses'
 import {FFLogsEventNormaliser} from './FFLogsEventNormaliser'
 import GlobalCooldown from './GlobalCooldown'
 import HitType from './HitType'
@@ -44,6 +45,7 @@ export default [
 	Death,
 	Downtime,
 	Enemies,
+	EntityStatuses,
 	FFLogsEventNormaliser,
 	GlobalCooldown,
 	HitType,

--- a/src/parser/jobs/blm/modules/RotationWatchdog.tsx
+++ b/src/parser/jobs/blm/modules/RotationWatchdog.tsx
@@ -1,6 +1,5 @@
 import {t} from '@lingui/macro'
 import {Plural, Trans} from '@lingui/react'
-import _ from 'lodash'
 import React, {Fragment} from 'react'
 import {Icon, Message} from 'semantic-ui-react'
 
@@ -19,6 +18,7 @@ import Suggestions, {SEVERITY, Suggestion, TieredSuggestion} from 'parser/core/m
 import Timeline from 'parser/core/modules/Timeline'
 import UnableToAct from 'parser/core/modules/UnableToAct'
 
+import {EntityStatuses} from 'parser/core/modules/EntityStatuses'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 import {FIRE_SPELLS} from './Elements'
 import {BLM_GAUGE_EVENT} from './Gauge'
@@ -137,7 +137,7 @@ class Cycle {
 	}
 
 	constructor(start: number, gaugeState: GaugeState) {
-		this.startTime = start,
+		this.startTime = start
 		// Object.assign because this needs to be a by-value assignment, not by-reference
 		this.gaugeStateBeforeFire = Object.assign(this.gaugeStateBeforeFire, gaugeState)
 	}
@@ -181,6 +181,7 @@ export default class RotationWatchdog extends Module {
 	@dependency private timeline!: Timeline
 	@dependency private combatants!: Combatants
 	@dependency private unableToAct!: UnableToAct
+	@dependency private entityStatuses!: EntityStatuses
 
 	private currentGaugeState: GaugeState = new GaugeState()
 	private currentRotation: Cycle = new Cycle(this.parser.fight.start_time, this.currentGaugeState)
@@ -283,9 +284,9 @@ export default class RotationWatchdog extends Module {
 		this.currentRotation.errorCode = CYCLE_ERRORS.DIED
 	}
 
-	// Get the uptime percentage for the Thunder status defbuff
+	// Get the uptime percentage for the Thunder status debuff
 	private getThunderUptime() {
-		const statusTime = this.enemies.getStatusUptime(STATUSES.THUNDER_III.id)
+		const statusTime = this.entityStatuses.getStatusUptime(STATUSES.THUNDER_III.id, this.enemies.getEntities())
 		const uptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusTime / uptime) * 100

--- a/src/parser/jobs/brd/modules/Util.js
+++ b/src/parser/jobs/brd/modules/Util.js
@@ -12,6 +12,7 @@ export default class Util extends Module {
 		'combatants',
 		'downtime',
 		'enemies',
+		'entityStatuses',
 		'invuln',
 		'timeline',
 	]
@@ -21,14 +22,14 @@ export default class Util extends Module {
 	}
 
 	getDebuffUptime(status) {
-		const statusTime = this.enemies.getStatusUptime(status.id)
+		const statusTime = this.entityStatuses.getStatusUptime(status.id, this.enemies.getEntities())
 		const uptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusTime / uptime) * 100
 	}
 
 	getBuffUptime(status) {
-		const statusTime = this.combatants.getStatusUptime(status.id, this.parser.player.id)
+		const statusTime = this.entityStatuses.getStatusUptime(status.id, this.combatants.getEntities())
 		const uptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusTime / uptime) * 100

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -18,6 +18,7 @@ import Invulnerability from 'parser/core/modules/Invulnerability'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import Timeline from 'parser/core/modules/Timeline'
 
+import {EntityStatuses} from 'parser/core/modules/EntityStatuses'
 import {DEFAULT_SEVERITY_TIERS, FINISHES, STANDARD_FINISHES, TECHNICAL_FINISHES} from '../CommonData'
 import DISPLAY_ORDER from '../DISPLAY_ORDER'
 
@@ -97,6 +98,7 @@ export default class DirtyDancing extends Module {
 	@dependency private combatants!: Combatants
 	@dependency private timeline!: Timeline
 	@dependency private downtime!: Downtime
+	@dependency private entityStatuses!: EntityStatuses
 
 	private danceHistory: Dance[] = []
 	private missedDances = 0
@@ -201,7 +203,7 @@ export default class DirtyDancing extends Module {
 
 	private getStandardFinishUptimePercent() {
 		// Exclude downtime from both the status time and expected uptime
-		const statusTime = this.combatants.getStatusUptime(STATUSES.STANDARD_FINISH.id, this.parser.player.id) - this.downtime.getDowntime()
+		const statusTime = this.entityStatuses.getStatusUptime(STATUSES.STANDARD_FINISH.id, this.combatants.getEntities()) - this.downtime.getDowntime()
 		const uptime = this.parser.fightDuration - this.downtime.getDowntime()
 
 		return (statusTime / uptime) * 100

--- a/src/parser/jobs/drg/modules/Buffs.js
+++ b/src/parser/jobs/drg/modules/Buffs.js
@@ -47,6 +47,7 @@ export default class Buffs extends Module {
 	static dependencies = [
 		'checklist',
 		'combatants',
+		'entityStatuses',
 		'invuln',
 		'suggestions',
 	]
@@ -133,7 +134,7 @@ export default class Buffs extends Module {
 	}
 
 	_getDisembowelUptimePercent() {
-		const statusUptime = this.combatants.getStatusUptime(STATUSES.DISEMBOWEL.id)
+		const statusUptime = this.entityStatuses.getStatusUptime(STATUSES.DISEMBOWEL.id, this.combatants.getEntities())
 		const fightUptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 		return (statusUptime / fightUptime) * 100
 	}

--- a/src/parser/jobs/mnk/modules/Fists.tsx
+++ b/src/parser/jobs/mnk/modules/Fists.tsx
@@ -15,6 +15,7 @@ import Combatants from 'parser/core/modules/Combatants'
 import {PieChartStatistic, Statistics} from 'parser/core/modules/Statistics'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 
+import {EntityStatuses} from '../../../core/modules/EntityStatuses'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 import Gauge, {MAX_FASTER, MAX_STACKS} from './Gauge'
 
@@ -82,6 +83,7 @@ export default class Fists extends Module {
 	@dependency private gauge!: Gauge
 	@dependency private statistics!: Statistics
 	@dependency private suggestions!: Suggestions
+	@dependency private entityStatuses!: EntityStatuses
 
 	private fistory: Fist[] = []
 	private foulWinds: number = 0
@@ -238,7 +240,7 @@ export default class Fists extends Module {
 	}
 
 	getFistUptimePercent(fistId: number): string {
-		const statusUptime = this.combatants.getStatusUptime(fistId)
+		const statusUptime = this.entityStatuses.getStatusUptime(fistId, this.combatants.getEntities())
 
 		return ((statusUptime / this.parser.fightDuration) * 100).toFixed(2)
 	}

--- a/src/parser/jobs/mnk/modules/TwinSnakes.tsx
+++ b/src/parser/jobs/mnk/modules/TwinSnakes.tsx
@@ -1,20 +1,17 @@
 import {Plural, Trans} from '@lingui/react'
-import React from 'react'
-
 import {ActionLink, StatusLink} from 'components/ui/DbLink'
 import {getDataBy} from 'data'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-
 import {BuffEvent, CastEvent} from 'fflogs'
 import Module, {dependency} from 'parser/core/Module'
 import Checklist, {Requirement, Rule} from 'parser/core/modules/Checklist'
 import Combatants from 'parser/core/modules/Combatants'
 import Enemies from 'parser/core/modules/Enemies'
+import {EntityStatuses} from 'parser/core/modules/EntityStatuses'
 import Invulnerability from 'parser/core/modules/Invulnerability'
 import Suggestions, {SEVERITY, Suggestion, TieredSuggestion} from 'parser/core/modules/Suggestions'
-
-import {EntityStatuses} from '../../../core/modules/EntityStatuses'
+import React from 'react'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 // Expected time to drop Twin in GL4 (basically part way thru previous GCD)

--- a/src/parser/jobs/mnk/modules/TwinSnakes.tsx
+++ b/src/parser/jobs/mnk/modules/TwinSnakes.tsx
@@ -14,6 +14,7 @@ import Enemies from 'parser/core/modules/Enemies'
 import Invulnerability from 'parser/core/modules/Invulnerability'
 import Suggestions, {SEVERITY, Suggestion, TieredSuggestion} from 'parser/core/modules/Suggestions'
 
+import {EntityStatuses} from '../../../core/modules/EntityStatuses'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 // Expected time to drop Twin in GL4 (basically part way thru previous GCD)
@@ -48,6 +49,7 @@ export default class TwinSnakes extends Module {
 	@dependency private enemies!: Enemies
 	@dependency private invuln!: Invulnerability
 	@dependency private suggestions!: Suggestions
+	@dependency private entityStatuses!: EntityStatuses
 
 	private history: TwinState[] = []
 	private twinSnake?: TwinState
@@ -211,7 +213,7 @@ export default class TwinSnakes extends Module {
 	}
 
 	private getBuffUptimePercent(statusId: number): number {
-		const statusUptime = this.combatants.getStatusUptime(statusId, this.parser.player.id)
+		const statusUptime = this.entityStatuses.getStatusUptime(statusId, this.combatants.getEntities())
 		const fightUptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusUptime / fightUptime) * 100

--- a/src/parser/jobs/sam/modules/Buffs.js
+++ b/src/parser/jobs/sam/modules/Buffs.js
@@ -13,6 +13,7 @@ export default class Buffs extends Module {
 	static dependencies = [
 		'checklist',
 		'combatants',
+		'entityStatuses',
 		'invuln',
 	]
 
@@ -43,7 +44,7 @@ export default class Buffs extends Module {
 	}
 
 	getUptimePercent(StatusId) {
-		const statusUptime = this.combatants.getStatusUptime((StatusId), this.parser.player.id)
+		const statusUptime = this.entityStatuses.getStatusUptime((StatusId), this.combatants.getEntities())
 		const fightUptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusUptime / fightUptime) * 100

--- a/src/parser/jobs/sam/modules/Higanbana.js
+++ b/src/parser/jobs/sam/modules/Higanbana.js
@@ -23,6 +23,7 @@ export default class Higanbana extends Module {
 	static dependencies = [
 		'checklist',
 		'enemies',
+		'entityStatuses',
 		'invuln',
 		'suggestions',
 	]
@@ -104,7 +105,7 @@ export default class Higanbana extends Module {
 		}))
 	}
 	getDotUptimePercent(statusId) {
-		const statusUptime = this.enemies.getStatusUptime(statusId)
+		const statusUptime = this.entityStatuses.getStatusUptime(statusId, this.enemies.getEntities())
 		const fightDuration = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusUptime / fightDuration) * 100

--- a/src/parser/jobs/smn/modules/DoTs.js
+++ b/src/parser/jobs/smn/modules/DoTs.js
@@ -34,6 +34,7 @@ export default class DoTs extends Module {
 	static dependencies = [
 		'checklist',
 		'enemies',
+		'entityStatuses',
 		'gauge',
 		'invuln',
 		'suggestions',
@@ -146,7 +147,7 @@ export default class DoTs extends Module {
 	}
 
 	getDotUptimePercent(statusId) {
-		const statusUptime = this.enemies.getStatusUptime(statusId)
+		const statusUptime = this.entityStatuses.getStatusUptime(statusId, this.enemies.getEntities())
 		const fightDuration = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusUptime / fightDuration) * 100

--- a/src/parser/jobs/war/modules/StormsEye.js
+++ b/src/parser/jobs/war/modules/StormsEye.js
@@ -16,6 +16,7 @@ export default class StormsEye extends Module {
 	static dependencies = [
 		'checklist',
 		'combatants',
+		'entityStatuses',
 		'invuln',
 		'suggestions',
 	]
@@ -80,7 +81,7 @@ export default class StormsEye extends Module {
 
 	//
 	getUptimePercent() {
-		const statusUptime = this.combatants.getStatusUptime(STATUSES.STORMS_EYE.id, this.parser.player.id)
+		const statusUptime = this.entityStatuses.getStatusUptime(STATUSES.STORMS_EYE.id, this.combatants.getEntities())
 		const fightUptime = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusUptime / fightUptime) * 100

--- a/src/parser/jobs/whm/modules/DoTs.js
+++ b/src/parser/jobs/whm/modules/DoTs.js
@@ -28,6 +28,7 @@ export default class DoTs extends Module {
 	static dependencies = [
 		'checklist',
 		'enemies',
+		'entityStatuses',
 		'invuln',
 		'suggestions',
 	]
@@ -102,7 +103,7 @@ export default class DoTs extends Module {
 	}
 
 	getDotUptimePercent(statusId) {
-		const statusUptime = this.enemies.getStatusUptime(statusId)
+		const statusUptime = this.entityStatuses.getStatusUptime(statusId, this.enemies.getEntities())
 		const fightDuration = this.parser.fightDuration - this.invuln.getInvulnerableUptime()
 
 		return (statusUptime / fightDuration) * 100


### PR DESCRIPTION
This is in support of #670 and the effort to switch to targetability events for invulnerability.  This should break the dependency from entities to invulnerability, and resolve the circular dependency created from switching to targetability events.  

I only lifted out the getStatusUptime method (and duplicated some of the buff tracking) because the existing Entities module is populating entity.buffs for each processed entity, which some modules depend on via entity.hasStatus (Bard Barrage tracking, for one).

I've reviewed a few jobs and confirmed that calculated DoT uptime is exactly the same for most of them.  White Mage DoT tracking on Titan is coming up with (very slightly higher) different numbers, though on fights like Leviathan it's exactly the same, so there seems to be some interaction with Titan Jails that this refactor is changing; not sure if it's something severe enough to be alarmed about or not.