### PR TITLE
Adjusted allowedDowntime and firstUseOffset for SMN cooldowns.

### DIFF
--- a/src/parser/jobs/smn/modules/GeneralCDDowntime.ts
+++ b/src/parser/jobs/smn/modules/GeneralCDDowntime.ts
@@ -25,7 +25,7 @@ export default class GeneralCDDowntime extends CooldownDowntime {
 			ACTIONS.ASSAULT_I_EARTHEN_ARMOR,
 			ACTIONS.ASSAULT_I_CRIMSON_CYCLONE,
 		],
-		firstUseOffset: 1000,
+		firstUseOffset: 3500,
 		// isAffectedBySpeed: true,
 	}, {
 		cooldowns: [
@@ -34,6 +34,7 @@ export default class GeneralCDDowntime extends CooldownDowntime {
 			ACTIONS.ASSAULT_II_FLAMING_CRUSH,
 		],
 		firstUseOffset: 3500,
+		// isAffectedBySpeed: true,
 	}, {
 		cooldowns: [
 			ACTIONS.ENKINDLE_AERIAL_BLAST,

--- a/src/parser/jobs/smn/modules/GeneralCDDowntime.ts
+++ b/src/parser/jobs/smn/modules/GeneralCDDowntime.ts
@@ -1,38 +1,50 @@
 import ACTIONS from 'data/ACTIONS'
 import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 
-const DEFAULT_ALLOWED_DOWNTIME = 4000
 // Although the trance cooldown is 55s, it is better in many cases
 // to hold for a 60s alignment, so some downtime per use must be allowed.
 const TRANCE_ALLOWED_DOWNTIME = 5000
 
 export default class GeneralCDDowntime extends CooldownDowntime {
-	defaultAllowedAverageDowntime = DEFAULT_ALLOWED_DOWNTIME
-	trackedCds = [
-		{
-			cooldowns: [ACTIONS.DREADWYRM_TRANCE, ACTIONS.FIREBIRD_TRANCE],
-			allowedAverageDowntime: TRANCE_ALLOWED_DOWNTIME,
-		},
-		{cooldowns: [
+	trackedCds = [ {
+		cooldowns: [
+			ACTIONS.DREADWYRM_TRANCE,
+			ACTIONS.FIREBIRD_TRANCE,
+		],
+		allowedAverageDowntime: TRANCE_ALLOWED_DOWNTIME,
+		firstUseOffset: 7500,
+	}, {
+		cooldowns: [
 			ACTIONS.ENERGY_DRAIN,
 			ACTIONS.ENERGY_SIPHON,
-		]},
-		{cooldowns: [
+		],
+		firstUseOffset: 2500,
+	}, {
+		cooldowns: [
 			ACTIONS.ASSAULT_I_AERIAL_SLASH,
 			ACTIONS.ASSAULT_I_EARTHEN_ARMOR,
 			ACTIONS.ASSAULT_I_CRIMSON_CYCLONE,
-		]},
-		{cooldowns: [
+		],
+		firstUseOffset: 1000,
+		// isAffectedBySpeed: true,
+	}, {
+		cooldowns: [
 			ACTIONS.ASSAULT_II_SLIIPSTREAM,
 			ACTIONS.ASSAULT_II_MOUNTAIN_BUSTER,
 			ACTIONS.ASSAULT_II_FLAMING_CRUSH,
-		]},
-		{cooldowns: [
+		],
+		firstUseOffset: 3500,
+	}, {
+		cooldowns: [
 			ACTIONS.ENKINDLE_AERIAL_BLAST,
 			ACTIONS.ENKINDLE_EARTHEN_FURY,
 			ACTIONS.ENKINDLE_INFERNO,
-		]},
-		{cooldowns: [ACTIONS.SMN_AETHERPACT]},
-	]
-
+		],
+		firstUseOffset: 9250,
+	}, {
+		cooldowns: [
+			ACTIONS.SMN_AETHERPACT,
+		],
+		firstUseOffset: 6750,
+	}]
 }


### PR DESCRIPTION
Most important part here is getting rid of the 4s fuzz time leftover from the previous implementation.  First use offsets also added to improve accuracy.