### PR TITLE
DNC - Count/Show Players Buffed by Tech Finish

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -318,6 +318,7 @@
   "dnc.procs.suggestions.drops.why": "Du hast {droppedProcs, plural, one {# Proc} other {# Procs}} verloren",
   "dnc.procs.suggestions.overwrite.content": "Vermeide deine Procs zu überschreiben. Geprocte Aktionen sind stärker als deine reguläre Angriffskombo, daher büßt du beim Überschreiben hohen DPS ein.",
   "dnc.procs.suggestions.overwrite.why": "Du hast {0, plural, one {# proc} other {# procs}} überschrieben",
+  "dnc.technicalities.rotation-table.header.buffed": "",
   "dnc.technicalities.rotation-table.header.missed": "<0/> rechtzeitig benutzt?",
   "dnc.technicalities.rotation-table.header.pooled": "<0/> angesammelt?",
   "dnc.technicalities.suggestions.bad-devilments.content": "<0/> außerhalb deiner <1/>-Phasen zu nutzen führt zu vermeidbarem Schadensverlust. Von gewissen speziellen Openersituationen abgesehen, solltest du grundsätzlich <2/> am Anfang von <3/>-Phasen nutzen.",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -318,6 +318,7 @@
   "dnc.procs.suggestions.drops.why": "You dropped {droppedProcs, plural, one {# proc} other {# procs}}",
   "dnc.procs.suggestions.overwrite.content": "Avoid overwriting your procs. Your proc actions are stronger than your normal combo, so overwriting them is a significant DPS loss.",
   "dnc.procs.suggestions.overwrite.why": "You overwrote {0, plural, one {# proc} other {# procs}}",
+  "dnc.technicalities.rotation-table.header.buffed": "Players Buffed",
   "dnc.technicalities.rotation-table.header.missed": "<0/> On Time?",
   "dnc.technicalities.rotation-table.header.pooled": "<0/> Pooled?",
   "dnc.technicalities.suggestions.bad-devilments.content": "Using <0/> outside of your <1/> windows leads to an avoidable loss in DPS. Aside from certain opener situations, you should be using <2/> at the beginning of your <3/> windows.",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -318,6 +318,7 @@
   "dnc.procs.suggestions.drops.why": "Vous avez laisser tombé{droppedProcs, plural,one {# proc}other {# procs}}",
   "dnc.procs.suggestions.overwrite.content": "Évitez d' écraser vos procs trop vite. Vos actions proc sont plus fortes que votre combo normal, donc les écraser est une perte significative de DPS.",
   "dnc.procs.suggestions.overwrite.why": "Vous avez écrasé {0, plural,one {# proc}other {# procs}}",
+  "dnc.technicalities.rotation-table.header.buffed": "",
   "dnc.technicalities.rotation-table.header.missed": "<0/> dans les temps ?",
   "dnc.technicalities.rotation-table.header.pooled": "<0/> Pris l'aggro avant le tank ?",
   "dnc.technicalities.suggestions.bad-devilments.content": "L'utilisation de <0/> en dehors de vos fenêtres <1/> entraîne une perte évitable de DPS. En dehors de certaines situations d'ouverture, vous devriez utiliser <2/> au début de vos fenêtres <3/>.",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -318,6 +318,7 @@
   "dnc.procs.suggestions.drops.why": "",
   "dnc.procs.suggestions.overwrite.content": "",
   "dnc.procs.suggestions.overwrite.why": "",
+  "dnc.technicalities.rotation-table.header.buffed": "",
   "dnc.technicalities.rotation-table.header.missed": "",
   "dnc.technicalities.rotation-table.header.pooled": "",
   "dnc.technicalities.suggestions.bad-devilments.content": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -318,6 +318,7 @@
   "dnc.procs.suggestions.drops.why": "{droppedProcs, plural, other {# 회}}의 프록을 잃었습니다.",
   "dnc.procs.suggestions.overwrite.content": "프록이 이미 뜬 상태에서 덮어 씌워지지 않도록 반드시 사용하십시오. 프록에서 파생되는 기술들은 기본 콤보 기술보다 더 강력하므로 덮어 씌워지는것은 당연한 딜 손해입니다.",
   "dnc.procs.suggestions.overwrite.why": "프록을 {0, plural, one {#회} other {#회}} 덧썼습니다",
