### PR TITLE
Modified core CDDT to handle pre-fight and downtime usages.

### DIFF
--- a/src/parser/core/modules/CooldownDowntime.tsx
+++ b/src/parser/core/modules/CooldownDowntime.tsx
@@ -150,7 +150,7 @@ export abstract class CooldownDowntime extends Module {
 			const actual = (this.usages.get(cdGroup) || []).length || 0
 			let percent = actual / expected * 100
 			if (process.env.NODE_ENV === 'production') {
-				percent = (percent < 100) ? percent : 100
+				percent = Math.min(percent, 100)
 			}
 			const requirementDisplay = cdGroup.cooldowns.map((val, ix) => <>
 				{(ix > 0 ? ', ' : '')}
@@ -187,8 +187,8 @@ export abstract class CooldownDowntime extends Module {
 		const gResets = this.resets.get(group) || []
 		const gUsages = (this.usages.get(group) || [])
 		const dtUsages = gUsages
-						.filter(u => this.downtime.isDowntime(u.timestamp))
-						.map(u => this.downtime.getDowntimeWindows(u.timestamp)[0])
+			.filter(u => this.downtime.isDowntime(u.timestamp))
+			.map(u => this.downtime.getDowntimeWindows(u.timestamp)[0])
 		const resetTime = (group.resetBy && group.resetBy.refundAmount) ? group.resetBy.refundAmount : 0
 
 		let timeLost = 0 // TODO: this variable is for logging only and does not actually affect the final count

--- a/src/parser/core/modules/CooldownDowntime.tsx
+++ b/src/parser/core/modules/CooldownDowntime.tsx
@@ -148,7 +148,10 @@ export abstract class CooldownDowntime extends Module {
 		for (const cdGroup of this.trackedCds) {
 			const expected = this.calculateMaxUsages(cdGroup)
 			const actual = (this.usages.get(cdGroup) || []).length || 0
-			const percent = actual / expected * 100
+			let percent = actual / expected * 100
+			if (process.env.NODE_ENV === 'production') {
+				percent = (percent < 100) ? percent : 100
+			}
 			const requirementDisplay = cdGroup.cooldowns.map((val, ix) => <>
 				{(ix > 0 ? ', ' : '')}
 				<ActionLink {...this.data.getAction(val.id)} />

--- a/src/parser/jobs/dnc/modules/OGCDDowntime.tsx
+++ b/src/parser/jobs/dnc/modules/OGCDDowntime.tsx
@@ -4,7 +4,7 @@ import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 export default class OGCDDowntime extends CooldownDowntime {
 	trackedCds = [
 		{cooldowns: [ACTIONS.TECHNICAL_STEP]},
-		{cooldowns: [ACTIONS.STANDARD_STEP]},
+		{cooldowns: [ACTIONS.STANDARD_STEP], firstUseOffset: -15000},
 		{cooldowns: [ACTIONS.DEVILMENT]},
 		{cooldowns: [ACTIONS.FLOURISH]},
 	]


### PR DESCRIPTION
This aims to reduce the number of 14/12 type situations.

Jobs wanting to mark skills for pre-fight usage consideration should change firstUseOffset to a negative number.  Charged skills are not supported for pre-fight usages at this time.

Downtime usages are handled for all skills.  (In one of the logs that prompted this change, Energy Drain was used on True Heart, which did no damage, but gave Aetherflow, so I did not limit downtime usage checking to only cooldowns with pre-fight usage checking.)