### PR TITLE
fix: Sort normalisedX events into the event array to maintain expected ordering

### DIFF
--- a/src/parser/core/EventSorting.ts
+++ b/src/parser/core/EventSorting.ts
@@ -27,7 +27,7 @@ const EVENT_TYPE_ORDER: {[key: string]: number} = {
 	normalisedapplybuff: 3.5,
 }
 
-export function SortNormalisedEvents(events: Event[]) {
+export function SortEvents(events: Event[]) {
 	return stable.inplace(events, (a, b) => {
 		if (a.timestamp === b.timestamp) {
 			const aTypeOrder = (typeof a.type === 'string' ? EVENT_TYPE_ORDER[a.type] : null) || EVENT_TYPE_ORDER.default

--- a/src/parser/core/EventSorting.ts
+++ b/src/parser/core/EventSorting.ts
@@ -1,0 +1,39 @@
+import {Event} from 'fflogs'
+import stable from 'stable'
+
+const EVENT_TYPE_ORDER: {[key: string]: number} = {
+	death: -4,
+	begincast: -3,
+	cast: -2,
+	calculateddamage: -1.5,
+	calculatedheal: -1.5,
+	normaliseddamage: -1.25,
+	normalisedheal: -1.25,
+	targetabilityupdate: -1,
+	damage: -0.5,
+	heal: -0.5,
+	default: 0,
+	removebuff: 1,
+	removebuffstack: 1,
+	removedebuff: 1,
+	removedebuffstack: 1,
+	refreshbuff: 2,
+	refreshdebuff: 2,
+	normalisedremovebuff: 2.5,
+	applybuff: 3,
+	applybuffstack: 3,
+	applydebuff: 3,
+	applydebuffstack: 3,
+	normalisedapplybuff: 3.5,
+}
+
+export function SortNormalisedEvents(events: Event[]) {
+	return stable.inplace(events, (a, b) => {
+		if (a.timestamp === b.timestamp) {
+			const aTypeOrder = (typeof a.type === 'string' ? EVENT_TYPE_ORDER[a.type] : null) || EVENT_TYPE_ORDER.default
+			const bTypeOrder = (typeof b.type === 'string' ? EVENT_TYPE_ORDER[b.type] : null) || EVENT_TYPE_ORDER.default
+			return aTypeOrder - bTypeOrder
+		}
+		return a.timestamp - b.timestamp
+	})
+}

--- a/src/parser/core/modules/AdditionalEvents.js
+++ b/src/parser/core/modules/AdditionalEvents.js
@@ -1,4 +1,4 @@
-import {SortNormalisedEvents} from 'parser/core/EventSorting'
+import {SortEvents} from 'parser/core/EventSorting'
 import {getFflogsEvents} from 'api'
 import Module from 'parser/core/Module'
 import {isDefined} from 'utilities'
@@ -77,6 +77,6 @@ export default class AdditionalEvents extends Module {
 		// Add them onto the end, then sort. Using stable to ensure order is kept, as it can be sensitive sometimes.
 		events.push(...newEvents)
 
-		return SortNormalisedEvents(events)
+		return SortEvents(events)
 	}
 }

--- a/src/parser/core/modules/AdditionalEvents.js
+++ b/src/parser/core/modules/AdditionalEvents.js
@@ -1,5 +1,4 @@
-import stable from 'stable'
-
+import {SortNormalisedEvents} from 'parser/core/EventSorting'
 import {getFflogsEvents} from 'api'
 import Module from 'parser/core/Module'
 import {isDefined} from 'utilities'
@@ -21,30 +20,6 @@ const buildQueryFilter = data => [
 		targetsOnly: true,
 	},
 ]
-
-const EVENT_TYPE_ORDER = {
-	death: -4,
-	begincast: -3,
-	cast: -2,
-	calculateddamage: -1.5,
-	calculatedheal: -1.5,
-	normaliseddamage: -1.25,
-	normalisedheal: -1.25,
-	targetabilityupdate: -1,
-	damage: -0.5,
-	heal: -0.5,
-	default: 0,
-	removebuff: 1,
-	removebuffstack: 1,
-	removedebuff: 1,
-	removedebuffstack: 1,
-	refreshbuff: 2,
-	refreshdebuff: 2,
-	applybuff: 3,
-	applybuffstack: 3,
-	applydebuff: 3,
-	applydebuffstack: 3,
-}
 
 export default class AdditionalEvents extends Module {
 	static handle = 'additionalEvents'
@@ -101,15 +76,7 @@ export default class AdditionalEvents extends Module {
 
 		// Add them onto the end, then sort. Using stable to ensure order is kept, as it can be sensitive sometimes.
 		events.push(...newEvents)
-		stable.inplace(events, (a, b) => {
-			if (a.timestamp === b.timestamp) {
-				const aTypeOrder = EVENT_TYPE_ORDER[a.type] || EVENT_TYPE_ORDER.default
-				const bTypeOrder = EVENT_TYPE_ORDER[b.type] || EVENT_TYPE_ORDER.default
-				return aTypeOrder - bTypeOrder
-			}
-			return a.timestamp - b.timestamp
-		})
 
-		return events
+		return SortNormalisedEvents(events)
 	}
 }

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -1,4 +1,5 @@
 import {AbilityEvent, BuffEvent, DamageEvent, Event, HealEvent, isApplyBuffEvent, isDamageEvent, isHealEvent, isRemoveBuffEvent} from 'fflogs'
+import {SortNormalisedEvents} from 'parser/core/EventSorting'
 import Module, {dependency} from 'parser/core/Module'
 import HitType from 'parser/core/modules/HitType'
 
@@ -124,7 +125,7 @@ export class NormalisedEvents extends Module {
 	normalise(events: Event[]): Event[] {
 		events.forEach(this.normaliseEvent)
 
-		return events.concat(Array.from(this._normalisedEvents.values()))
+		return SortNormalisedEvents(events.concat(Array.from(this._normalisedEvents.values())))
 	}
 
 	private normaliseEvent = (event: Event) => {

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -1,5 +1,5 @@
 import {AbilityEvent, BuffEvent, DamageEvent, Event, HealEvent, isApplyBuffEvent, isDamageEvent, isHealEvent, isRemoveBuffEvent} from 'fflogs'
-import {SortNormalisedEvents} from 'parser/core/EventSorting'
+import {SortEvents} from 'parser/core/EventSorting'
 import Module, {dependency} from 'parser/core/Module'
 import HitType from 'parser/core/modules/HitType'
 
@@ -125,7 +125,7 @@ export class NormalisedEvents extends Module {
 	normalise(events: Event[]): Event[] {
 		events.forEach(this.normaliseEvent)
 
-		return SortNormalisedEvents(events.concat(Array.from(this._normalisedEvents.values())))
+		return SortEvents(events.concat(Array.from(this._normalisedEvents.values())))
 	}
 
 	private normaliseEvent = (event: Event) => {


### PR DESCRIPTION
Per discovery today that the gauges break in fun and exciting ways if they don't get events in timestamp order, and that there isn't anything running after all the normalisers to re-sort the events array.

I refactored this out of AdditionalEvents and both AdditionalEvents and NormalisedEvents are now referencing the same sort logic.  The BLM Gauge normaliser is still doing its own sorting of sorts (tracking insertAfter for events it needs to generate and then splicing in at the appropriate point at the end), but on quick scan I'm not seeing other normalisers that are doing sort-like things with their synthetic events (aside from AOE, which is going to be removed after the NormalisedEvents migration is finished).