### PR TITLE
Add BLU Weaving module

### DIFF
--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -4,6 +4,13 @@ import CONTRIBUTORS from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2020-02-08'),
+		Changes: () => <>
+			Added BLU Weaving module to reduce false positives.
+		</>,
+		contributors: [CONTRIBUTORS.PAIGE_404],
+	},
+	{
 		date: new Date('2020-02-01'),
 		Changes: () => <>
 			Adjusted several GCD actions to fix Always Be Casting estimations.

--- a/src/parser/jobs/blu/modules/Weaving.ts
+++ b/src/parser/jobs/blu/modules/Weaving.ts
@@ -1,0 +1,22 @@
+import ACTIONS from 'data/ACTIONS'
+import CoreWeaving, {WeaveInfo} from 'parser/core/modules/Weaving'
+
+const TO_MILLISECONDS = 1000
+
+export default class Weaving extends CoreWeaving {
+	isBadWeave(weave: WeaveInfo) {
+		let surpanakhas = 0
+		weave.weaves.forEach((value) => {
+			if (value.ability.guid === ACTIONS.SURPANAKHA.id) {
+				surpanakhas++
+			}
+		})
+		if (surpanakhas &&
+			weave.weaves.length === surpanakhas &&
+			weave.gcdTimeDiff < (surpanakhas + 1) * TO_MILLISECONDS) {
+			return false
+		}
+
+		return super.isBadWeave(weave)
+	}
+}

--- a/src/parser/jobs/blu/modules/index.tsx
+++ b/src/parser/jobs/blu/modules/index.tsx
@@ -1,1 +1,5 @@
-export default []
+import Weaving from './Weaving'
+
+export default [
+	Weaving,
+]


### PR DESCRIPTION
- Reduce false positives by greenlighting speedy and effective use of Surpanaka
    - Surpanakha is best used 4 times between GCDs, with no other actions
      weaved in, in a maximum of 5 seconds between GCDs