+  "dnc.technicalities.rotation-table.header.buffed": "",
   "dnc.technicalities.rotation-table.header.missed": "<0/>이 제떄 사용되었습니까?",
   "dnc.technicalities.rotation-table.header.pooled": "<0/>이 축적되었습니까?",
   "dnc.technicalities.suggestions.bad-devilments.content": "<1/> 구간외 <0/>를 사용할시 반드시 딜 손해를 받습니다. 전투에 다른 오프닝같은 특별한 상황이 아니라면 <3/> 구간에 진입할떄마다 <2/>를 사용하십시오.",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -318,6 +318,7 @@
   "dnc.procs.suggestions.drops.why": "你损失了  {droppedProcs, plural, one {# 次触发} other {# 次触发}}",
   "dnc.procs.suggestions.overwrite.content": "避免刷新触发。触发的威力高于普通连击，被刷新是很严重的DPS损失。",
   "dnc.procs.suggestions.overwrite.why": "{0, plural, one {# 次触发} other {# 次触发}}被覆盖掉",
+  "dnc.technicalities.rotation-table.header.buffed": "",
   "dnc.technicalities.rotation-table.header.missed": "<0/>是否准时？",
   "dnc.technicalities.rotation-table.header.pooled": "<0/>堆积了？",
   "dnc.technicalities.suggestions.bad-devilments.content": "在<1/>的持续时间外用<0/>会造成dps损失。除了部分特殊的开场起手，你都应该在<3/>的开始的时候用<2/>。",

--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -56,4 +56,9 @@ export const changelog = [
 		Changes: () => <>Updated dropped proc suggestion wording, and fixed a bug with broken combo allowances under Technical Finish.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2019-12-09'),
+		Changes: () => <>Technical Finish windows now display how many players were affected, and windows sourced only to other dancers in the party are hidden.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -58,7 +58,7 @@ export const changelog = [
 	},
 	{
 		date: new Date('2019-12-09'),
-		Changes: () => <>Technical Finish windows now display how many players were affected, and windows sourced only to other dancers in the party are hidden.</>,
+		Changes: () => <>Technical Finish windows now display how many players were affected by your buff.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 ]

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -19,6 +19,7 @@ import Timeline from 'parser/core/modules/Timeline'
 import DISPLAY_ORDER from '../DISPLAY_ORDER'
 import FeatherGauge from './FeatherGauge'
 
+const DEBUG_SHOW_ALL_WINDOWS = false && process.env.NODE_ENV !== 'production'
 
 // Harsher than the default since you'll only have 4-5 total windows anyways
 const TECHNICAL_SEVERITY_TIERS = {
@@ -273,7 +274,7 @@ export default class Technicalities extends Module {
 						accessor: 'buffed',
 					},
 				]}
