### PR TITLE
Fix SMN going turbomode during DWT and swiftcast

### DIFF
--- a/src/parser/core/Module.ts
+++ b/src/parser/core/Module.ts
@@ -23,9 +23,15 @@ export function dependency(target: Module, prop: string) {
 	const dependency = Reflect.getMetadata('design:type', target, prop)
 	const constructor = target.constructor as typeof Module
 
+	// DO NOT REMOVE
+	// This totally-redundant line is a workaround for an issue in FF ~73 which causes the
+	// assignment in the conditional below to completely kludge the entire array regardless
+	// of it's contents if this isn't here.
+	const constructorDependencies = constructor.dependencies
+
 	// Make sure we're not modifying every single module
 	if (!constructor.hasOwnProperty('dependencies')) {
-		constructor.dependencies = [...constructor.dependencies]
+		constructor.dependencies = [...constructorDependencies]
 	}
 
 	// If the dep is Object, it's _probably_ from a JS file. Fall back to simple handling

--- a/src/parser/core/modules/Swiftcast.tsx
+++ b/src/parser/core/modules/Swiftcast.tsx
@@ -47,6 +47,17 @@ export abstract class SwiftcastModule extends BuffWindowModule {
 		severityTiers: this.severityTiers,
 	}
 
+	/**
+	 * Implementing modules MAY override this if they have special cases not covered
+	 * by the standard 'considerAction' method – for example, SMN with instant ruins during
+	 * DWT.
+	 * @param action - the action to consider
+	 * @returns true to allow the spell; false to ignore the spell
+	 */
+	protected considerSwiftAction(action: Action): boolean {
+		return true
+	}
+
 	protected init() {
 		super.init()
 		// Inheriting the class doesn't update expectedGCDs's parameters when they
@@ -73,11 +84,11 @@ export abstract class SwiftcastModule extends BuffWindowModule {
 	}
 
 	protected considerAction(action: Action) {
+		this.debug('Evaluating action during window:', action)
 		// ignore actions that don't have a castTime
-		if (!action.castTime) {
+		if (!action.castTime ) {
 			return false
 		}
-
-		return true
+		return this.considerSwiftAction(action)
 	}
 }

--- a/src/parser/core/modules/Swiftcast.tsx
+++ b/src/parser/core/modules/Swiftcast.tsx
@@ -86,7 +86,7 @@ export abstract class SwiftcastModule extends BuffWindowModule {
 	protected considerAction(action: Action) {
 		this.debug('Evaluating action during window:', action)
 		// ignore actions that don't have a castTime
-		if (!action.castTime ) {
+		if (!action.castTime) {
 			return false
 		}
 		return this.considerSwiftAction(action)

--- a/src/parser/jobs/smn/modules/DWT.js
+++ b/src/parser/jobs/smn/modules/DWT.js
@@ -24,7 +24,7 @@ const CORRECT_GCDS = [
 	ACTIONS.ASSAULT_II_FLAMING_CRUSH.id,
 ]
 
-const DWT_CAST_TIME_MOD = -2.5
+export const DWT_CAST_TIME_MOD = -2.5
 
 export const DWT_LENGTH = 15000
 

--- a/src/parser/jobs/smn/modules/EgiCommands.tsx
+++ b/src/parser/jobs/smn/modules/EgiCommands.tsx
@@ -75,7 +75,6 @@ class UnexecutedCommands {
 export default class EgiCommands extends Module {
 	static handle = 'egicommands'
 	static title = t('smn.egicommands.title')`Unexecuted Egi Commands`
-	static debug = true
 
 	@dependency private suggestions!: Suggestions
 	@dependency private timeline!: Timeline

--- a/src/parser/jobs/smn/modules/Swiftcast.js
+++ b/src/parser/jobs/smn/modules/Swiftcast.js
@@ -12,7 +12,7 @@ const MISSED_SEVERITIES = {
 export default class Swiftcast extends SwiftcastModule {
 	static handle = 'swiftcast'
 
-	@dependency 'dwt'
+	@dependency dwt
 
 	severityTiers = MISSED_SEVERITIES
 

--- a/src/parser/jobs/smn/modules/Swiftcast.js
+++ b/src/parser/jobs/smn/modules/Swiftcast.js
@@ -1,6 +1,5 @@
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import {SwiftcastModule} from 'parser/core/modules/Swiftcast'
-// eslint-disable-next-line no-unused-vars
 import {DWT_LENGTH, DWT_CAST_TIME_MOD} from './DWT'
 
 const MISSED_SEVERITIES = {
@@ -28,7 +27,7 @@ export default class Swiftcast extends SwiftcastModule {
 		const guid = event.ability.guid
 
 		if (guid === this.data.actions.DREADWYRM_TRANCE.id) {
-			this.debug(`dwt now active ${this.parser.formatTimestamp(event.timestamp)}`)
+			this.debug(`DWT now active ${this.parser.formatTimestamp(event.timestamp)}`)
 			this._dwtActive = true
 			this._dwtActiveTimestamp = event.timestamp
 			return
@@ -46,10 +45,7 @@ export default class Swiftcast extends SwiftcastModule {
 
 	considerSwiftAction(event) {
 		this.debug(`DWT Active (${this._dwtActive}): ${event.name}`)
-		if (this._dwtActive) {
-			if (event.castTime + DWT_CAST_TIME_MOD > 0) {
-				return true
-			}
+		if (this._dwtActive && event.castTime + DWT_CAST_TIME_MOD <= 0) {
 			return false
 		}
 		return true

--- a/src/parser/jobs/smn/modules/Swiftcast.js
+++ b/src/parser/jobs/smn/modules/Swiftcast.js
@@ -1,6 +1,7 @@
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import {SwiftcastModule} from 'parser/core/modules/Swiftcast'
-import {DWT_LENGTH, DWT_CAST_TIME_MOD} from './DWT'
+import {DWT_CAST_TIME_MOD} from './DWT'
+import {dependency} from 'parser/core/Module'
 
 const MISSED_SEVERITIES = {
 	1: SEVERITY.MINOR,
@@ -11,41 +12,12 @@ const MISSED_SEVERITIES = {
 export default class Swiftcast extends SwiftcastModule {
 	static handle = 'swiftcast'
 
+	@dependency 'dwt'
+
 	severityTiers = MISSED_SEVERITIES
-	_dwtActive = false
-	_dwtActiveTimestamp = 0
-
-	constructor(...args) {
-		super(...args)
-
-		this.addEventHook('cast', {to: 'player'}, this._onCast)
-		this.addEventHook('normaliseddamage', {by: 'player', abilityId: this.data.actions.DEATHFLARE.id}, this._endDWT)
-		this.addEventHook('death', {to: 'player'}, this._endDWT)
-	}
-
-	_onCast(event) {
-		const guid = event.ability.guid
-
-		if (guid === this.data.actions.DREADWYRM_TRANCE.id) {
-			this.debug(`DWT now active ${this.parser.formatTimestamp(event.timestamp)}`)
-			this._dwtActive = true
-			this._dwtActiveTimestamp = event.timestamp
-			return
-		}
-
-		if (this._dwtActive && event.timestamp - this._dwtActiveTimestamp > DWT_LENGTH) {
-			this._endDWT(event)
-		}
-	}
-
-	_endDWT(event) {
-		this.debug(`Ending DWT ${this.parser.formatTimestamp(event.timestamp)}`)
-		this._dwtActive = false
-	}
 
 	considerSwiftAction(event) {
-		this.debug(`DWT Active (${this._dwtActive}): ${event.name}`)
-		if (this._dwtActive && event.castTime + DWT_CAST_TIME_MOD <= 0) {
+		if (this.dwt.activeAt(this.parser.currentTimestamp) && event.castTime + DWT_CAST_TIME_MOD <= 0) {
 			return false
 		}
 		return true

--- a/src/parser/jobs/smn/modules/Swiftcast.js
+++ b/src/parser/jobs/smn/modules/Swiftcast.js
@@ -1,5 +1,7 @@
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import {SwiftcastModule} from 'parser/core/modules/Swiftcast'
+// eslint-disable-next-line no-unused-vars
+import {DWT_LENGTH, DWT_CAST_TIME_MOD} from './DWT'
 
 const MISSED_SEVERITIES = {
 	1: SEVERITY.MINOR,
@@ -8,5 +10,48 @@ const MISSED_SEVERITIES = {
 }
 
 export default class Swiftcast extends SwiftcastModule {
+	static handle = 'swiftcast'
+
 	severityTiers = MISSED_SEVERITIES
+	_dwtActive = false
+	_dwtActiveTimestamp = 0
+
+	constructor(...args) {
+		super(...args)
+
+		this.addEventHook('cast', {to: 'player'}, this._onCast)
+		this.addEventHook('normaliseddamage', {by: 'player', abilityId: this.data.actions.DEATHFLARE.id}, this._endDWT)
+		this.addEventHook('death', {to: 'player'}, this._endDWT)
+	}
+
+	_onCast(event) {
+		const guid = event.ability.guid
+
+		if (guid === this.data.actions.DREADWYRM_TRANCE.id) {
+			this.debug(`dwt now active ${this.parser.formatTimestamp(event.timestamp)}`)
+			this._dwtActive = true
+			this._dwtActiveTimestamp = event.timestamp
+			return
+		}
+
+		if (this._dwtActive && event.timestamp - this._dwtActiveTimestamp > DWT_LENGTH) {
+			this._endDWT(event)
+		}
+	}
+
+	_endDWT(event) {
+		this.debug(`Ending DWT ${this.parser.formatTimestamp(event.timestamp)}`)
+		this._dwtActive = false
+	}
+
+	considerSwiftAction(event) {
+		this.debug(`DWT Active (${this._dwtActive}): ${event.name}`)
+		if (this._dwtActive) {
+			if (event.castTime + DWT_CAST_TIME_MOD > 0) {
+				return true
+			}
+			return false
+		}
+		return true
+	}
 }


### PR DESCRIPTION
* Added helper method to Swiftcast that's much like it's parent class that allows users to filter out swiftcasts.
* Modified the SMN-specific implementation of swiftcast to filter out casts during DWT. To do this, I'm pretty sure I just read a book on necromancy (or figured out some of the pain SMN devs have to go through) to figure out how DWT worked.
* Modified DWT to export DWT_CAST_TIME_MOD so it only has to be edited in one place instead of every file (do we have a 'job constants' file somewhere?)
* Was a good dev and disabled debug mode on EgiCommands.tsx when I saw that someone had left it enabled