### PR TITLE
Fix the GCD estimation

### DIFF
--- a/src/data/ACTIONS/root/BLM.ts
+++ b/src/data/ACTIONS/root/BLM.ts
@@ -34,7 +34,7 @@ export const BLM = ensureActions({
 		name: 'Freeze',
 		icon: 'https://xivapi.com/i/002000/002653.png',
 		onGcd: true,
-		castTime: 3.0,
+		castTime: 2.5,
 	},
 	UMBRAL_SOUL: {
 		id: 16506,


### PR DESCRIPTION
So _apparently_ serverticks are the cause as to why we can get faster/slower GCD estimates, in a 0.05s range around the real GCD.

Initial idea is to locate peaks in the GCD histogram and then rebin the whole thing since it's most likely to have the client side GCD value as the GCD and not GCD +- 0.05.