### PR TITLE
[Bugfix] Added second ACTIONS entry for Ten because SE things

### DIFF
--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -40,6 +40,15 @@ export const NIN = ensureActions({
 		gcdRecast: 0.5,
 	},
 
+	TEN_KASSATSU: {
+		id: 18805,
+		name: 'Ten',
+		icon: 'https://xivapi.com/i/002000/002901.png',
+		onGcd: true,
+		cooldown: 20,
+		gcdRecast: 0.5,
+	},
+
 	CHI: {
 		id: 18806,
 		name: 'Chi',

--- a/src/parser/jobs/nin/modules/TrickAttackUsage.js
+++ b/src/parser/jobs/nin/modules/TrickAttackUsage.js
@@ -32,7 +32,7 @@ export default class TrickAttackUsage extends Module {
 	_onCast(event) {
 		const action = getDataBy(ACTIONS, 'id', event.ability.guid)
 		if (action && action.onGcd && !(
-			action.id === ACTIONS.TEN.id || action.id === ACTIONS.CHI.id || action.id === ACTIONS.JIN.id)) {
+			action.id === ACTIONS.TEN.id || action.id === ACTIONS.TEN_KASSATSU.id || action.id === ACTIONS.CHI.id || action.id === ACTIONS.JIN.id)) {
 			// Don't count the individual mudras as GCDs for this - they'll make the count screw if Suiton wasn't set up pre-pull
 			this._gcdCount++
 		}


### PR DESCRIPTION
Yeah so apparently there are two versions of Ten that actually get used but not of Chi or Jin? Neat, I guess. Except it really isn't. But whatevs. This should fix the timeline so it actually shows the Ten cast on Hyosho now.