### PR TITLE
Bump WAR to support 5.2

### DIFF
--- a/src/data/STATUSES/layers/index.ts
+++ b/src/data/STATUSES/layers/index.ts
@@ -1,8 +1,12 @@
 import {Layer} from 'data/layer'
 import {StatusRoot} from '../root'
 
+import {patch510} from './patch5.1'
+
 export const layers: Array<Layer<StatusRoot>> = [
 	// Layers should be in their own files, and imported for use here.
 	// Example layer:
 	// {patch: '5.05', data: {BIO_II: {id: 9001}}}}
+
+	patch510,
 ]

--- a/src/data/STATUSES/layers/patch5.1.ts
+++ b/src/data/STATUSES/layers/patch5.1.ts
@@ -1,0 +1,12 @@
+import {Layer} from 'data/layer'
+import {StatusRoot} from '../root'
+
+export const patch510: Layer<StatusRoot> = {
+	patch: '5.1',
+	data: {
+		// WAR 5.1 duration changes
+		RAW_INTUITION: {duration: 6},
+		VENGEANCE: {duration: 15},
+		HOLMGANG: {duration: 8},
+	},
+}

--- a/src/data/STATUSES/root/WAR.ts
+++ b/src/data/STATUSES/root/WAR.ts
@@ -19,14 +19,14 @@ export const WAR = ensureStatuses({
 		id: 735,
 		name: 'Raw Intuition',
 		icon: 'https://xivapi.com/i/012000/012555.png',
-		duration: 5,
+		duration: 6,
 	},
 
 	VENGEANCE: {
 		id: 89,
 		name: 'Vengeance',
 		icon: 'https://xivapi.com/i/010000/010256.png',
-		duration: 10,
+		duration: 15,
 	},
 
 	DEFIANCE: {
@@ -46,7 +46,7 @@ export const WAR = ensureStatuses({
 		id: 409,
 		name: 'Holmgang',
 		icon: 'https://xivapi.com/i/000000/000266.png',
-		duration: 6,
+		duration: 8,
 	},
 
 	STORMS_EYE: {

--- a/src/data/STATUSES/root/WAR.ts
+++ b/src/data/STATUSES/root/WAR.ts
@@ -19,14 +19,14 @@ export const WAR = ensureStatuses({
 		id: 735,
 		name: 'Raw Intuition',
 		icon: 'https://xivapi.com/i/012000/012555.png',
-		duration: 6,
+		duration: 5,
 	},
 
 	VENGEANCE: {
 		id: 89,
 		name: 'Vengeance',
 		icon: 'https://xivapi.com/i/010000/010256.png',
-		duration: 15,
+		duration: 10,
 	},
 
 	DEFIANCE: {
@@ -46,7 +46,7 @@ export const WAR = ensureStatuses({
 		id: 409,
 		name: 'Holmgang',
 		icon: 'https://xivapi.com/i/000000/000266.png',
-		duration: 8,
+		duration: 6,
 	},
 
 	STORMS_EYE: {

--- a/src/parser/jobs/war/index.js
+++ b/src/parser/jobs/war/index.js
@@ -25,10 +25,11 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.08',
+		to: '5.2',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.SKYE, role: ROLES.MAINTAINER},
+		{user: CONTRIBUTORS.ACCHAN, role: ROLES.DEVELOPER},
 	],
 
 	changelog: [


### PR DESCRIPTION
No changes to the job since 5.08 anyway, I won't take over as maintainer as such but I'll keep an eye on the module and handle any bugs, maybe tackle some of the TODO.

I didn't add layers for the status changes, mostly because they're not used at all in analysis.