### PR TITLE
Bump WAR to 5.25 (latest)

### DIFF
--- a/src/parser/jobs/war/index.js
+++ b/src/parser/jobs/war/index.js
@@ -25,7 +25,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.2',
+		to: '5.25',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.SKYE, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Title, more or less.

Warrior should be all good to go and can just get bumped up.