### PR TITLE
Bugfix negative expected GCDs in Swiftcast module

### DIFF
--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -122,7 +122,7 @@ export abstract class BuffWindowModule extends Module {
 	@dependency private data!: Data
 	@dependency private suggestions!: Suggestions
 	@dependency private timeline!: Timeline
-	@dependency private globalCooldown!: GlobalCooldown
+	@dependency protected globalCooldown!: GlobalCooldown
 
 	private buffWindows: BuffWindowState[] = []
 

--- a/src/parser/core/modules/Swiftcast.tsx
+++ b/src/parser/core/modules/Swiftcast.tsx
@@ -63,7 +63,13 @@ export abstract class SwiftcastModule extends BuffWindowModule {
 	// ding them only if they had enough time during the window to use a spell with
 	// swiftcast
 	protected reduceExpectedGCDsEndOfFight(buffWindow: BuffWindowState): number {
-		return Math.min(1, super.reduceExpectedGCDsEndOfFight(buffWindow))
+		if ( this.buffStatus.duration ) {
+			// Check to see if this window is rushing due to end of fight - reduce expected GCDs accordingly
+			const fightTimeRemaining = this.parser.fight.end_time - buffWindow.start
+			const gcdEstimate = this.globalCooldown.getEstimate()
+			return ( fightTimeRemaining > gcdEstimate ) ? 0 : 1
+		}
+		return 0
 	}
 
 	protected considerAction(action: Action) {

--- a/src/parser/core/modules/Swiftcast.tsx
+++ b/src/parser/core/modules/Swiftcast.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS, {Action} from 'data/ACTIONS'
 import STATUSES, {Status} from 'data/STATUSES'
-import {BuffWindowExpectedGCDs, BuffWindowModule} from 'parser/core/modules/BuffWindow'
+import {BuffWindowExpectedGCDs, BuffWindowModule, BuffWindowState} from 'parser/core/modules/BuffWindow'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 
 interface SeverityTiers {
@@ -45,6 +45,25 @@ export abstract class SwiftcastModule extends BuffWindowModule {
 		expectedPerWindow: 1,
 		suggestionContent: this.suggestionContent,
 		severityTiers: this.severityTiers,
+	}
+
+	protected init() {
+		super.init()
+		// Inheriting the class doesn't update expectedGCDs's parameters when they
+		// override, so let's (re)define it here... feels mega jank tho
+		this.expectedGCDs = {
+			expectedPerWindow: 1,
+			suggestionContent: this.suggestionContent,
+			severityTiers: this.severityTiers,
+		}
+	}
+
+	// Provide our own logic for the end of the fight – even though the window is
+	// ~4 GCDs 'wide', we can only use one action with it anyway; this change should
+	// ding them only if they had enough time during the window to use a spell with
+	// swiftcast
+	protected reduceExpectedGCDsEndOfFight(buffWindow: BuffWindowState): number {
+		return Math.min(1, super.reduceExpectedGCDsEndOfFight(buffWindow))
 	}
 
 	protected considerAction(action: Action) {


### PR DESCRIPTION
* Provide our own `reduceExpectedGCDsEndOfFight` method that totally doesn't just rip off the original at all
* Redefine `expectedGCDs` in init (lemme know if you want me to move this to the constructor instead) so that inheriting classes can provide their own suggestion content and severity tiers.