### PR TITLE
[BugFix] Low DoT uptime calculation when boss is invuln mid-DoT

### DIFF
--- a/src/parser/core/modules/EntityStatuses.ts
+++ b/src/parser/core/modules/EntityStatuses.ts
@@ -130,7 +130,7 @@ export class EntityStatuses extends Module {
 				eventToAdjust.end = invuln.start
 				eventToAdjust.stackHistory.splice(-1, 1, {stacks: 0, timestamp: invuln.start, invuln: true})
 
-				if (invuln.end < eventToAdjust.end!) {
+				if (invuln.end < statusEvent.end!) {
 					this.debug('Invuln split the range - synthesizing second event for status time after invuln')
 					// Invuln ended before the status ended - create a second status for the time after the invuln ended
 					const newStackHistory = statusEvent.stackHistory.slice(0, -1)


### PR DESCRIPTION
Under certain circumstances (most notably e6s), if a DoT is continuously maintained but the boss goes invulnerable in the middle of the duration, the process to exclude the invuln time (and thus not double-count it) from DoT uptime isn't properly synthesizing the "second half" of the DoT duration, due to checking the wrong object.