### PR TITLE
DRG: Adjust first use offset for CDDT

### DIFF
--- a/src/parser/jobs/drg/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drg/modules/OGCDDowntime.ts
@@ -1,17 +1,45 @@
 import ACTIONS from 'data/ACTIONS'
 import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 
-const DEFAULT_FIRST_USE_OFFSET = 25000
+// at high skill speeds, Battle Litany is first, so the order is a bit fluid,
+// however all are used before the third GCD
+const BUFF_FIRST_USE_OFFSET = 5000
+
+// the high sks opener delays jumps to better line up with later windows,
+// at least that's what I'm told. These timings should account for both openers,
+// assuming the fast sks threshold of 2.35s
+const JUMP_FIRST_USE_OFFSET = 11750
+const SSD_FIRST_USE_OFFSET = 16450
+const DFD_FIRST_USE_OFFSET = 18800
+
+// always before Full Thrust, the 8th GCD
+const LIFE_SURGE_FIRST_USE_OFFSET = 17500
 
 export default class OGCDDowntime extends CooldownDowntime {
-	defaultFirstUseOffset = DEFAULT_FIRST_USE_OFFSET
 	trackedCds = [
-		{cooldowns: [ACTIONS.HIGH_JUMP]},
-		{cooldowns: [ACTIONS.SPINESHATTER_DIVE]},
-		{cooldowns: [ACTIONS.DRAGONFIRE_DIVE]},
-		{cooldowns: [ACTIONS.LIFE_SURGE]},
-		{cooldowns: [ACTIONS.LANCE_CHARGE]},
-		{cooldowns: [ACTIONS.DRAGON_SIGHT]},
-		{cooldowns: [ACTIONS.BATTLE_LITANY]},
+		{
+			cooldowns: [ACTIONS.HIGH_JUMP],
+			firstUseOffset: JUMP_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.SPINESHATTER_DIVE],
+			firstUseOffset: SSD_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.DRAGONFIRE_DIVE],
+			firstUseOffset: DFD_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.LIFE_SURGE],
+			firstUseOffset: LIFE_SURGE_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [
+				ACTIONS.LANCE_CHARGE,
+				ACTIONS.DRAGON_SIGHT,
+				ACTIONS.BATTLE_LITANY,
+			],
+			firstUseOffset: BUFF_FIRST_USE_OFFSET,
+		},
 	]
 }

--- a/src/parser/jobs/drg/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drg/modules/OGCDDowntime.ts
@@ -8,9 +8,9 @@ const BUFF_FIRST_USE_OFFSET = 5000
 // the high sks opener delays jumps to better line up with later windows,
 // at least that's what I'm told. These timings should account for both openers,
 // assuming the fast sks threshold of 2.35s
-const JUMP_FIRST_USE_OFFSET = 11750
-const SSD_FIRST_USE_OFFSET = 16450
-const DFD_FIRST_USE_OFFSET = 18800
+const JUMP_FIRST_USE_OFFSET = 14100		// before 7th gcd
+const SSD_FIRST_USE_OFFSET = 18800		// before 9th gcd
+const DFD_FIRST_USE_OFFSET = 21500		// before 10th gcd
 
 // always before Full Thrust, the 8th GCD
 const LIFE_SURGE_FIRST_USE_OFFSET = 17500

--- a/src/parser/jobs/drg/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drg/modules/OGCDDowntime.ts
@@ -16,6 +16,7 @@ const DFD_FIRST_USE_OFFSET = 21500		// before 10th gcd
 const LIFE_SURGE_FIRST_USE_OFFSET = 17500
 
 export default class OGCDDowntime extends CooldownDowntime {
+	defaultFirstUseOffset = BUFF_FIRST_USE_OFFSET
 	trackedCds = [
 		{
 			cooldowns: [ACTIONS.HIGH_JUMP],
@@ -33,13 +34,8 @@ export default class OGCDDowntime extends CooldownDowntime {
 			cooldowns: [ACTIONS.LIFE_SURGE],
 			firstUseOffset: LIFE_SURGE_FIRST_USE_OFFSET,
 		},
-		{
-			cooldowns: [
-				ACTIONS.LANCE_CHARGE,
-				ACTIONS.DRAGON_SIGHT,
-				ACTIONS.BATTLE_LITANY,
-			],
-			firstUseOffset: BUFF_FIRST_USE_OFFSET,
-		},
+		{cooldowns: [ACTIONS.LANCE_CHARGE]},
+		{cooldowns: [ACTIONS.DRAGON_SIGHT]},
+		{cooldowns: [ACTIONS.BATTLE_LITANY]},
 	]
 }

--- a/src/parser/jobs/drg/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drg/modules/OGCDDowntime.ts
@@ -1,19 +1,20 @@
 import ACTIONS from 'data/ACTIONS'
 import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 
+// +2s start of fight buffer added for all first use
 // at high skill speeds, Battle Litany is first, so the order is a bit fluid,
 // however all are used before the third GCD
-const BUFF_FIRST_USE_OFFSET = 5000
+const BUFF_FIRST_USE_OFFSET = 7000
 
 // the high sks opener delays jumps to better line up with later windows,
-// at least that's what I'm told. These timings should account for both openers,
-// assuming the fast sks threshold of 2.35s
-const JUMP_FIRST_USE_OFFSET = 14100		// before 7th gcd
-const SSD_FIRST_USE_OFFSET = 18800		// before 9th gcd
-const DFD_FIRST_USE_OFFSET = 21500		// before 10th gcd
+// but isn't used with current sets. Timings listed here should work
+// for both openers, if the high sks build ever becomes relevant.
+const JUMP_FIRST_USE_OFFSET = 16100		// before 7th gcd
+const SSD_FIRST_USE_OFFSET = 20800		// before 9th gcd
+const DFD_FIRST_USE_OFFSET = 23500		// before 10th gcd
 
 // always before Full Thrust, the 8th GCD
-const LIFE_SURGE_FIRST_USE_OFFSET = 17500
+const LIFE_SURGE_FIRST_USE_OFFSET = 19500
 
 export default class OGCDDowntime extends CooldownDowntime {
 	defaultFirstUseOffset = BUFF_FIRST_USE_OFFSET


### PR DESCRIPTION
Tightening up the first use offset based on latest use times in both DRG openers (low/high skill speed).