### PR TITLE
PLD 5.2 updates

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -629,7 +629,7 @@
   "pld.goring.suggestions.goringblade.why": "{0} of <0/> lost to early refreshes.",
   "pld.requiescat.suggestions.nobuff.content": "<0/> should only be used when over 80% MP. Try to not miss on the 20% Magic Damage buff <1/> provides.",
   "pld.requiescat.suggestions.nobuff.why": "{missedRequiescatBuffs, plural, one {# usage} other {# usages}} while under 80% MP.",
-  "pld.requiescat.suggestions.wrong-gcd.content": "GCDs used during <0/> should consist of 4 uses of <1/> (or multi-hit <2/>) and 1 use of <3/> for optimal damage.",
+  "pld.requiescat.suggestions.wrong-gcd.content": "GCDs used during <0/> should consist of 3-4 uses of <1/> (or 4 uses of multi-hit <2/>) and 1 use of <3/> for optimal damage.",
   "pld.requiescat.suggestions.wrong-gcd.why": "{missedCasts, plural, one {# missing cast} other {# missing casts}} during the <0/> buff window.",
   "pld.requiescat.title": "Requiescat Usage",
   "rdm.about.description": "<0>This analyzer aims to give you the information you need to turn your <1>parses</1> into <2>parses</2></0><3>If you would like to learn more about RDM, check the guides over at <4>The Balance</4>, and have a chat in the <5>#rdm_questions</5> channel.</3>",

--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -34,7 +34,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.08',
+		to: '5.2',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.MIKEMATRIX, role: ROLES.MAINTAINER},
@@ -84,6 +84,13 @@ export default new Meta({
 				Don't penalize for rushed Fight or Flight windows due to expected downtime or end-of-fight.
 			</>,
 			contributors: [CONTRIBUTORS.LHEA],
+		},
+		{
+			date: new Date('2020-04-19'),
+			Changes: () => <>
+				Adjust recommendations for Requiescat and Fight or Flight window lengths.
+			</>,
+			contributors: [CONTRIBUTORS.QAPHLA],
 		},
 	],
 })

--- a/src/parser/jobs/pld/modules/FightOrFlight.tsx
+++ b/src/parser/jobs/pld/modules/FightOrFlight.tsx
@@ -56,7 +56,7 @@ const CONSTANTS = {
 		EXPECTED: 1,
 	},
 	GCD: {
-		EXPECTED: 10,
+		EXPECTED: 11,
 	},
 }
 

--- a/src/parser/jobs/pld/modules/NOTES.md
+++ b/src/parser/jobs/pld/modules/NOTES.md
@@ -10,5 +10,5 @@
 * Ensure 1 Spirits Within, 1 Circle of Scorn, 1+ Intervene per FoF use. (barring add delay). Sometimes worth to not use an Intervene, but that's fight specific.
 * Naturally, they will be used every 63~ seconds, not 60. Requires a coding exceeption. With the intro of Atonement, possible to easily use every 60 seconds.
 # Proper Req usage
-* Ensure 4 casts of Holy Spirit and 1 Confiteor in Req.
+* Ensure 3-4 casts of Holy Spirit and 1 Confiteor in Req.
 * Extra check if casts were made outside of Requiescat, that would have caused a loss of mana.

--- a/src/parser/jobs/pld/modules/NOTES.md
+++ b/src/parser/jobs/pld/modules/NOTES.md
@@ -5,7 +5,7 @@
 # Casting Clemency
 * Interrupts combo, obvious flags.
 # Proper utilization of FoF
-* 10 total GCDs of FoF (Lead Goring, filler, end Goring) - see guide for a rotation image.
+* 11 total GCDs of FoF (Lead Goring, filler, end Goring) - see guide for a rotation image.
 * At most 2 Gorings per FoF use.
 * Ensure 1 Spirits Within, 1 Circle of Scorn, 1+ Intervene per FoF use. (barring add delay). Sometimes worth to not use an Intervene, but that's fight specific.
 * Naturally, they will be used every 63~ seconds, not 60. Requires a coding exceeption. With the intro of Atonement, possible to easily use every 60 seconds.

--- a/src/parser/jobs/pld/modules/Requiescat.tsx
+++ b/src/parser/jobs/pld/modules/Requiescat.tsx
@@ -42,7 +42,7 @@ class RequiescatState {
 	start: number
 	end: number | null = null
 	rotation: CastEvent[] = []
-	hasAscociatedBuff: boolean = false
+	hasAssociatedBuff: boolean = false
 	isRushing: boolean = false
 
 	constructor(start: number) {
@@ -120,7 +120,7 @@ export default class Requiescat extends Module {
 		const lastRequiescat = this.lastRequiescat
 
 		if (lastRequiescat != null) {
-			lastRequiescat.hasAscociatedBuff = true
+			lastRequiescat.hasAssociatedBuff = true
 		}
 	}
 
@@ -136,10 +136,10 @@ export default class Requiescat extends Module {
 		// The difference between Holy Spirit and Confiteor is massive (450 potency before multipliers). For this reason, it condenses suggestions
 		// to just log any missed Confiteor as a missed Holy Spirit, since Confiteor functionally just doubles your last Holy Spirit.
 		const missedCasts = this.requiescats
-			.filter(requiescat => requiescat.hasAscociatedBuff && !requiescat.isRushing)
+			.filter(requiescat => requiescat.hasAssociatedBuff && !requiescat.isRushing)
 			.reduce((sum, requiescat) =>
 				sum + Math.max(0, CONSTANTS.HOLY_SPIRIT.EXPECTED - requiescat.holySpirits) + Math.max(0, CONSTANTS.CONFITEOR.EXPECTED - requiescat.confiteors), 0)
-		const missedRequiescatBuffs = this.requiescats.filter(requiescat => !requiescat.hasAscociatedBuff).length
+		const missedRequiescatBuffs = this.requiescats.filter(requiescat => !requiescat.hasAssociatedBuff).length
 
 		this.suggestions.add(new TieredSuggestion({
 			icon: ACTIONS.HOLY_SPIRIT.icon,
@@ -184,7 +184,7 @@ export default class Requiescat extends Module {
 				},
 			]}
 			data={this.requiescats
-				.filter(requiescat => requiescat.hasAscociatedBuff)
+				.filter(requiescat => requiescat.hasAssociatedBuff)
 				.map(requiescat => ({
 					start: requiescat.start - this.parser.fight.start_time,
 					end: requiescat.end != null ?

--- a/src/parser/jobs/pld/modules/Requiescat.tsx
+++ b/src/parser/jobs/pld/modules/Requiescat.tsx
@@ -24,7 +24,7 @@ const SEVERITIES = {
 
 const CONSTANTS = {
 	HOLY_SPIRIT: {
-		EXPECTED: 4,
+		EXPECTED: 3,
 	},
 	CONFITEOR: {
 		EXPECTED: 1,
@@ -147,7 +147,7 @@ export default class Requiescat extends Module {
 				<Plural value={missedCasts} one="# missing cast" other="# missing casts"/> during the <StatusLink {...STATUSES.REQUIESCAT}/> buff window.
 			</Trans>,
 			content: <Trans id="pld.requiescat.suggestions.wrong-gcd.content">
-				GCDs used during <ActionLink {...ACTIONS.REQUIESCAT}/> should consist of 4 uses of <ActionLink {...ACTIONS.HOLY_SPIRIT}/> (or
+				GCDs used during <ActionLink {...ACTIONS.REQUIESCAT}/> should consist of 3-4 uses of <ActionLink {...ACTIONS.HOLY_SPIRIT}/> (or 4 uses of
 				multi-hit <ActionLink {...ACTIONS.HOLY_CIRCLE}/>) and 1 use of <ActionLink {...ACTIONS.CONFITEOR}/> for optimal damage.
 			</Trans>,
 			tiers: SEVERITIES.MISSED_CASTS,


### PR DESCRIPTION
This PR makes some minor changes to PLD recommendations and (due to the lack of major changes) marks PLD as supported through 5.2.

Change details:
- Fight or Flight now recommends fitting 11 GCDs rather than 10 to reflect best practices.
- Requiescat now only complains about sub-3-Holy Spirit windows, to reflect the frequent utility of a 60s PLD rotation which drops a Holy Spirit every minute.