### PR TITLE
Mark DRG as supported for 5.2

### DIFF
--- a/src/parser/jobs/drg/index.js
+++ b/src/parser/jobs/drg/index.js
@@ -18,7 +18,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.1',
+		to: '5.2',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},


### PR DESCRIPTION
No changes in 5.2 for DRG.