### PR TITLE
Suppress interrupt table output if there's no interrupts

### DIFF
--- a/src/parser/core/modules/Interrupts.tsx
+++ b/src/parser/core/modules/Interrupts.tsx
@@ -59,8 +59,16 @@ export abstract class Interrupts extends Module {
 	 * @param missedCasts
 	 * @param missedTime
 	 */
-	private suggestionWhy(missedCasts: CastEvent[], missedTime: number): JSX.Element {
+	protected suggestionWhy(missedCasts: CastEvent[], missedTime: number): JSX.Element {
 		return <Trans id="core.interrupts.suggestion.why">You missed { missedCasts.length } casts (approximately { this.parser.formatDuration(missedTime) } of total casting time) due to interruption.</Trans>
+	}
+
+	/**
+	 * Implementing modules MAY override this function to provide alternative output if there's 0 interrupted
+	 * casts (in lieu of an empty table)
+	 */
+	protected noInterruptsOutput(): JSX.Element | undefined {
+		return undefined
 	}
 
 	protected init() {
@@ -109,6 +117,10 @@ export abstract class Interrupts extends Module {
 	}
 
 	output() {
+		if (this.droppedCasts.length === 0) {
+			return this.noInterruptsOutput()
+		}
+
 		return <Table compact unstackable celled collapsing>
 		<Table.Header>
 			<Table.Row>

--- a/src/parser/core/modules/Interrupts.tsx
+++ b/src/parser/core/modules/Interrupts.tsx
@@ -56,8 +56,10 @@ export abstract class Interrupts extends Module {
 
 	/**
 	 * Implementing modules MAY override this function to provide specific text if they wish for the 'why'
-	 * @param missedCasts
-	 * @param missedTime
+	 * The default is to complain that they missed a number of casts and give them an estimate
+	 * @param missedCasts The array of missed casts
+	 * @param missedTime The approximate time wasted via interrupts
+	 * @returns JSX that conforms to your suggestion content
 	 */
 	protected suggestionWhy(missedCasts: CastEvent[], missedTime: number): JSX.Element {
 		return <Trans id="core.interrupts.suggestion.why">You missed { missedCasts.length } casts (approximately { this.parser.formatDuration(missedTime) } of total casting time) due to interruption.</Trans>


### PR DESCRIPTION
What it says on the tin, except there's now a method to provide alternative output as well. Also, corrected an issue which technically would lead to chaos if someone tried to use ts to provide suggestion why content.