### PR TITLE
FormatDuration cleanup & fixes

### DIFF
--- a/src/components/ui/RotationTable.tsx
+++ b/src/components/ui/RotationTable.tsx
@@ -160,7 +160,7 @@ export class RotationTable extends React.Component<RotationTableProps> {
 	static Row = ({onGoto, targets, notes, notesMap, start, end, targetsData, rotation}: RotationTableRowProps & RotationTableEntry) =>
 		<Table.Row>
 			<Table.Cell textAlign="center">
-				<span style={{marginRight: 5}}>{formatDuration(start)}</span>
+				<span style={{marginRight: 5}}>{formatDuration(start, {secondPrecision: 0})}</span>
 				{typeof onGoto === 'function' && <Button
 					circular
 					compact

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -462,7 +462,7 @@ class Parser {
 	}
 
 	formatDuration(duration: number, secondPrecision?: number) {
-		return formatDuration(duration, {hideMinutesIfZero: true})
+		return formatDuration(duration, {secondPrecision, hideMinutesIfZero: true, showNegative: true})
 	}
 
 	/**

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -1,15 +1,19 @@
+import _ from 'lodash'
+
 /**
  * Renders a time given into the format `mm:ss`
  * @param duration {number} Milliseconds
  * @param options {object} Interface for optional option values
  * @param options.secondPrecision {number} Optional value for number of decimal places to format seconds values to
- * @param options.hideMinutesIfZero {boolean} Optional value for whether the return string should hide minutes (and only return ss.##s for values less than 1 minute).  Defaults to false (always show minutes)
+ * @param options.hideMinutesIfZero {boolean} Value for whether the return string should hide minutes (and only return ss.##s for values less than 1 minute).  Defaults to false (always show minutes)
+ * @param options.showNegative {boolean} Optional value for whether the return string should show a negative number.  Will return '< 0s' for negative numbers if this is false or undefined
  * @return {string} Formatted duration
  */
 export function formatDuration(duration: number, options: {
 		secondPrecision?: number,
-		hideMinutesIfZero: boolean,
-	} = {secondPrecision: undefined, hideMinutesIfZero: false}): string {
+		hideMinutesIfZero?: boolean,
+		showNegative?: boolean,
+	} = {}): string {
 	if (duration == null || isNaN(duration)) {
 		throw Error('A non-numeric value was supplied to formatDuration')
 	}
@@ -19,21 +23,17 @@ export function formatDuration(duration: number, options: {
 	const defaultSecondPrecision = duration < 10 ? 2 : 0
 	const precision = options.secondPrecision != null ? options.secondPrecision : defaultSecondPrecision
 
-	const minutesFormatter = new Intl.NumberFormat(
-		undefined,
-		{
-			minimumIntegerDigits: 2,
-			maximumFractionDigits: 0,
-			useGrouping: false,
-		},
-	)
-	if (duration < 0)
+	duration = _.round(duration, precision)
+
+	const minutesFormatter = new Intl.NumberFormat(undefined, {minimumIntegerDigits: 2, maximumFractionDigits: 0, useGrouping: false})
+
+	if (duration < 0 && !options.showNegative)
 	{
 		return '< 0s'
 	}
 
 	const seconds = duration % 60
-	const minutes = Math.floor(duration / 60)
+	const minutes = (duration < 0) ? Math.ceil(duration / 60) : Math.floor(duration / 60)
 	if (minutes === 0 && options.hideMinutesIfZero) {
 		const secondsFormatter = new Intl.NumberFormat(undefined, {minimumIntegerDigits: 1, maximumFractionDigits: precision})
 		return `${secondsFormatter.format(seconds)}s`

--- a/src/utilities/strings.ts
+++ b/src/utilities/strings.ts
@@ -39,7 +39,7 @@ export function formatDuration(duration: number, options: {
 		return `${secondsFormatter.format(seconds)}s`
 	} else {
 		const secondsFormatter = new Intl.NumberFormat(undefined, {minimumIntegerDigits: 2, maximumFractionDigits: precision})
-		return `${minutesFormatter.format(minutes)}:${secondsFormatter.format(seconds)}`
+		return `${minutesFormatter.format(minutes)}:${secondsFormatter.format(Math.abs(seconds))}`
 	}
 	/* tslint:enable:no-magic-numbers */
 }


### PR DESCRIPTION
- Pass the secondPrecison option from parser.formatDuration to the function, so that the option is actually respected (whoopsie daisy) - restores original behavior
- Add a parameter for showNegative to control whether to format and return the actual negative amount or to return `< 0s` for negative numbers.  Along with this, fix the rounding for minutes so that it rounds in the correct direction on negative numbers, and fix showing -00:-15 if a longer duration.
- Since all of our default option values are falsey, actually make all of the options optional.
- Fix RotationTable so it requests 0 decimals precision for seconds (which it was getting previously with the way the string function behaved), so early windows show as 00:01 instead of 00:01.25, in line with the rest of the table