### PR TITLE
Update Asylum ID

### DIFF
--- a/src/data/STATUSES/root/WHM.ts
+++ b/src/data/STATUSES/root/WHM.ts
@@ -62,7 +62,7 @@ export const WHM = ensureStatuses({
 	},
 
 	ASYLUM: {
-		id: 739,
+		id: 1911,
 		name: 'Asylum',
 		icon: 'https://xivapi.com/i/012000/012629.png',
 		duration: 24,


### PR DESCRIPTION
Asylum is using an older ID; it gets changed to a new one at 78 because of the new trait.