### PR TITLE
[BugFix] Adjust Successful Hit semantics and logic for ghosted hits

### DIFF
--- a/src/parser/core/modules/AoEUsages.tsx
+++ b/src/parser/core/modules/AoEUsages.tsx
@@ -93,7 +93,7 @@ export abstract class AoEUsages extends Module {
 		if (tracked === undefined) { return }
 
 		const minTargets = this.adjustMinTargets(event, tracked.minTargets)
-		if (event.successfulHit && event.hits < minTargets) {
+		if (event.hasSuccessfulHit && event.hitCount < minTargets) {
 			this.badUsages.set(event.ability.guid, (this.badUsages.get(event.ability.guid) || 0) + 1)
 		}
 	}

--- a/src/parser/core/modules/Combos.tsx
+++ b/src/parser/core/modules/Combos.tsx
@@ -28,7 +28,9 @@ export class ComboEvent extends NormalisedEvent {
 
 	constructor(event: NormalisedDamageEvent) {
 		super()
-		Object.assign(this, event)
+		Object.assign(this, (({type, ...props}) => ({...props}))(event))
+		this.calculatedEvents = event.calculatedEvents.slice(0)
+		this.confirmedEvents = event.confirmedEvents.slice(0)
 	}
 }
 

--- a/src/parser/core/modules/Combos.tsx
+++ b/src/parser/core/modules/Combos.tsx
@@ -3,10 +3,11 @@
 import {t} from '@lingui/macro'
 import {Plural, Trans} from '@lingui/react'
 import {RotationTable} from 'components/ui/RotationTable'
+import {DamageEvent} from 'fflogs'
 import _ from 'lodash'
 import Module, {dependency} from 'parser/core/Module'
 import DISPLAY_ORDER from 'parser/core/modules/DISPLAY_ORDER'
-import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
+import {NormalisedDamageEvent, NormalisedEvent} from 'parser/core/modules/NormalisedEvents'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import Timeline from 'parser/core/modules/Timeline'
 import React from 'react'
@@ -20,10 +21,14 @@ const ISSUE_TYPENAMES = {
 	failedcombo: <Trans id="core.combos.issuetypenames.failed">Missed or Invulnerable</Trans>,
 }
 
-export class ComboEvent extends NormalisedDamageEvent {
+export class ComboEvent extends NormalisedEvent {
+	type = 'combo'
+	calculatedEvents: DamageEvent[] = []
+	confirmedEvents: DamageEvent[] = []
+
 	constructor(event: NormalisedDamageEvent) {
-		super(event)
-		this.type = 'combo'
+		super()
+		Object.assign(this, event)
 	}
 }
 
@@ -177,7 +182,7 @@ export default class Combos extends Module {
 
 		// If it's a combo action, run it through the combo checking logic
 		if (action.combo) {
-			if (!event.successfulHit) {
+			if (!event.hasSuccessfulHit) {
 				// Failed attacks break combo
 				this.recordFailedCombo(event, this.currentComboChain)
 				return

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -46,7 +46,18 @@ class NormalisedEvent {
 		}
 		return 0
 	}
+
+	/**
+	 * Did any of the events for this action generate a successful hit?
+	 * - Successful hits are hits that did not miss, and that did not hit an INVULNERABLE or IMMUNE target
+	 *     (e.g. due to filter debuffs that force you to attack a specific target)
+	 * - In game data from e6s confirms that an event is considered successful by the game for advancing combo
+	 *     or generating gauge as long as the calculateddamage event occurs, even if the confirming damage packet doesn't
+	 */
 	get successfulHit(): boolean {
+		if (isBaseEventArray(this.calculatedEvents) && this.calculatedEvents.length > 0) {
+			return this.calculatedEvents.reduce((successfulHit: boolean, evt) => successfulHit || evt.successfulHit, false)
+		}
 		if (isBaseEventArray(this.confirmedEvents)) {
 			return this.confirmedEvents.reduce((successfulHit: boolean, evt) => successfulHit || evt.successfulHit, false)
 		}

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -12,49 +12,47 @@ const isBaseEvent = (event: Event): event is BaseEvent => isDamageEvent(event) |
 const isSupportedEvent = (event: Event): event is BaseEvent | BuffEvent => isBaseEvent(event) || isSupportedBuffEvent(event)
 const isBaseEventArray = (array: Array<BaseEvent | BuffEvent>): array is BaseEvent[] => array.length > 0 && isBaseEvent(array[0])
 
-interface NormalisedEvent extends AbilityEvent {
+export interface NormalisedEvent extends AbilityEvent {
 	type: string
 	calculatedEvents: Array<BaseEvent | BuffEvent>
 	confirmedEvents: Array<BaseEvent | BuffEvent>
 }
-class NormalisedEvent {
+export class NormalisedEvent {
 	get targetsHit(): number { return new Set(this.confirmedEvents.map(evt => `${evt.targetID}-${evt.targetInstance}`)).size }
-	get hits(): number { return this.confirmedEvents.length }
-	get amount(): number {
-		if (isBaseEventArray(this.confirmedEvents)) {
-			return this.confirmedEvents.reduce((total, evt) => total + evt.amount, 0)
-		}
-		return 0
-	}
+
 	/**
-	 * Number of damage events that did not do confirmed damage to the target.
-	 *  Typically due to target or source despawning before damage applied.
+	 * Return all hits, regardless of whether they were confirmed or were ghosted
 	 */
-	get ghostedHits(): number {
-		if (isBaseEventArray(this.calculatedEvents)) {
-			return this.calculatedEvents.filter((evt) => evt.unpaired).reduce((total, evt) => total + evt.amount, 0)
+	get hits(): Array<BaseEvent | BuffEvent> {
+		if (this.calculatedEvents.length > 0) {
+			return this.calculatedEvents
 		}
-		return 0
-	}
-	/**
-	 * Total amount of damage from damage events that did not do confirmed damage to the target.
-	 *  Typically due to target or source despawning before damage applied.
-	 */
-	get ghostedAmount(): number {
-		if (isBaseEventArray(this.calculatedEvents)) {
-			return this.calculatedEvents.filter((evt) => evt.unpaired).length
-		}
-		return 0
+		return this.confirmedEvents
 	}
 
 	/**
-	 * Did any of the events for this action generate a successful hit?
+	 * Return the number of hits recorded for this actions, confirmed or ghosted
+	 */
+	get hitCount(): number { return this.hits.length }
+
+	/**
+	 * For damage or heal actions, the total of all damage or healing done by all hits, confirmed or ghosted
+	 * For buff actions, 0
+	 */
+	get hitAmount(): number {
+		if (isBaseEventArray(this.hits)) {
+			return this.hits.reduce((total, evt) => total + evt.amount, 0)
+		}
+		return 0
+	}
+	/**
+	 * For damage or heal actions, did any of the events (confirmed or ghosted) for this action generate a successful hit?
 	 * - Successful hits are hits that did not miss, and that did not hit an INVULNERABLE or IMMUNE target
 	 *     (e.g. due to filter debuffs that force you to attack a specific target)
 	 * - In game data from e6s confirms that an event is considered successful by the game for advancing combo
 	 *     or generating gauge as long as the calculateddamage event occurs, even if the confirming damage packet doesn't
 	 */
-	get successfulHit(): boolean {
+	get hasSuccessfulHit(): boolean {
 		if (isBaseEventArray(this.calculatedEvents) && this.calculatedEvents.length > 0) {
 			return this.calculatedEvents.reduce((successfulHit: boolean, evt) => successfulHit || evt.successfulHit, false)
 		}
@@ -62,6 +60,56 @@ class NormalisedEvent {
 			return this.confirmedEvents.reduce((successfulHit: boolean, evt) => successfulHit || evt.successfulHit, false)
 		}
 		return false
+	}
+
+	/**
+	 * For damage or heal actions, return all hits that ghosted for this action
+	 *  Ghosted hits generate a "prepares" packet but did not actually deal damage or apply healing
+	 *  Hits typically ghost due to target or source despawning before damage applied.
+	 * For buff events, returns an empty array
+	 */
+	get ghostedHits(): BaseEvent[] {
+		if (isBaseEventArray(this.calculatedEvents)) {
+			return this.calculatedEvents.filter(evt => evt.unpaired)
+		}
+		return []
+	}
+	/**
+	 * Return the number of hits for this action that ghosted.
+	 */
+	get ghostedHitCount(): number {
+		return this.ghostedHits.length
+	}
+	/**
+	 * For damage or heal actions, the total of all damage or healing that did not occur due to ghosted hits
+	 * For buff events, 0
+	 */
+	get ghostedHitAmount(): number {
+		return this.ghostedHits.reduce((total, evt) => total + evt.amount, 0)
+	}
+
+	/**
+	 * For damage or heal actions, return all hits that succeeded for this action (generated a confirming damage action)
+	 * For buff events, returns all events
+	 */
+	get successfulHits(): Array<BaseEvent | BuffEvent> {
+		return this.confirmedEvents
+	}
+	/**
+	 * Return the number of hits for this action that succeeded
+	 */
+	get successsfulHitCount(): number {
+		return this.successfulHits.length
+	}
+	/**
+	 * For damage or heal actions, the total of all damage or healing that was confirmed
+	 * For buff events, 0
+	 */
+	get successfulHitAmount(): number {
+		if (isBaseEventArray(this.successfulHits)) {
+			return this.successfulHits.reduce((total, evt) => total + evt.amount, 0)
+		}
+		return 0
 	}
 
 	attachEvent(event: BaseEvent | BuffEvent) {
@@ -82,7 +130,12 @@ export class NormalisedDamageEvent extends NormalisedEvent {
 
 	constructor(event: DamageEvent | NormalisedDamageEvent) {
 		super()
-		Object.assign(this, (({type, amount, successfulHit, ...props}) => ({...props}))(event))
+		if (isDamageEvent(event)) {
+			Object.assign(this, (({type, amount, successfulHit, ...props}) => ({...props}))(event))
+		}
+		if (isNormalisedDamageEvent(event)) {
+			Object.assign(this, event)
+		}
 	}
 }
 

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -115,7 +115,7 @@ export class NormalisedEvent {
 	/**
 	 * Return the number of hits for this action that succeeded
 	 */
-	get successsfulHitCount(): number {
+	get successfulHitCount(): number {
 		return this.successfulHits.length
 	}
 	/**

--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -128,14 +128,9 @@ export class NormalisedDamageEvent extends NormalisedEvent {
 	calculatedEvents: DamageEvent[] = []
 	confirmedEvents: DamageEvent[] = []
 
-	constructor(event: DamageEvent | NormalisedDamageEvent) {
+	constructor(event: DamageEvent) {
 		super()
-		if (isDamageEvent(event)) {
-			Object.assign(this, (({type, amount, successfulHit, ...props}) => ({...props}))(event))
-		}
-		if (isNormalisedDamageEvent(event)) {
-			Object.assign(this, event)
-		}
+		Object.assign(this, (({type, amount, successfulHit, ...props}) => ({...props}))(event))
 	}
 }
 

--- a/src/parser/jobs/brd/modules/Sidewinder.js
+++ b/src/parser/jobs/brd/modules/Sidewinder.js
@@ -74,7 +74,7 @@ export default class Sidewinder extends Module {
 
 	//For some reason, shadowbite's cast target doesn't work properly in dungeon trash pulls so we gotta do it the hard way
 	_onShadowbiteDamage(event) {
-		if (event.hits === 0) {
+		if (event.hitCount === 0) {
 			// Shadowbite did not hit any targets - action ghosted
 			return
 		}
@@ -92,12 +92,12 @@ export default class Sidewinder extends Module {
 		const shadowbiteDamageEvent = {
 			...event,
 			abilityId: event.ability.guid,
-			isSingleTargetShadowbite: event.hits === 1,
+			isSingleTargetShadowbite: event.hitCount === 1,
 			hasBothDots: dotsApplied > 1,
 			// Due to varience, a guess can be less then the actual raw damage, so we have to check to make sure they are actually losing damage first
-			missedDamage: event.hits * (dotsApplied < 2 ? (MAX_SHADOWBITE_POTENCY * potencyDamageRatio / 100) : 0),
-			missedPotency: event.hits * (MAX_SHADOWBITE_POTENCY - ACTIONS.SHADOWBITE.potency[dotsApplied]),
-			targetsHit: event.hits,
+			missedDamage: event.hitCount * (dotsApplied < 2 ? (MAX_SHADOWBITE_POTENCY * potencyDamageRatio / 100) : 0),
+			missedPotency: event.hitCount * (MAX_SHADOWBITE_POTENCY - ACTIONS.SHADOWBITE.potency[dotsApplied]),
+			targetsHit: event.hitCount,
 			dotsApplied,
 		}
 

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -186,7 +186,7 @@ export default class DirtyDancing extends Module {
 		}
 		// If the finisher didn't hit anything, and something could've been, ding it.
 		// Don't gripe if the boss is invuln, there is use-case for finishing during the downtime
-		if (!event.successfulHit && !this.invuln.isInvulnerable('all', finisher.timestamp)) {
+		if (!event.hasSuccessfulHit && !this.invuln.isInvulnerable('all', finisher.timestamp)) {
 			dance.missed = true
 		}
 		// Dancer messed up if more step actions were recorded than we expected

--- a/src/parser/jobs/dnc/modules/Esprit.tsx
+++ b/src/parser/jobs/dnc/modules/Esprit.tsx
@@ -77,7 +77,7 @@ export default class EspritGauge extends Module {
 	}
 
 	private onDamage(event: NormalisedDamageEvent) {
-		if (!ESPRIT_GENERATION_MULTIPLIERS[event.ability.guid] || !event.successfulHit) {
+		if (!ESPRIT_GENERATION_MULTIPLIERS[event.ability.guid] || !event.hasSuccessfulHit) {
 			return
 		}
 		let generatedAmt = 0

--- a/src/parser/jobs/dnc/modules/FeatherGauge.tsx
+++ b/src/parser/jobs/dnc/modules/FeatherGauge.tsx
@@ -59,7 +59,7 @@ export default class FeatherGauge extends Module {
 	}
 
 	private onCastGenerator(event: NormalisedDamageEvent) {
-		if (!event.successfulHit) {
+		if (!event.hasSuccessfulHit) {
 			return
 		}
 		this.avgGenerated += FEATHER_GENERATION_CHANCE

--- a/src/parser/jobs/drk/modules/ResourceSimulator.js
+++ b/src/parser/jobs/drk/modules/ResourceSimulator.js
@@ -243,14 +243,14 @@ export default class Resources extends Module {
 			}
 		}
 
-		if (event.hitSuccessfulHit && (event.type !== 'combo' && this.combatants.selected.hasStatus(STATUSES.BLOOD_WEAPON.id) && BLOOD_WEAPON_GENERATORS.hasOwnProperty(abilityId))) {
+		if (event.hasSuccessfulHit && (event.type !== 'combo' && this.combatants.selected.hasStatus(STATUSES.BLOOD_WEAPON.id) && BLOOD_WEAPON_GENERATORS.hasOwnProperty(abilityId))) {
 			// Actions that did not hit do not generate resources
 			// Don't double count blood weapon gains on comboed events
 			actionBloodGain += BLOOD_WEAPON_GENERATORS[abilityId].blood
 			actionMPGain += BLOOD_WEAPON_GENERATORS[abilityId].mp
 		}
 
-		if (event.hitSuccessfulHit && RESOURCE_GENERATORS.hasOwnProperty(abilityId)) {
+		if (event.hasSuccessfulHit && RESOURCE_GENERATORS.hasOwnProperty(abilityId)) {
 			// Actions that did not hit do not generate resources
 			const actionInfo = RESOURCE_GENERATORS[abilityId]
 			if ((!actionInfo.requiresCombo && event.type !== 'combo') || event.type === 'combo') {

--- a/src/parser/jobs/drk/modules/ResourceSimulator.js
+++ b/src/parser/jobs/drk/modules/ResourceSimulator.js
@@ -243,14 +243,14 @@ export default class Resources extends Module {
 			}
 		}
 
-		if (event.successfulHit && (event.type !== 'combo' && this.combatants.selected.hasStatus(STATUSES.BLOOD_WEAPON.id) && BLOOD_WEAPON_GENERATORS.hasOwnProperty(abilityId))) {
+		if (event.hitSuccessfulHit && (event.type !== 'combo' && this.combatants.selected.hasStatus(STATUSES.BLOOD_WEAPON.id) && BLOOD_WEAPON_GENERATORS.hasOwnProperty(abilityId))) {
 			// Actions that did not hit do not generate resources
 			// Don't double count blood weapon gains on comboed events
 			actionBloodGain += BLOOD_WEAPON_GENERATORS[abilityId].blood
 			actionMPGain += BLOOD_WEAPON_GENERATORS[abilityId].mp
 		}
 
-		if (event.successfulHit && RESOURCE_GENERATORS.hasOwnProperty(abilityId)) {
+		if (event.hitSuccessfulHit && RESOURCE_GENERATORS.hasOwnProperty(abilityId)) {
 			// Actions that did not hit do not generate resources
 			const actionInfo = RESOURCE_GENERATORS[abilityId]
 			if ((!actionInfo.requiresCombo && event.type !== 'combo') || event.type === 'combo') {

--- a/src/parser/jobs/gnb/modules/Ammo.tsx
+++ b/src/parser/jobs/gnb/modules/Ammo.tsx
@@ -95,7 +95,7 @@ export default class Ammo extends Module {
 	}
 
 	private onFatedCircle(event: NormalisedDamageEvent) {
-		if (event.hits < 2) {
+		if (event.hitCount < 2) {
 			this.erroneousCircles++
 		}
 	}

--- a/src/parser/jobs/mnk/modules/Steppies.tsx
+++ b/src/parser/jobs/mnk/modules/Steppies.tsx
@@ -53,7 +53,7 @@ export default class Steppies extends Module {
 	}
 
 	private onDamage(event: NormalisedDamageEvent): void {
-		if (event.hits > 0) {
+		if (event.hitCount > 0) {
 			const boot = new Boot(event.confirmedEvents[0].criticalHit, this.combatants.selected.hasStatus(STATUSES.LEADEN_FIST.id), event.timestamp)
 			this.steppies.push(boot)
 		}

--- a/src/parser/jobs/nin/modules/Ninjutsu.js
+++ b/src/parser/jobs/nin/modules/Ninjutsu.js
@@ -50,7 +50,7 @@ export default class Ninjutsu extends Module {
 			this._onDotonCast()
 		}
 
-		this._dotonCasts.current.ticks.push(event.hits) // Track the number of enemies hit per tick
+		this._dotonCasts.current.ticks.push(event.hitCount) // Track the number of enemies hit per tick
 	}
 
 	_finishDotonWindow() {

--- a/src/parser/jobs/nin/modules/Ninki.js
+++ b/src/parser/jobs/nin/modules/Ninki.js
@@ -111,7 +111,7 @@ export default class Ninki extends Module {
 	}
 
 	_onHellfrogAoe(event) {
-		if (event.hits === 1) {
+		if (event.hitCount === 1) {
 			// If we have a Hellfrog AoE event with only one target, it should've been a Bhava instead
 			this._erroneousFrogs++
 		}

--- a/src/parser/jobs/rdm/modules/Gauge.js
+++ b/src/parser/jobs/rdm/modules/Gauge.js
@@ -93,7 +93,7 @@ class GaugeAction {
 		const abilityId = event.ability.guid
 		const {white, black} = MANA_GAIN[abilityId] || {}
 		if (white || black) {
-			if (!event.hitSuccessfulHit) {
+			if (!event.hasSuccessfulHit) {
 				// Melee combo skills will still consume mana but will not continue the combo, set an invuln/missed flag for downstream consumers
 				this.missOrInvuln = true
 

--- a/src/parser/jobs/rdm/modules/Gauge.js
+++ b/src/parser/jobs/rdm/modules/Gauge.js
@@ -93,7 +93,7 @@ class GaugeAction {
 		const abilityId = event.ability.guid
 		const {white, black} = MANA_GAIN[abilityId] || {}
 		if (white || black) {
-			if (!event.successfulHit) {
+			if (!event.hitSuccessfulHit) {
 				// Melee combo skills will still consume mana but will not continue the combo, set an invuln/missed flag for downstream consumers
 				this.missOrInvuln = true
 

--- a/src/parser/jobs/sam/modules/AoeChecker.js
+++ b/src/parser/jobs/sam/modules/AoeChecker.js
@@ -47,7 +47,7 @@ export default class AoeChecker extends Module {
 
 			//Step 2: Check break point
 
-			if (event.hits < GAIN2) {
+			if (event.hitCount < GAIN2) {
 				//Step 3: Check type of resource used and increment
 
 				if (AOE_GCDS.has(action)) {
@@ -66,7 +66,7 @@ export default class AoeChecker extends Module {
 
 			//Step 2: Check break point
 
-			if (event.hits < GAIN3) {
+			if (event.hitCount < GAIN3) {
 				//Step 3: Check type of resource used and increment
 
 				if (AOE_GCDS.has(action)) {

--- a/src/parser/jobs/smn/modules/DWT.js
+++ b/src/parser/jobs/smn/modules/DWT.js
@@ -94,7 +94,7 @@ export default class DWT extends Module {
 	}
 
 	_onDeathflareDamage(event) {
-		this._stopAndSave(event.hits, event.timestamp)
+		this._stopAndSave(event.hitCount, event.timestamp)
 	}
 
 	_onApplyDwt(event) {

--- a/src/parser/jobs/smn/modules/Pets.js
+++ b/src/parser/jobs/smn/modules/Pets.js
@@ -182,7 +182,7 @@ export default class Pets extends Module {
 		}
 
 		if (abilityId === ACTIONS.WIND_BLADE.id &&
-			event.hits < GARUDA_MIN_TARGETS) {
+			event.hitCount < GARUDA_MIN_TARGETS) {
 			this._badWindBlades++
 		} else if (abilityId === ACTIONS.SLIPSTREAM.id) {
 			this._slipstreams.push({
@@ -200,7 +200,7 @@ export default class Pets extends Module {
 			this._slipstreams[this._slipstreams.length - 1].ticks.push(event)
 		} else if (
 			IFRIT_AOE_CAPABLE_ACTIONS.includes(abilityId) &&
-			event.hits >= GARUDA_MIN_TARGETS
+			event.hitCount >= GARUDA_MIN_TARGETS
 		) {
 			this._ifritMultiHits++
 		}


### PR DESCRIPTION
In light of e6s confirming that "ghosted" hits still advance combo and generate gauge, this is to adjust the semantics of normalised events (and combo events) to behave the same way as the in game combos & gauge generation do.

Renamed & adjusted the getters on the NormalisedEvent base class per semantics discussion in Discord, fixed downstream consumers as required.