### PR TITLE
[BugFix]: Undefined reference error when synthesizing new stack history

### DIFF
--- a/src/parser/core/modules/EntityStatuses.ts
+++ b/src/parser/core/modules/EntityStatuses.ts
@@ -133,7 +133,8 @@ export class EntityStatuses extends Module {
 				if (invuln.end < statusEvent.end!) {
 					this.debug('Invuln split the range - synthesizing second event for status time after invuln')
 					// Invuln ended before the status ended - create a second status for the time after the invuln ended
-					const newStackHistory = statusEvent.stackHistory.slice(0, -1)
+					// If the status overlaps the end of the fight or the disappearance of the boss, there may not be a stackHistory event for the end of the debuff - splice on to the end of the array as-is
+					const newStackHistory = statusEvent.stackHistory.some(history => history.stacks === 0) ? statusEvent.stackHistory.slice(0, -1) : statusEvent.stackHistory
 					const stacksBeforeInvuln = newStackHistory[newStackHistory.length - 1].stacks
 					newStackHistory.splice(-1, 1,
 						{stacks: 0, timestamp: invuln.start, invuln: true},


### PR DESCRIPTION
If a DOT overran the end of the fight (seems to be mostly prevalent in wipe logs), there's no stack history event for the removal of the DOT, which broke an assumption of the process that split a status range due to invulnerability.  Given that this was a simple fix (if somewhat requiring an inelegant comment), I'm too lazy to go looking through consumers to figure out if we even need to care about the stack history :blobknife: