### PR TITLE
Deprecate aoeX and migrate consumers to normalisedX

### DIFF
--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -222,7 +222,7 @@ class Parser {
 
 	hydrateFabrication(event: Partial<Event>): Event {
 		// TODO: they've got a 'triggered' prop too...?
-		return {
+		const clone = Object.assign({
 			// Provide default fields
 			timestamp: this.currentTimestamp,
 			type: 'fabrication',
@@ -231,10 +231,11 @@ class Parser {
 			targetID: -1,
 			targetInstance: -1,
 			targetIsFriendly: true,
-
-			// Fill out with any overwritten fields
-			...event,
+		}, event)
+		if (Object.getPrototypeOf(event)) {
+			Object.setPrototypeOf(clone, Object.getPrototypeOf(event))
 		}
+		return clone
 	}
 
 	fabricateEvent(event: Partial<Event>) {

--- a/src/parser/core/modules/AoEUsages.tsx
+++ b/src/parser/core/modules/AoEUsages.tsx
@@ -3,7 +3,7 @@ import {Plural, Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
 import {Action} from 'data/ACTIONS'
 import Module, {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import React from 'react'
 import {Table} from 'semantic-ui-react'
@@ -73,8 +73,8 @@ export abstract class AoEUsages extends Module {
 	private badUsages = new Map<number, number>()
 
 	protected init() {
-		this.addHook('aoedamage', {by: 'player', abilityId: this.trackedAbilities.map(a => a.aoeAbility.id)}, this.onAbility)
-		this.addHook('complete', this.onComplete)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: this.trackedAbilities.map(a => a.aoeAbility.id)}, this.onAbility)
+		this.addEventHook('complete', this.onComplete)
 	}
 
 	/**
@@ -83,17 +83,17 @@ export abstract class AoEUsages extends Module {
 	 * @param event The event for which the number of minimum targets is being adjusted.
 	 * @param minTargets The default number of minimum targets for the ability as defined in trackedAbilities.
 	 */
-	protected adjustMinTargets(event: AoeEvent, minTargets: number) {
+	protected adjustMinTargets(event: NormalisedDamageEvent, minTargets: number) {
 		return minTargets
 	}
 
-	private onAbility(event: AoeEvent) {
+	private onAbility(event: NormalisedDamageEvent) {
 		const tracked = this.trackedAbilities.find(a => a.aoeAbility.id === event.ability.guid)
 
 		if (tracked === undefined) { return }
 
 		const minTargets = this.adjustMinTargets(event, tracked.minTargets)
-		if (event.successfulHit && event.hits.length < minTargets) {
+		if (event.successfulHit && event.hits < minTargets) {
 			this.badUsages.set(event.ability.guid, (this.badUsages.get(event.ability.guid) || 0) + 1)
 		}
 	}

--- a/src/parser/core/modules/Combos.tsx
+++ b/src/parser/core/modules/Combos.tsx
@@ -5,8 +5,8 @@ import {Plural, Trans} from '@lingui/react'
 import {RotationTable} from 'components/ui/RotationTable'
 import _ from 'lodash'
 import Module, {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
 import DISPLAY_ORDER from 'parser/core/modules/DISPLAY_ORDER'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import Timeline from 'parser/core/modules/Timeline'
 import React from 'react'
@@ -20,14 +20,17 @@ const ISSUE_TYPENAMES = {
 	failedcombo: <Trans id="core.combos.issuetypenames.failed">Missed or Invulnerable</Trans>,
 }
 
-export interface ComboEvent extends AoeEvent {
-	type: 'combo'
+export class ComboEvent extends NormalisedDamageEvent {
+	constructor(event: NormalisedDamageEvent) {
+		super(event)
+		this.type = 'combo'
+	}
 }
 
 export interface ComboIssue {
 	type: keyof typeof ISSUE_TYPENAMES
-	context: AoeEvent[]
-	event: AoeEvent
+	context: NormalisedDamageEvent[]
+	event: NormalisedDamageEvent
 }
 
 export default class Combos extends Module {
@@ -43,15 +46,15 @@ export default class Combos extends Module {
 	@dependency private timeline!: Timeline
 
 	private lastGcdTime = this.parser.fight.start_time
-	private currentComboChain: AoeEvent[] = []
+	private currentComboChain: NormalisedDamageEvent[] = []
 	private issues: ComboIssue[] = []
 
 	protected init() {
-		this.addHook('aoedamage', {by: 'player'}, this.onCast)
-		this.addHook('complete', this.onComplete)
+		this.addEventHook('normaliseddamage', {by: 'player'}, this.onCast)
+		this.addEventHook('complete', this.onComplete)
 	}
 
-	private get lastComboEvent(): AoeEvent | null {
+	private get lastComboEvent(): NormalisedDamageEvent | null {
 		return _.last(this.currentComboChain) || null
 	}
 
@@ -76,16 +79,13 @@ export default class Combos extends Module {
 			.map(issue => issue.event)
 	}
 
-	protected fabricateComboEvent(event: AoeEvent) {
-		const combo: ComboEvent = {
-			...event,
-			type: 'combo',
-		}
+	protected fabricateComboEvent(event: NormalisedDamageEvent) {
+		const combo = new ComboEvent(event)
 		delete combo.timestamp // Since fabricateEvent adds that in anyway
 		this.parser.fabricateEvent(combo)
 	}
 
-	protected recordBrokenCombo(event: AoeEvent, context: AoeEvent[]) {
+	protected recordBrokenCombo(event: NormalisedDamageEvent, context: NormalisedDamageEvent[]) {
 		if (!this.isAllowableComboBreak(event, context)) {
 			this.issues.push({
 				type: 'combobreak',
@@ -96,7 +96,7 @@ export default class Combos extends Module {
 		this.currentComboChain = []
 	}
 
-	protected recordUncomboedGcd(event: AoeEvent) {
+	protected recordUncomboedGcd(event: NormalisedDamageEvent) {
 		this.issues.push({
 			type: 'uncomboed',
 			event,
@@ -105,7 +105,7 @@ export default class Combos extends Module {
 		this.currentComboChain = []
 	}
 
-	protected recordFailedCombo(event: AoeEvent, context: AoeEvent[]) {
+	protected recordFailedCombo(event: NormalisedDamageEvent, context: NormalisedDamageEvent[]) {
 		this.issues.push({
 			type: 'failedcombo',
 			event,
@@ -120,7 +120,7 @@ export default class Combos extends Module {
 	 * @param event
 	 * @return true if combo, false otherwise
 	 */
-	protected checkCombo(combo: TODO /* Should be an Action type */, event: AoeEvent): boolean {
+	protected checkCombo(combo: TODO /* Should be an Action type */, event: NormalisedDamageEvent): boolean {
 		// Not in a combo
 		if (this.lastAction == null) {
 			// Combo starter, we good
@@ -158,7 +158,7 @@ export default class Combos extends Module {
 		return false
 	}
 
-	private onCast(event: AoeEvent) {
+	private onCast(event: NormalisedDamageEvent) {
 		const action = this.data.getAction(event.ability.guid)
 
 		if (!action) {
@@ -229,7 +229,7 @@ export default class Combos extends Module {
 	 * what particular actions were misused and when in the fight.
 	 * The overriding module should return true if the default suggestion is not wanted
 	 */
-	addJobSpecificSuggestions(comboBreakers: AoeEvent[], uncomboedGcds: AoeEvent[]) {
+	addJobSpecificSuggestions(comboBreakers: NormalisedDamageEvent[], uncomboedGcds: NormalisedDamageEvent[]) {
 		return false
 	}
 
@@ -239,7 +239,7 @@ export default class Combos extends Module {
 	 * the event and context will not be recorded, and the current combo will be cleared with no other side effects.
 	 * Returning false will allow the break to be recorded, and displayed to the user
 	 */
-	isAllowableComboBreak(event: AoeEvent, context: AoeEvent[]): boolean {
+	isAllowableComboBreak(event: NormalisedDamageEvent, context: NormalisedDamageEvent[]): boolean {
 		return false
 	}
 

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -68,7 +68,7 @@ export class NormalisedDamageEvent extends NormalisedEvent {
 	calculatedEvents: DamageEvent[] = []
 	confirmedEvents: DamageEvent[] = []
 
-	constructor(event: DamageEvent) {
+	constructor(event: DamageEvent | NormalisedDamageEvent) {
 		super()
 		Object.assign(this, (({type, amount, successfulHit, ...props}) => ({...props}))(event))
 	}

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -168,6 +168,7 @@ export class NormalisedEvents extends Module {
 		// No packetID set - match based on timestamps
 		const possibleRelatedEvents = Array.from(this._normalisedEvents.values())
 			.filter(normalisedEvent =>
+				event.type.includes(normalisedEvent.type.replace('normalised', '')) &&
 				event.ability.guid === normalisedEvent.ability.guid &&
 				event.sourceID === normalisedEvent.sourceID &&
 				normalisedEvent.timestamp <= event.timestamp &&

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -102,8 +102,8 @@ export class NormalisedApplyBuffEvent extends NormalisedEvent {
 
 export const isNormalisedRemoveBuffEvent = (event: NormalisedEvent): event is NormalisedRemoveBuffEvent => event.type === 'normalisedremovebuff'
 export interface NormalisedRemoveBuffEvent extends Omit<BuffEvent, 'type'>, NormalisedEvent {}
-export class NormalisedRefreshBuffEvent extends NormalisedEvent {
-	type = 'normalisedrefreshbuff'
+export class NormalisedRemoveBuffEvent extends NormalisedEvent {
+	type = 'normalisedremovebuff'
 	calculatedEvents: BuffEvent[] = []
 	confirmedEvents: BuffEvent[] = []
 
@@ -119,7 +119,7 @@ export class NormalisedEvents extends Module {
 
 	@dependency private hitType!: HitType // Dependency to ensure HitType properties are available for determining hit success
 
-	private _normalisedEvents = new Map<number, NormalisedEvent>()
+	private _normalisedEvents = new Map<string, NormalisedEvent>()
 
 	normalise(events: Event[]): Event[] {
 		events.forEach(this.normaliseEvent)
@@ -136,19 +136,19 @@ export class NormalisedEvents extends Module {
 
 		if (!normalisedEvent) {
 			this.debug('No matching event found, creating new event')
-			let identifier: number
+			let identifier: string
 			if (isDamageEvent(event)) {
 				normalisedEvent = new NormalisedDamageEvent(event)
-				identifier = event.packetID ?? event.timestamp
+				identifier = event.packetID ? `${event.packetID}` : `${event.timestamp}-${event.ability.guid}`
 			} else if (isHealEvent(event)) {
 				normalisedEvent = new NormalisedHealEvent(event)
-				identifier = event.packetID ?? event.timestamp
+				identifier = event.packetID ? `${event.packetID}` : `${event.timestamp}-${event.ability.guid}`
 			} else {
-				identifier = event.timestamp
+				identifier = `${event.timestamp}-${event.ability.guid}`
 				if (isApplyBuffEvent(event)) {
 					normalisedEvent = new NormalisedApplyBuffEvent(event)
 				} else {
-					normalisedEvent = new NormalisedRefreshBuffEvent(event)
+					normalisedEvent = new NormalisedRemoveBuffEvent(event)
 				}
 			}
 			this._normalisedEvents.set(identifier, normalisedEvent)
@@ -161,10 +161,10 @@ export class NormalisedEvents extends Module {
 		this.debug(`Searching for related events for event ${event.ability.name} at ${this.parser.formatTimestamp(event.timestamp)}`)
 		if (isBaseEvent(event) && event.packetID) {
 			this.debug(`Searching by packetID ${event.packetID}`)
-			return this._normalisedEvents.get(event.packetID)
+			return this._normalisedEvents.get(`${event.packetID}`)
 		}
 
-		this.debug(`Searching by timestamp ${event.timestamp}`)
+		this.debug(`Searching by timestamp ${event.timestamp} and ability ID ${event.ability.guid}`)
 		// No packetID set - match based on timestamps
 		const possibleRelatedEvents = Array.from(this._normalisedEvents.values())
 			.filter(normalisedEvent =>

--- a/src/parser/jobs/dnc/modules/Combos.ts
+++ b/src/parser/jobs/dnc/modules/Combos.ts
@@ -1,9 +1,9 @@
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
 import {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
 import Combatants from 'parser/core/modules/Combatants'
 import CoreCombos from 'parser/core/modules/Combos'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 import DirtyDancing from './DirtyDancing'
 
 const GCD_TIMEOUT_MILLIS = 15000
@@ -17,7 +17,7 @@ export default class Combos extends CoreCombos {
 
 	// Override check for allowable breaks. If two dances were started during the initial context's GCD timeout window,
 	// (ie, both Standard and Technical were danced), then we'll allow it
-	isAllowableComboBreak(event: AoeEvent, context: AoeEvent[]): boolean {
+	isAllowableComboBreak(event: NormalisedDamageEvent, context: NormalisedDamageEvent[]): boolean {
 		// Shouldn't ever be the case, but protect against weird shit
 		if (context.length !== 1) {
 			return false

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -10,15 +10,14 @@ import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
 import {CastEvent} from 'fflogs'
 import Module, {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
 import CheckList, {Requirement, Rule} from 'parser/core/modules/Checklist'
 import Combatants from 'parser/core/modules/Combatants'
 import Downtime from 'parser/core/modules/Downtime'
+import {EntityStatuses} from 'parser/core/modules/EntityStatuses'
 import Invulnerability from 'parser/core/modules/Invulnerability'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import Timeline from 'parser/core/modules/Timeline'
-
-import {EntityStatuses} from 'parser/core/modules/EntityStatuses'
 import {DEFAULT_SEVERITY_TIERS, FINISHES, STANDARD_FINISHES, TECHNICAL_FINISHES} from '../CommonData'
 import DISPLAY_ORDER from '../DISPLAY_ORDER'
 
@@ -115,11 +114,11 @@ export default class DirtyDancing extends Module {
 	}
 
 	protected init() {
-		this.addHook('cast', {by: 'player', abilityId: STEPS}, this.beginDance)
-		this.addHook('cast', {by: 'player'}, this.continueDance)
-		this.addHook('cast', {by: 'player', abilityId: FINISHES}, this.finishDance)
-		this.addHook('aoedamage', {by: 'player', abilityId: FINISHES}, this.resolveDance)
-		this.addHook('complete', this.onComplete)
+		this.addEventHook('cast', {by: 'player', abilityId: STEPS}, this.beginDance)
+		this.addEventHook('cast', {by: 'player'}, this.continueDance)
+		this.addEventHook('cast', {by: 'player', abilityId: FINISHES}, this.finishDance)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: FINISHES}, this.resolveDance)
+		this.addEventHook('complete', this.onComplete)
 	}
 
 	dancesInRange(startTime: number, endTime: number) {
@@ -171,7 +170,7 @@ export default class DirtyDancing extends Module {
 		dance.dancing = false
 	}
 
-	private resolveDance(event: AoeEvent) {
+	private resolveDance(event: NormalisedDamageEvent) {
 		const dance = this.lastDance
 
 		if (!dance || dance.resolved) {

--- a/src/parser/jobs/dnc/modules/Esprit.tsx
+++ b/src/parser/jobs/dnc/modules/Esprit.tsx
@@ -11,8 +11,8 @@ import JOBS from 'data/JOBS'
 import STATUSES from 'data/STATUSES'
 import {BuffEvent} from 'fflogs'
 import Module, {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
 import Combatants from 'parser/core/modules/Combatants'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 import Suggestions, {TieredSuggestion} from 'parser/core/modules/Suggestions'
 
 import {FINISHES, GAUGE_SEVERITY_TIERS, GaugeGraphEntry} from '../CommonData'
@@ -68,15 +68,15 @@ export default class EspritGauge extends Module {
 	private improvisationStart = 0
 
 	protected init() {
-		this.addHook('aoedamage', {by: 'player'}, this.onDamage)
-		this.addHook('cast', {by: 'player', abilityId: ACTIONS.SABER_DANCE.id}, this.onConsumeEsprit)
-		this.addHook('applybuff', {by: 'player', abilityId: STATUSES.IMPROVISATION.id}, this.startImprov)
-		this.addHook('removebuff', {by: 'player', abilityId: STATUSES.IMPROVISATION.id}, this.endImprov)
-		this.addHook('death', {to: 'player'}, this.onDeath)
-		this.addHook('complete', this.onComplete)
+		this.addEventHook('normaliseddamage', {by: 'player'}, this.onDamage)
+		this.addEventHook('cast', {by: 'player', abilityId: ACTIONS.SABER_DANCE.id}, this.onConsumeEsprit)
+		this.addEventHook('applybuff', {by: 'player', abilityId: STATUSES.IMPROVISATION.id}, this.startImprov)
+		this.addEventHook('removebuff', {by: 'player', abilityId: STATUSES.IMPROVISATION.id}, this.endImprov)
+		this.addEventHook('death', {to: 'player'}, this.onDeath)
+		this.addEventHook('complete', this.onComplete)
 	}
 
-	private onDamage(event: AoeEvent) {
+	private onDamage(event: NormalisedDamageEvent) {
 		if (!ESPRIT_GENERATION_MULTIPLIERS[event.ability.guid] || !event.successfulHit) {
 			return
 		}

--- a/src/parser/jobs/dnc/modules/FeatherGauge.tsx
+++ b/src/parser/jobs/dnc/modules/FeatherGauge.tsx
@@ -9,7 +9,7 @@ import TimeLineChart from 'components/ui/TimeLineChart'
 import ACTIONS from 'data/ACTIONS'
 import JOBS from 'data/JOBS'
 import Module, {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 import Suggestions, {TieredSuggestion} from 'parser/core/modules/Suggestions'
 
 import {GAUGE_SEVERITY_TIERS, GaugeGraphEntry} from '../CommonData'
@@ -45,10 +45,10 @@ export default class FeatherGauge extends Module {
 	private featherOvercap = 0
 
 	protected init() {
-		this.addHook('aoedamage', {by: 'player', abilityId: FEATHER_GENERATORS}, this.onCastGenerator)
-		this.addHook('cast', {by: 'player', abilityId: FEATHER_CONSUMERS}, this.onConsumeFeather)
-		this.addHook('death', {to: 'player'}, this.onDeath)
-		this.addHook('complete', this.onComplete)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: FEATHER_GENERATORS}, this.onCastGenerator)
+		this.addEventHook('cast', {by: 'player', abilityId: FEATHER_CONSUMERS}, this.onConsumeFeather)
+		this.addEventHook('death', {to: 'player'}, this.onDeath)
+		this.addEventHook('complete', this.onComplete)
 	}
 
 	public feathersSpentInRange(start: number, end: number): number {
@@ -58,7 +58,7 @@ export default class FeatherGauge extends Module {
 		return this.history.filter(event => event.t >= start - this.parser.fight.start_time && event.t <= end - this.parser.fight.start_time && !event.isGenerator).length
 	}
 
-	private onCastGenerator(event: AoeEvent) {
+	private onCastGenerator(event: NormalisedDamageEvent) {
 		if (!event.successfulHit) {
 			return
 		}

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -85,7 +85,7 @@ export default class Technicalities extends Module {
 
 		// Find out how many players we hit with the buff.
 		if (!lastWindow.playersBuffed) {
-			lastWindow.playersBuffed = event.hits
+			lastWindow.playersBuffed = event.confirmedEvents.filter(hit => this.parser.fightFriendlies.findIndex(f => f.id === hit.targetID) >= 0).length
 		}
 	}
 

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -11,8 +11,8 @@ import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
 import {BuffEvent, CastEvent} from 'fflogs'
 import Module, {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
 import Combatants from 'parser/core/modules/Combatants'
+import {NormalisedApplyBuffEvent} from 'parser/core/modules/NormalisedEvents'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import Timeline from 'parser/core/modules/Timeline'
 
@@ -39,7 +39,7 @@ class TechnicalWindow {
 	start: number
 	end?: number
 
-	rotation: Array<AoeEvent | CastEvent> = []
+	rotation: Array<NormalisedApplyBuffEvent | CastEvent> = []
 	gcdCount: number = 0
 	trailingGcdEvent?: CastEvent
 
@@ -71,25 +71,25 @@ export default class Technicalities extends Module {
 	private lastDevilmentTimestamp: number = -1
 
 	protected init() {
-		this.addHook('applybuff', {to: 'player', abilityId: STATUSES.TECHNICAL_FINISH.id}, this.tryOpenWindow)
-		this.addHook('aoeapplybuff', {by: 'player', abilityId: STATUSES.TECHNICAL_FINISH.id}, this.countTechBuffs)
-		this.addHook('removebuff', {to: 'player', abilityId: WINDOW_STATUSES}, this.tryCloseWindow)
-		this.addHook('cast', {by: 'player'}, this.onCast)
-		this.addHook('complete', this.onComplete)
+		this.addEventHook('applybuff', {to: 'player', abilityId: STATUSES.TECHNICAL_FINISH.id}, this.tryOpenWindow)
+		this.addEventHook('normalisedapplybuff', {by: 'player', abilityId: STATUSES.TECHNICAL_FINISH.id}, this.countTechBuffs)
+		this.addEventHook('removebuff', {to: 'player', abilityId: WINDOW_STATUSES}, this.tryCloseWindow)
+		this.addEventHook('cast', {by: 'player'}, this.onCast)
+		this.addEventHook('complete', this.onComplete)
 	}
 
-	private countTechBuffs(event: AoeEvent) {
+	private countTechBuffs(event: NormalisedApplyBuffEvent) {
 		// Get this from tryOpenWindow. If a window wasn't open, we'll open one.
 		// If it was already open (because another Dancer went first), we'll keep using it
 		const lastWindow: TechnicalWindow | undefined = this.tryOpenWindow(event)
 
 		// Find out how many players we hit with the buff.
 		if (!lastWindow.playersBuffed) {
-			lastWindow.playersBuffed += event.hits.filter(hit => this.parser.fightFriendlies.findIndex(f => f.id === hit.id) >= 0).length
+			lastWindow.playersBuffed = event.hits
 		}
 	}
 
-	private tryOpenWindow(event: BuffEvent | AoeEvent): TechnicalWindow {
+	private tryOpenWindow(event: BuffEvent | NormalisedApplyBuffEvent): TechnicalWindow {
 		const lastWindow: TechnicalWindow | undefined = _.last(this.history)
 
 		// Handle multiple dancer's buffs overwriting each other, we'll have a remove then an apply with the same timestamp

--- a/src/parser/jobs/drk/modules/Darkside.js
+++ b/src/parser/jobs/drk/modules/Darkside.js
@@ -28,10 +28,10 @@ export default class Darkside extends Module {
 
 	constructor(...args) {
 		super(...args)
-		this.addHook('aoedamage', {by: 'player', abilityId: Object.keys(DARKSIDE_EXTENSION).map(Number)}, this._updateDarkside)
-		this.addHook('death', {to: 'player'}, this._onDeath)
-		this.addHook('raise', {to: 'player'}, this._onRaise)
-		this.addHook('complete', this._onComplete)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: Object.keys(DARKSIDE_EXTENSION).map(Number)}, this._updateDarkside)
+		this.addEventHook('death', {to: 'player'}, this._onDeath)
+		this.addEventHook('raise', {to: 'player'}, this._onRaise)
+		this.addEventHook('complete', this._onComplete)
 	}
 
 	_updateDarkside(event) {

--- a/src/parser/jobs/drk/modules/ResourceSimulator.js
+++ b/src/parser/jobs/drk/modules/ResourceSimulator.js
@@ -119,15 +119,15 @@ export default class Resources extends Module {
 
 	constructor(...args) {
 		super(...args)
-		this.addHook(['aoedamage', 'combo'], {by: 'player', abilityId: this._resourceEvents}, this._onEvent)
-		// Hook cast for Living Shadow, as it doesn't directly deal damage so doesn't have an aoedamage event
-		this.addHook('cast', {by: 'player', abilityId: ACTIONS.LIVING_SHADOW.id}, this._onEvent)
+		this.addEventHook(['normaliseddamage', 'combo'], {by: 'player', abilityId: this._resourceEvents}, this._onEvent)
+		// Hook cast for Living Shadow, as it doesn't directly deal damage so doesn't have a damage event
+		this.addEventHook('cast', {by: 'player', abilityId: ACTIONS.LIVING_SHADOW.id}, this._onEvent)
 		// Hook cast for TBN application
-		this.addHook('cast', {by: 'player', abilityId: ACTIONS.THE_BLACKEST_NIGHT.id}, this._onCastBlackestNight)
-		this.addHook('removebuff', {by: 'player', abilityId: STATUSES.BLACKEST_NIGHT.id}, this._onRemoveBlackestNight)
-		this.addHook('death', {by: 'player'}, this._onDeath)
-		this.addHook('raise', {by: 'player'}, this._onRaise)
-		this.addHook('complete', this._onComplete)
+		this.addEventHook('cast', {by: 'player', abilityId: ACTIONS.THE_BLACKEST_NIGHT.id}, this._onCastBlackestNight)
+		this.addEventHook('removebuff', {by: 'player', abilityId: STATUSES.BLACKEST_NIGHT.id}, this._onRemoveBlackestNight)
+		this.addEventHook('death', {by: 'player'}, this._onDeath)
+		this.addEventHook('raise', {by: 'player'}, this._onRaise)
+		this.addEventHook('complete', this._onComplete)
 	}
 
 	// -----

--- a/src/parser/jobs/gnb/NOTES.md
+++ b/src/parser/jobs/gnb/NOTES.md
@@ -2,7 +2,7 @@
 
 ## Ammo
 - [ ] Check for bad Burst Strikes - (i.e. when at 1 ammo + Bloodfest is on CD + Gnashing is off CD)
-- [ ] Check for uses of Fated Circle on a single target (requires infrastructure work for `DamageEvent` to accept `'aoedamage'`)
+- [X] Check for uses of Fated Circle on a single target (requires infrastructure work for `DamageEvent` to accept `'aoedamage'`)
 - [X] Fix bug where uncomboed Solid Barrel counts toward Cartridge generation
 - [X] Log waste by source somewhere in output
 - [ ] Include End of Fight as a potential waste source
@@ -16,4 +16,4 @@
 - [X] Ignore missed GCDs on No Mercy windows that would expire after the end of the fight
 
 ## OGCDDowntime
-- [ ] Figure out how charge systems work (requires infrastructure work)
+- [X] Figure out how charge systems work (requires infrastructure work)

--- a/src/parser/jobs/gnb/modules/Ammo.tsx
+++ b/src/parser/jobs/gnb/modules/Ammo.tsx
@@ -8,10 +8,11 @@ import {ActionLink} from 'components/ui/DbLink'
 import TimeLineChart from 'components/ui/TimeLineChart'
 import ACTIONS from 'data/ACTIONS'
 import JOBS from 'data/JOBS'
-import {CastEvent, Event} from 'fflogs'
+import {CastEvent} from 'fflogs'
 import Module, {dependency, DISPLAY_MODE} from 'parser/core/Module'
 import Checklist, {Requirement, Rule} from 'parser/core/modules/Checklist'
 import {ComboEvent} from 'parser/core/modules/Combos'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 
 const ON_CAST_GENERATORS = {
@@ -63,8 +64,8 @@ export default class Ammo extends Module {
 	@dependency private suggestions!: Suggestions
 
 	protected init() {
-		this.addHook('init', this.pushToHistory)
-		this.addHook(
+		this.addEventHook('init', this.pushToHistory)
+		this.addEventHook(
 			'cast',
 			{
 				by: 'player',
@@ -72,7 +73,7 @@ export default class Ammo extends Module {
 			},
 			this.onCastGenerator,
 		)
-		this.addHook(
+		this.addEventHook(
 			'combo',
 			{
 				by: 'player',
@@ -80,7 +81,7 @@ export default class Ammo extends Module {
 			},
 			this.onComboGenerator,
 		)
-		this.addHook(
+		this.addEventHook(
 			'cast',
 			{
 				by: 'player',
@@ -88,14 +89,13 @@ export default class Ammo extends Module {
 			},
 			this.onSpender,
 		)
-		this.addHook('aoedamage', {by: 'player', abilityId: ACTIONS.FATED_CIRCLE.id}, this.onFatedCircle)
-		this.addHook('death', {to: 'player'}, this.onDeath)
-		this.addHook('complete', this.onComplete)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: ACTIONS.FATED_CIRCLE.id}, this.onFatedCircle)
+		this.addEventHook('death', {to: 'player'}, this.onDeath)
+		this.addEventHook('complete', this.onComplete)
 	}
 
-	private onFatedCircle(event: Event) {
-		if (event.hasOwnProperty('hits') &&
-			(event as any).hits.length < 2) {
+	private onFatedCircle(event: NormalisedDamageEvent) {
+		if (event.hits < 2) {
 			this.erroneousCircles++
 		}
 	}

--- a/src/parser/jobs/mnk/modules/MnkAoE.tsx
+++ b/src/parser/jobs/mnk/modules/MnkAoE.tsx
@@ -1,11 +1,10 @@
 import {getDataBy} from 'data'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-
 import {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
 import {AoeAbility, AoEUsages} from 'parser/core/modules/AoEUsages'
 import Combatants from 'parser/core/modules/Combatants'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 
 export default class MnkAoE extends AoEUsages {
 	static handle = 'mnkaoe'
@@ -39,7 +38,7 @@ export default class MnkAoE extends AoEUsages {
 		},
 	]
 
-	protected adjustMinTargets(event: AoeEvent, minTargets: number): number {
+	protected adjustMinTargets(event: NormalisedDamageEvent, minTargets: number): number {
 		const action = getDataBy(ACTIONS, 'id', event.ability.guid) as TODO
 
 		// How in the fuck did we even get here tbh

--- a/src/parser/jobs/nin/modules/Ninjutsu.js
+++ b/src/parser/jobs/nin/modules/Ninjutsu.js
@@ -27,12 +27,12 @@ export default class Ninjutsu extends Module {
 	constructor(...args) {
 		super(...args)
 
-		this.addHook('cast', {by: 'player', abilityId: [ACTIONS.HYOTON.id, ACTIONS.HYOTON_TCJ.id]}, () => { this._hyotonCount++ })
-		this.addHook('cast', {by: 'player', abilityId: ACTIONS.RABBIT_MEDIUM.id}, () => { this._rabbitCount++ })
-		this.addHook('cast', {by: 'player', abilityId: [ACTIONS.DOTON.id, ACTIONS.DOTON_TCJ.id]}, this._onDotonCast)
-		this.addHook('aoedamage', {by: 'player', abilityId: STATUSES.DOTON.id}, this._onDotonDamage)
-		this.addHook('removebuff', {by: 'player', abilityId: STATUSES.DOTON.id}, this._finishDotonWindow)
-		this.addHook('complete', this._onComplete)
+		this.addEventHook('cast', {by: 'player', abilityId: [ACTIONS.HYOTON.id, ACTIONS.HYOTON_TCJ.id]}, () => { this._hyotonCount++ })
+		this.addEventHook('cast', {by: 'player', abilityId: ACTIONS.RABBIT_MEDIUM.id}, () => { this._rabbitCount++ })
+		this.addEventHook('cast', {by: 'player', abilityId: [ACTIONS.DOTON.id, ACTIONS.DOTON_TCJ.id]}, this._onDotonCast)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: STATUSES.DOTON.id}, this._onDotonDamage)
+		this.addEventHook('removebuff', {by: 'player', abilityId: STATUSES.DOTON.id}, this._finishDotonWindow)
+		this.addEventHook('complete', this._onComplete)
 	}
 
 	_onDotonCast() {
@@ -50,7 +50,7 @@ export default class Ninjutsu extends Module {
 			this._onDotonCast()
 		}
 
-		this._dotonCasts.current.ticks.push(event.hits.length) // Track the number of enemies hit per tick
+		this._dotonCasts.current.ticks.push(event.hits) // Track the number of enemies hit per tick
 	}
 
 	_finishDotonWindow() {

--- a/src/parser/jobs/nin/modules/Ninki.js
+++ b/src/parser/jobs/nin/modules/Ninki.js
@@ -81,14 +81,14 @@ export default class Ninki extends Module {
 
 	constructor(...args) {
 		super(...args)
-		this.addHook('cast', {by: 'player', abilityId: NINKI_GCDS}, event => this._addNinki(event, GCD_NINKI_GAIN[event.ability.guid]))
-		this.addHook('combo', {by: 'player', abilityId: NINKI_COMBOS}, event => this._addNinki(event, GCD_NINKI_GAIN[event.ability.guid]))
-		this.addHook('cast', {by: 'player', abilityId: NINKI_OGCDS}, event => this._addNinki(event, OGCD_NINKI_GAIN[event.ability.guid]))
-		this.addHook('cast', {by: 'pet'}, event => this._addNinki(event, BUNSHIN_NINKI_GAIN))
-		this.addHook('cast', {by: 'player', abilityId: NINKI_SPENDERS}, this._onSpenderCast)
-		this.addHook('aoedamage', {by: 'player', abilityId: ACTIONS.HELLFROG_MEDIUM.id}, this._onHellfrogAoe)
-		this.addHook('death', {to: 'player'}, this._onDeath)
-		this.addHook('complete', this._onComplete)
+		this.addEventHook('cast', {by: 'player', abilityId: NINKI_GCDS}, event => this._addNinki(event, GCD_NINKI_GAIN[event.ability.guid]))
+		this.addEventHook('combo', {by: 'player', abilityId: NINKI_COMBOS}, event => this._addNinki(event, GCD_NINKI_GAIN[event.ability.guid]))
+		this.addEventHook('cast', {by: 'player', abilityId: NINKI_OGCDS}, event => this._addNinki(event, OGCD_NINKI_GAIN[event.ability.guid]))
+		this.addEventHook('cast', {by: 'pet'}, event => this._addNinki(event, BUNSHIN_NINKI_GAIN))
+		this.addEventHook('cast', {by: 'player', abilityId: NINKI_SPENDERS}, this._onSpenderCast)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: ACTIONS.HELLFROG_MEDIUM.id}, this._onHellfrogAoe)
+		this.addEventHook('death', {to: 'player'}, this._onDeath)
+		this.addEventHook('complete', this._onComplete)
 
 	}
 
@@ -111,7 +111,7 @@ export default class Ninki extends Module {
 	}
 
 	_onHellfrogAoe(event) {
-		if (event.hits.length === 1) {
+		if (event.hits === 1) {
 			// If we have a Hellfrog AoE event with only one target, it should've been a Bhava instead
 			this._erroneousFrogs++
 		}

--- a/src/parser/jobs/rdm/modules/Gauge.js
+++ b/src/parser/jobs/rdm/modules/Gauge.js
@@ -183,13 +183,13 @@ export default class Gauge extends Module {
 		constructor(...args) {
 			super(...args)
 
-			this.addHook('cast', {
+			this.addEventHook('cast', {
 				by: 'player',
 				abilityId: ACTIONS.MANAFICATION.id,
 			}, this._gaugeEvent)
-			this.addHook('aoedamage', {by: 'player'}, this._gaugeEvent)
-			this.addHook('death', {to: 'player'}, this._onDeath)
-			this.addHook('complete', this._onComplete)
+			this.addEventHook('normaliseddamage', {by: 'player'}, this._gaugeEvent)
+			this.addEventHook('death', {to: 'player'}, this._onDeath)
+			this.addEventHook('complete', this._onComplete)
 		}
 
 		_pushToGraph() {

--- a/src/parser/jobs/sam/modules/AoeChecker.js
+++ b/src/parser/jobs/sam/modules/AoeChecker.js
@@ -33,8 +33,8 @@ export default class AoeChecker extends Module {
 
 	constructor(...args) {
 		super(...args)
-		this.addHook('aoedamage', {by: 'player'}, this._onAoe)
-		this.addHook('complete', this._onComplete)
+		this.addEventHook('normaliseddamage', {by: 'player'}, this._onAoe)
+		this.addEventHook('complete', this._onComplete)
 	}
 
 	_onAoe(event) {
@@ -47,7 +47,7 @@ export default class AoeChecker extends Module {
 
 			//Step 2: Check break point
 
-			if (event.hits.length < GAIN2) {
+			if (event.hits < GAIN2) {
 				//Step 3: Check type of resource used and increment
 
 				if (AOE_GCDS.has(action)) {
@@ -66,7 +66,7 @@ export default class AoeChecker extends Module {
 
 			//Step 2: Check break point
 
-			if (event.hits.length < GAIN3) {
+			if (event.hits < GAIN3) {
 				//Step 3: Check type of resource used and increment
 
 				if (AOE_GCDS.has(action)) {

--- a/src/parser/jobs/sam/modules/Combos.ts
+++ b/src/parser/jobs/sam/modules/Combos.ts
@@ -1,16 +1,16 @@
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
 import {dependency} from 'parser/core/Module'
-import {AoeEvent} from 'parser/core/modules/AoE'
 import Combatants from 'parser/core/modules/Combatants'
 import CoreCombos, {ComboEvent} from 'parser/core/modules/Combos'
+import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
 
 export default class Combos extends CoreCombos {
 	static suggestionIcon = ACTIONS.HAKAZE.icon
 
 	@dependency private combatants!: Combatants
 
-	checkCombo(combo: ComboEvent, event: AoeEvent) {
+	checkCombo(combo: ComboEvent, event: NormalisedDamageEvent) {
 		// If they've got Meikyo Shisui up, all combos are correct, and nothing combos together
 		if (this.combatants.selected.hasStatus(STATUSES.MEIKYO_SHISUI.id) && (event.ability.guid !== ACTIONS.HAKAZE.id)) {
 			this.fabricateComboEvent(event)

--- a/src/parser/jobs/smn/modules/DWT.js
+++ b/src/parser/jobs/smn/modules/DWT.js
@@ -58,19 +58,19 @@ export default class DWT extends Module {
 	constructor(...args) {
 		super(...args)
 
-		this.addHook('cast', {by: 'player'}, this._onCast)
+		this.addEventHook('cast', {by: 'player'}, this._onCast)
 
-		this.addHook('aoedamage', {
+		this.addEventHook('normaliseddamage', {
 			by: 'player',
 			abilityId: ACTIONS.DEATHFLARE.id,
 		}, this._onDeathflareDamage)
 
-		this.addHook('death', {to: 'player'}, () => {
+		this.addEventHook('death', {to: 'player'}, () => {
 			if (!this._active) { return }
 			this._dwt.died = true
 		})
 
-		this.addHook('complete', this._onComplete)
+		this.addEventHook('complete', this._onComplete)
 	}
 
 	_onCast(event) {
@@ -96,7 +96,7 @@ export default class DWT extends Module {
 	}
 
 	_onDeathflareDamage(event) {
-		this._stopAndSave(event.hits.length, event.timestamp)
+		this._stopAndSave(event.hits, event.timestamp)
 	}
 
 	_onApplyDwt(event) {
@@ -106,7 +106,7 @@ export default class DWT extends Module {
 	}
 
 	_onRemoveDwt() {
-		// Only save if there's no DF - the aoedamage will handle DWTs w/ DF (hopefully all of them lmao)
+		// Only save if there's no DF - _onDeathflareDamage will handle DWTs w/ DF (hopefully all of them lmao)
 		if (!this._dwt.casts.some(cast => cast.ability.guid === ACTIONS.DEATHFLARE.id)) {
 			this._stopAndSave(0)
 		}

--- a/src/parser/jobs/smn/modules/Pets.js
+++ b/src/parser/jobs/smn/modules/Pets.js
@@ -90,14 +90,14 @@ export default class Pets extends Module {
 
 	constructor(...args) {
 		super(...args)
-		this.addHook('init', this._onInit)
-		this.addHook('cast', {by: 'player'}, this._onCast)
-		this.addHook('aoedamage', {by: 'pet'}, this._onPetDamage)
-		this.addHook('summonpet', this._onChangePet)
+		this.addEventHook('init', this._onInit)
+		this.addEventHook('cast', {by: 'player'}, this._onCast)
+		this.addEventHook('normaliseddamage', {by: 'pet'}, this._onPetDamage)
+		this.addEventHook('summonpet', this._onChangePet)
 		// Hook changed from on pet death to on player death due to pet changes in Shadowbringers
 		// Pets now won't die unless their caster dies, so FFLogs API no longer emitting pet death events
-		this.addHook('death', {to: 'player'}, this._onDeath)
-		this.addHook('complete', this._onComplete)
+		this.addEventHook('death', {to: 'player'}, this._onDeath)
+		this.addEventHook('complete', this._onComplete)
 	}
 
 	normalise(events) {
@@ -182,7 +182,7 @@ export default class Pets extends Module {
 		}
 
 		if (abilityId === ACTIONS.WIND_BLADE.id &&
-			event.hits.length < GARUDA_MIN_TARGETS) {
+			event.hits < GARUDA_MIN_TARGETS) {
 			this._badWindBlades++
 		} else if (abilityId === ACTIONS.SLIPSTREAM.id) {
 			this._slipstreams.push({
@@ -200,7 +200,7 @@ export default class Pets extends Module {
 			this._slipstreams[this._slipstreams.length - 1].ticks.push(event)
 		} else if (
 			IFRIT_AOE_CAPABLE_ACTIONS.includes(abilityId) &&
-			event.hits.length >= GARUDA_MIN_TARGETS
+			event.hits >= GARUDA_MIN_TARGETS
 		) {
 			this._ifritMultiHits++
 		}


### PR DESCRIPTION
 (damage and applybuff were the only two being consumed)

This isn't ready for merge yet, as I haven't been able to test it, since FFLogs is melted this evening, but I wanted to go ahead and post the code changes for review/comment.

Jobs/Modules to test:
- [x] GNB Ammo tracking
- [x] DNC allowable combo
- [x] DNC incorrect dances
- [x] DNC esprit generation
- [x] DNC feather generation
- [x] DNC technical step windows
- [x] DRK darkside
- [x] DRK resource generation
- [x] MNK AOE minimum hit checking
- [x] NIN Doton targets hit
- [x] NIN Ninki single target hellfrog
- [x] RDM Gauge
- [x] SAM AOE minimum hit checking
- [x] SAM combo validation (Meikyo override)
- [x] SMN DWT check deathflare targets hit
- [x] SMN pet AOE checker (Garuda vs Ifrit recommendation)
- [x] SMN AOE minimum hit checking (extends core)
- [x] All class combo tracking