### PR TITLE
bugfix: track solo dragon sight in lotd window

### DIFF
--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.js
@@ -73,7 +73,7 @@ export default class BloodOfTheDragon extends Module {
 			active.push(STATUSES.BATTLE_LITANY.id)
 		}
 
-		if (this.combatants.selected.hasStatus(STATUSES.RIGHT_EYE.id) || this.combatants.selected.hasStatus(STATUSES.RIGHT_EYE_SOLO)) {
+		if (this.combatants.selected.hasStatus(STATUSES.RIGHT_EYE.id) || this.combatants.selected.hasStatus(STATUSES.RIGHT_EYE_SOLO.id)) {
 			active.push(STATUSES.RIGHT_EYE.id)
 		}
 


### PR DESCRIPTION
Super tiny bugfix: dragon sight used without a partner will now appear in the buff list for life of the dragon windows.