-				data={this.history.map(window => {
+				data={this.history.filter(window => window.playersBuffed > 0 || DEBUG_SHOW_ALL_WINDOWS).map(window => {
 					return ({
 						start: window.start - this.parser.fight.start_time,
 						end: window.end != null ?

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -19,6 +19,7 @@ import Timeline from 'parser/core/modules/Timeline'
 import DISPLAY_ORDER from '../DISPLAY_ORDER'
 import FeatherGauge from './FeatherGauge'
 
+
 // Harsher than the default since you'll only have 4-5 total windows anyways
 const TECHNICAL_SEVERITY_TIERS = {
 	1: SEVERITY.MINOR,
@@ -267,6 +268,10 @@ export default class Technicalities extends Module {
 						header: <Trans id="dnc.technicalities.rotation-table.header.pooled"><ActionLink showName={false} {...ACTIONS.FAN_DANCE}/> Pooled?</Trans>,
 						accessor: 'pooled',
 					},
+					{
+						header: <Trans id="dnc.technicalities.rotation-table.header.buffed">Players Buffed</Trans>,
+						accessor: 'buffed',
+					},
 				]}
 				data={this.history.map(window => {
 					return ({
@@ -275,8 +280,9 @@ export default class Technicalities extends Module {
 							window.end - this.parser.fight.start_time :
 							window.start - this.parser.fight.start_time,
 							notesMap: {
-								timely: <>{this.getNotesIcon(!window.timelyDevilment)}</>,
-								pooled: <>{this.getNotesIcon(window.poolingProblem)}</>,
+								timely: <>{window.playersBuffed ? this.getNotesIcon(!window.timelyDevilment): 'N/A'}</>,
+								pooled: <>{window.playersBuffed ? this.getNotesIcon(window.poolingProblem): 'N/A'}</>,
+								buffed: <>{window.playersBuffed ? window.playersBuffed : 'N/A'}</>,
 							},
 						rotation: window.rotation,
 					})

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -19,8 +19,6 @@ import Timeline from 'parser/core/modules/Timeline'
 import DISPLAY_ORDER from '../DISPLAY_ORDER'
 import FeatherGauge from './FeatherGauge'
 
-const DEBUG_SHOW_ALL_WINDOWS = false && process.env.NODE_ENV !== 'production'
-
 // Harsher than the default since you'll only have 4-5 total windows anyways
 const TECHNICAL_SEVERITY_TIERS = {
 	1: SEVERITY.MINOR,
@@ -274,15 +272,15 @@ export default class Technicalities extends Module {
 						accessor: 'buffed',
 					},
 				]}
-				data={this.history.filter(window => window.playersBuffed > 0 || DEBUG_SHOW_ALL_WINDOWS).map(window => {
+				data={this.history.map(window => {
 					return ({
 						start: window.start - this.parser.fight.start_time,
 						end: window.end != null ?
 							window.end - this.parser.fight.start_time :
 							window.start - this.parser.fight.start_time,
 							notesMap: {
-								timely: <>{window.playersBuffed ? this.getNotesIcon(!window.timelyDevilment): 'N/A'}</>,
-								pooled: <>{window.playersBuffed ? this.getNotesIcon(window.poolingProblem): 'N/A'}</>,
+								timely: <>{this.getNotesIcon(!window.timelyDevilment)}</>,
+								pooled: <>{this.getNotesIcon(window.poolingProblem)}</>,
 								buffed: <>{window.playersBuffed ? window.playersBuffed : 'N/A'}</>,
 							},
 						rotation: window.rotation,

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -49,6 +49,7 @@ class TechnicalWindow {
 	poolingProblem: boolean = false
 
 	buffsRemoved: number[] = []
+	playersBuffed: number = 0
 
 	constructor(start: number) {
 		this.start = start
@@ -71,28 +72,41 @@ export default class Technicalities extends Module {
 
 	protected init() {
 		this.addHook('applybuff', {to: 'player', abilityId: STATUSES.TECHNICAL_FINISH.id}, this.tryOpenWindow)
+		this.addHook('aoeapplybuff', {by: 'player', abilityId: STATUSES.TECHNICAL_FINISH.id}, this.countTechBuffs)
 		this.addHook('removebuff', {to: 'player', abilityId: WINDOW_STATUSES}, this.tryCloseWindow)
 		this.addHook('cast', {by: 'player'}, this.onCast)
 		this.addHook('complete', this.onComplete)
 	}
 
-	private tryOpenWindow(event: BuffEvent) {
+	private countTechBuffs(event: AoeEvent) {
+		// Get this from tryOpenWindow. If a window wasn't open, we'll open one.
+		// If it was already open (because another Dancer went first), we'll keep using it
+		const lastWindow: TechnicalWindow | undefined = this.tryOpenWindow(event)
+
+		// Find out how many players we hit with the buff.
+		if (!lastWindow.playersBuffed) {
+			lastWindow.playersBuffed += event.hits.filter(hit => this.parser.fightFriendlies.findIndex(f => f.id === hit.id) >= 0).length
+		}
+	}
+
+	private tryOpenWindow(event: BuffEvent | AoeEvent): TechnicalWindow {
 		const lastWindow: TechnicalWindow | undefined = _.last(this.history)
 
 		// Handle multiple dancer's buffs overwriting each other, we'll have a remove then an apply with the same timestamp
 		// If that happens, re-open the last window and keep tracking
 		if (lastWindow) {
 			if (!lastWindow.end) {
-				return
+				return lastWindow
 			}
 			if (lastWindow.end === event.timestamp) {
 				lastWindow.end = undefined
-				return
+				return lastWindow
 			}
 		}
 
 		const newWindow = new TechnicalWindow(event.timestamp)
 		this.history.push(newWindow)
+		return newWindow
 	}
 
 	private tryCloseWindow(event: BuffEvent) {


### PR DESCRIPTION
- Count the number of players affected by your technical finish buffs
- Show the number of players affected in the rotation table display
  - If the player did not contribute to this window's buff (ie, another dancer initiated the window, and this dancer's buff didn't overwrite theirs at all), this will display as a 'N/A'