### PR TITLE
Added a check in the Ninjutsu module to forgive prepull STDs

### DIFF
--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -180,6 +180,7 @@ export const NIN = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002911.png',
 		onGcd: true,
 		gcdRecast: 1.5,
+		statusesApplied: ['DOTON'],
 	},
 
 	DOTON_TCJ: {
@@ -188,6 +189,7 @@ export const NIN = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002911.png',
 		onGcd: true,
 		gcdRecast: 1.5,
+		statusesApplied: ['DOTON'],
 	},
 
 	SUITON: {
@@ -196,6 +198,7 @@ export const NIN = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002913.png',
 		onGcd: true,
 		gcdRecast: 1.5,
+		statusesApplied: ['SUITON'],
 	},
 
 	SUITON_TCJ: {
@@ -204,6 +207,7 @@ export const NIN = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002913.png',
 		onGcd: true,
 		gcdRecast: 1.5,
+		statusesApplied: ['SUITON'],
 	},
 
 	RABBIT_MEDIUM: {

--- a/src/parser/jobs/nin/modules/Ninjutsu.js
+++ b/src/parser/jobs/nin/modules/Ninjutsu.js
@@ -30,7 +30,7 @@ export default class Ninjutsu extends Module {
 		this.addEventHook('cast', {by: 'player', abilityId: [ACTIONS.HYOTON.id, ACTIONS.HYOTON_TCJ.id]}, () => { this._hyotonCount++ })
 		this.addEventHook('cast', {by: 'player', abilityId: ACTIONS.RABBIT_MEDIUM.id}, () => { this._rabbitCount++ })
 		this.addEventHook('cast', {by: 'player', abilityId: [ACTIONS.DOTON.id, ACTIONS.DOTON_TCJ.id]}, this._onDotonCast)
-		this.addEventHook('normaliseddamage', {by: 'player', abilityId: STATUSES.DOTON.id}, this._onDotonDamage)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: STATUSES.DOTON.id}, event => { this._dotonCasts.current.ticks.push(event.hitCount) })
 		this.addEventHook('removebuff', {by: 'player', abilityId: STATUSES.DOTON.id}, this._finishDotonWindow)
 		this.addEventHook('complete', this._onComplete)
 	}
@@ -43,15 +43,6 @@ export default class Ninjutsu extends Module {
 			ticks: [],
 			prepull: event.timestamp < this.parser.fight.start_time,
 		}
-	}
-
-	_onDotonDamage(event) {
-		// If there are no casts at all, use the damage event to fabricate one
-		if (!this._dotonCasts.current) {
-			this._onDotonCast(event)
-		}
-
-		this._dotonCasts.current.ticks.push(event.hitCount) // Track the number of enemies hit per tick
 	}
 
 	_finishDotonWindow() {

--- a/src/parser/jobs/nin/modules/Ninjutsu.js
+++ b/src/parser/jobs/nin/modules/Ninjutsu.js
@@ -9,7 +9,7 @@ import {TieredSuggestion, Suggestion, SEVERITY} from 'parser/core/modules/Sugges
 
 const DOTON_TICK_TARGET = 6
 const JUSTIFIABLE_DOTON_TICKS = 10
-const PREPULL_DOTON_BUFFER = 3000
+const PREPULL_DOTON_BUFFER = 18000
 
 export default class Ninjutsu extends Module {
 	static handle = 'ninjutsu'

--- a/src/parser/jobs/nin/modules/Ninjutsu.js
+++ b/src/parser/jobs/nin/modules/Ninjutsu.js
@@ -9,7 +9,6 @@ import {TieredSuggestion, Suggestion, SEVERITY} from 'parser/core/modules/Sugges
 
 const DOTON_TICK_TARGET = 6
 const JUSTIFIABLE_DOTON_TICKS = 10
-const PREPULL_DOTON_BUFFER = 18000
 
 export default class Ninjutsu extends Module {
 	static handle = 'ninjutsu'
@@ -36,21 +35,20 @@ export default class Ninjutsu extends Module {
 		this.addEventHook('complete', this._onComplete)
 	}
 
-	_onDotonCast(event, fabricated) {
+	_onDotonCast(event) {
 		this._finishDotonWindow()
 
 		this._dotonCasts.current = {
 			tcj: this.combatants.selected.hasStatus(STATUSES.TEN_CHI_JIN.id),
 			ticks: [],
-			prepull: fabricated && (event.timestamp - PREPULL_DOTON_BUFFER) <= this.parser.fight.start_time,
-			// Flag Dotons with no cast event and a first damage tick at or before 3s as prepull so we don't ding on them
+			prepull: event.timestamp < this.parser.fight.start_time,
 		}
 	}
 
 	_onDotonDamage(event) {
 		// If there are no casts at all, use the damage event to fabricate one
 		if (!this._dotonCasts.current) {
-			this._onDotonCast(event, true)
+			this._onDotonCast(event)
 		}
 
 		this._dotonCasts.current.ticks.push(event.hitCount) // Track the number of enemies hit per tick

--- a/src/parser/jobs/nin/modules/TrickAttackUsage.js
+++ b/src/parser/jobs/nin/modules/TrickAttackUsage.js
@@ -31,7 +31,7 @@ export default class TrickAttackUsage extends Module {
 
 	_onCast(event) {
 		const action = getDataBy(ACTIONS, 'id', event.ability.guid)
-		if (action && action.onGcd && !(
+		if (event.timestamp >= this.parser.fight.start_time && action && action.onGcd && !(
 			action.id === ACTIONS.TEN.id || action.id === ACTIONS.TEN_KASSATSU.id || action.id === ACTIONS.CHI.id || action.id === ACTIONS.JIN.id)) {
 			// Don't count the individual mudras as GCDs for this - they'll make the count screw if Suiton wasn't set up pre-pull
 			this._gcdCount++


### PR DESCRIPTION
The meme opener for NIN on fights where the boss gets pulled far enough into middle includes a prepull Doton before the Hide reset into Suiton. The module was dinging on it when there's no harm in getting free damage, so this fixes that.