### PR TITLE
Unify the utilities function formatDuration with parser.formatDuration

### DIFF
--- a/src/components/Find/FightItem.js
+++ b/src/components/Find/FightItem.js
@@ -32,7 +32,7 @@ class FightItem extends Component {
 		const url = `/find/${code}/${id}/`
 		const colour = kill? 'green' : 'red'
 		const progress = Math.round(100 - (fightPercentage/100))
-		const duration = Math.round((end_time - start_time)/1000)
+		const duration = end_time - start_time
 
 		return <Menu.Item as={Link} to={url}>
 			{name}

--- a/src/components/GlobalSidebar/Breadcrumbs.js
+++ b/src/components/GlobalSidebar/Breadcrumbs.js
@@ -78,7 +78,7 @@ class Breadcrumbs extends React.Component {
 					const fight = getCorrectedFight(rawFight)
 					const start_time = parseInt(fight.start_time, 10)
 					const end_time = parseInt(fight.end_time, 10)
-					subtitle = `(${formatDuration(Math.floor(end_time - start_time) / 1000)})`
+					subtitle = `(${formatDuration(end_time - start_time)})`
 
 					crumbsBackground = getZoneBanner(fight.zoneID)
 					title = fight.name

--- a/src/components/ui/RotationTable.tsx
+++ b/src/components/ui/RotationTable.tsx
@@ -160,7 +160,7 @@ export class RotationTable extends React.Component<RotationTableProps> {
 	static Row = ({onGoto, targets, notes, notesMap, start, end, targetsData, rotation}: RotationTableRowProps & RotationTableEntry) =>
 		<Table.Row>
 			<Table.Cell textAlign="center">
-				<span style={{marginRight: 5}}>{formatDuration(start, 0, true, false)}</span>
+				<span style={{marginRight: 5}}>{formatDuration(start)}</span>
 				{typeof onGoto === 'function' && <Button
 					circular
 					compact

--- a/src/components/ui/RotationTable.tsx
+++ b/src/components/ui/RotationTable.tsx
@@ -160,7 +160,7 @@ export class RotationTable extends React.Component<RotationTableProps> {
 	static Row = ({onGoto, targets, notes, notesMap, start, end, targetsData, rotation}: RotationTableRowProps & RotationTableEntry) =>
 		<Table.Row>
 			<Table.Cell textAlign="center">
-				<span style={{marginRight: 5}}>{formatDuration(start / 1000)}</span>
+				<span style={{marginRight: 5}}>{formatDuration(start, 0, true, false)}</span>
 				{typeof onGoto === 'function' && <Button
 					circular
 					compact

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -456,7 +456,7 @@ class Parser {
 	}
 
 	formatDuration(duration: number, secondPrecision?: number) {
-		return formatDuration(duration, secondPrecision, true, true)
+		return formatDuration(duration, {hideMinutesIfZero: true})
 	}
 
 	/**

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -13,6 +13,7 @@ import {Dispatcher} from './Dispatcher'
 import {Meta} from './Meta'
 import Module, {DISPLAY_MODE, MappedDependency} from './Module'
 import {Patch} from './Patch'
+import {formatDuration} from 'utilities'
 
 interface Player extends Actor {
 	pets: Pet[]
@@ -455,19 +456,7 @@ class Parser {
 	}
 
 	formatDuration(duration: number, secondPrecision?: number) {
-		/* tslint:disable:no-magic-numbers */
-		duration /= 1000
-		const seconds = duration % 60
-		if (duration < 60) {
-			const precision = secondPrecision !== undefined? secondPrecision : seconds < 10? 2 : 0
-			return seconds.toFixed(precision) + 's'
-		}
-		const precision = secondPrecision !== undefined ? secondPrecision : 0
-		const secondsText = precision ? seconds.toFixed(precision) : '' + Math.floor(seconds)
-		let pointPos = secondsText.indexOf('.')
-		if (pointPos === -1) { pointPos = secondsText.length }
-		return `${Math.floor(duration / 60)}:${pointPos === 1? '0' : ''}${secondsText}`
-		/* tslint:enable:no-magic-numbers */
+		return formatDuration(duration, secondPrecision, true, true)
 	}
 
 	/**

--- a/src/parser/jobs/rdm/modules/MeleeCombos.js
+++ b/src/parser/jobs/rdm/modules/MeleeCombos.js
@@ -507,7 +507,7 @@ export default class MeleeCombos extends Module {
 
 							return (<Table.Row key={timestamp}>
 								<Table.Cell textAlign="center">
-									<span style={{marginRight: 5}}>{formatDuration(start / 1000)}</span>
+									<span style={{marginRight: 5}}>{formatDuration(start, 0, true, false)}</span>
 									{<Button
 										circular
 										compact

--- a/src/parser/jobs/rdm/modules/MeleeCombos.js
+++ b/src/parser/jobs/rdm/modules/MeleeCombos.js
@@ -507,7 +507,7 @@ export default class MeleeCombos extends Module {
 
 							return (<Table.Row key={timestamp}>
 								<Table.Cell textAlign="center">
-									<span style={{marginRight: 5}}>{formatDuration(start, 0, true, false)}</span>
+									<span style={{marginRight: 5}}>{formatDuration(start)}</span>
 									{<Button
 										circular
 										compact

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -1,16 +1,20 @@
 /**
  * Renders a time given into the format `mm:ss`
- * @param duration {number} Seconds
- * @param secondPrecision {number} Optional value for number of decimal places to format seconds values to
- * @param isMilliseconds {boolean} Optional value for whether the input duration is in Milliseconds.  Defaults to false (input value is in seconds)
- * @param hideMinutesIfZero {boolean} Optional value for whether the return string should hide minutes (and only return ss.##s for values less than 1 minute).  Defaults to false (always show minutes)
+ * @param duration {number} Milliseconds
+ * @param options {object} Interface for optional option values
+ * @param options.secondPrecision {number} Optional value for number of decimal places to format seconds values to
+ * @param options.hideMinutesIfZero {boolean} Optional value for whether the return string should hide minutes (and only return ss.##s for values less than 1 minute).  Defaults to false (always show minutes)
  * @return {string} Formatted duration
  */
-export function formatDuration(duration: number, secondPrecision?: number, isMilliseconds: boolean = false, hideMinutesIfZero: boolean = false): string {
+export function formatDuration(duration: number, options: {
+		secondPrecision?: number,
+		hideMinutesIfZero: boolean,
+	} = {secondPrecision: undefined, hideMinutesIfZero: false}): string {
 	/* tslint:disable:no-magic-numbers */
-	if (isMilliseconds)	{ duration /= 1000 }
+	duration /= 1000
+
 	const defaultSecondPrecision = duration < 10 ? 2 : 0
-	const precision = secondPrecision != null ? secondPrecision : defaultSecondPrecision
+	const precision = options.secondPrecision != null ? options.secondPrecision : defaultSecondPrecision
 
 	const minutesFormatter = new Intl.NumberFormat(
 		undefined,
@@ -27,7 +31,7 @@ export function formatDuration(duration: number, secondPrecision?: number, isMil
 
 	const seconds = duration % 60
 	const minutes = Math.floor(duration / 60)
-	if (minutes === 0 && hideMinutesIfZero) {
+	if (minutes === 0 && options.hideMinutesIfZero) {
 		const secondsFormatter = new Intl.NumberFormat(undefined, {minimumIntegerDigits: 1, maximumFractionDigits: precision})
 		return `${secondsFormatter.format(seconds)}s`
 	} else {

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -10,6 +10,9 @@ export function formatDuration(duration: number, options: {
 		secondPrecision?: number,
 		hideMinutesIfZero: boolean,
 	} = {secondPrecision: undefined, hideMinutesIfZero: false}): string {
+	if (duration == null || isNaN(duration)) {
+		throw Error('A non-numeric value was supplied to formatDuration')
+	}
 	/* tslint:disable:no-magic-numbers */
 	duration /= 1000
 

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -1,17 +1,39 @@
 /**
  * Renders a time given into the format `mm:ss`
  * @param duration {number} Seconds
+ * @param secondPrecision {number} Optional value for number of decimal places to format seconds values to
+ * @param isMilliseconds {boolean} Optional value for whether the input duration is in Milliseconds.  Defaults to false (input value is in seconds)
+ * @param hideMinutesIfZero {boolean} Optional value for whether the return string should hide minutes (and only return ss.##s for values less than 1 minute).  Defaults to false (always show minutes)
  * @return {string} Formatted duration
  */
-export function formatDuration(duration: number): string {
+export function formatDuration(duration: number, secondPrecision?: number, isMilliseconds: boolean = false, hideMinutesIfZero: boolean = false): string {
 	/* tslint:disable:no-magic-numbers */
-	const formatter = new Intl.NumberFormat(
+	if (isMilliseconds)	{ duration /= 1000 }
+	const defaultSecondPrecision = duration < 10 ? 2 : 0
+	const precision = secondPrecision != null ? secondPrecision : defaultSecondPrecision
+
+	const minutesFormatter = new Intl.NumberFormat(
 		undefined,
-		{minimumIntegerDigits: 2, maximumFractionDigits: 0, useGrouping: false},
+		{
+			minimumIntegerDigits: 2,
+			maximumFractionDigits: 0,
+			useGrouping: false,
+		},
 	)
-	const seconds = Math.floor(duration % 60)
+	if (duration < 0)
+	{
+		return '< 0s'
+	}
+
+	const seconds = duration % 60
 	const minutes = Math.floor(duration / 60)
-	return `${formatter.format(minutes)}:${formatter.format(seconds)}`
+	if (minutes === 0 && hideMinutesIfZero) {
+		const secondsFormatter = new Intl.NumberFormat(undefined, {minimumIntegerDigits: 1, maximumFractionDigits: precision})
+		return `${secondsFormatter.format(seconds)}s`
+	} else {
+		const secondsFormatter = new Intl.NumberFormat(undefined, {minimumIntegerDigits: 2, maximumFractionDigits: precision})
+		return `${minutesFormatter.format(minutes)}:${secondsFormatter.format(seconds)}`
+	}
 	/* tslint:enable:no-magic-numbers */
 }
 


### PR DESCRIPTION
This also changes the behavior of formatDuration for pre-pull timestamps to show <0s rather than -01:-01