### PR TITLE
Update support for WHM to 5.2

### DIFF
--- a/src/parser/jobs/whm/index.js
+++ b/src/parser/jobs/whm/index.js
@@ -35,7 +35,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.1',
+		to: '5.2',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.NIV, role: ROLES.MAINTAINER},
@@ -43,6 +43,11 @@ export default new Meta({
 		{user: CONTRIBUTORS.SUSHIROU, role: ROLES.DEVELOPER},
 	],
 	changelog: [
+		{
+			date: new Date('2020-02-27'),
+			Changes: () => <>Update WHM for 5.2 support.</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
 		{
 			date: new Date('2019-09-04'),
 			Changes: () => <>Track oGCDs with more clarity.</>,


### PR DESCRIPTION
Since no analysis-based breaking changes were made, this should be fine.