### PR TITLE
[NIN] Change Huton clipping suggestion to align with 5.1 combo changes

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -577,7 +577,7 @@
   "nin.huton.checklist.description.warning": "As Huton is now a gauge instead of a buff, please bear in mind that this is an estimate, not an exact value. This also applies to any Huton-related suggestions below.",
   "nin.huton.checklist.name": "Keep Huton up",
   "nin.huton.checklist.requirement.name": "<0/> uptime",
-  "nin.huton.suggestions.clipping.content": "Avoid using <0/> when <1/> has more than 40 seconds left on its duration. The excess time is wasted, so using [~action/AEOLIAN_EDGE] is typically the better option.",
+  "nin.huton.suggestions.clipping.content": "Avoid using <0/> when <1/> has more than 40 seconds left on its duration. The excess time is wasted, so using <2/> is typically the better option.",
   "nin.huton.suggestions.clipping.why": "You clipped {0} of Huton with early Armor Crushes.",
   "nin.huton.suggestions.futile-ac.content": "Avoid using <0/> when <1/> is down, as it provides no benefit and does less DPS than your other combo finishers.",
   "nin.huton.suggestions.futile-ac.why": "You used Armor Crush {futileArmorCrushes, plural, one {# time} other {# times}} when Huton was down.",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -577,7 +577,7 @@
   "nin.huton.checklist.description.warning": "As Huton is now a gauge instead of a buff, please bear in mind that this is an estimate, not an exact value. This also applies to any Huton-related suggestions below.",
   "nin.huton.checklist.name": "Keep Huton up",
   "nin.huton.checklist.requirement.name": "<0/> uptime",
-  "nin.huton.suggestions.clipping.content": "Avoid using <0/> when <1/> has more than 40 seconds left on its duration. The excess time is wasted, so your other two combo finishers are typically better options.",
+  "nin.huton.suggestions.clipping.content": "Avoid using <0/> when <1/> has more than 40 seconds left on its duration. The excess time is wasted, so using [~action/AEOLIAN_EDGE] is typically the better option.",
   "nin.huton.suggestions.clipping.why": "You clipped {0} of Huton with early Armor Crushes.",
   "nin.huton.suggestions.futile-ac.content": "Avoid using <0/> when <1/> is down, as it provides no benefit and does less DPS than your other combo finishers.",
   "nin.huton.suggestions.futile-ac.why": "You used Armor Crush {futileArmorCrushes, plural, one {# time} other {# times}} when Huton was down.",

--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -6,7 +6,7 @@ export const NIN = ensureActions({
 	// -----
 
 	AEOLIAN_EDGE: {
-		id: 3563,
+		id: 2255,
 		name: 'Aeolian Edge',
 		icon: 'https://xivapi.com/i/000000/000605.png',
 		onGcd: true,

--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -5,6 +5,19 @@ export const NIN = ensureActions({
 	// Player GCDs
 	// -----
 
+	AEOLIAN_EDGE: {
+		id: 3563,
+		name: 'Aeolian Edge',
+		icon: 'https://xivapi.com/i/000000/000605.png',
+		onGcd: true,
+		potency: 100,
+		combo: {
+			from: 2242,
+			potency: 480,
+			end: true,
+		},
+	},
+
 	ARMOR_CRUSH: {
 		id: 3563,
 		name: 'Armor Crush',

--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -5,19 +5,6 @@ export const NIN = ensureActions({
 	// Player GCDs
 	// -----
 
-	AEOLIAN_EDGE: {
-		id: 2255,
-		name: 'Aeolian Edge',
-		icon: 'https://xivapi.com/i/000000/000605.png',
-		onGcd: true,
-		potency: 100,
-		combo: {
-			from: 2242,
-			potency: 480,
-			end: true,
-		},
-	},
-
 	ARMOR_CRUSH: {
 		id: 3563,
 		name: 'Armor Crush',

--- a/src/parser/jobs/nin/modules/Huton.js
+++ b/src/parser/jobs/nin/modules/Huton.js
@@ -159,7 +159,7 @@ export default class Huton extends Module {
 		this.suggestions.add(new TieredSuggestion({
 			icon: ACTIONS.HUTON.icon,
 			content: <Trans id="nin.huton.suggestions.clipping.content">
-				Avoid using <ActionLink {...ACTIONS.ARMOR_CRUSH}/> when <ActionLink {...ACTIONS.HUTON}/> has more than 40 seconds left on its duration. The excess time is wasted, so your other two combo finishers are typically better options.
+				Avoid using <ActionLink {...ACTIONS.ARMOR_CRUSH}/> when <ActionLink {...ACTIONS.HUTON}/> has more than 40 seconds left on its duration. The excess time is wasted, so using <ActionLink {...ACTIONS.AEOLIAN_EDGE}/> is typically the better option.
 			</Trans>,
 			tiers: {
 				5000: SEVERITY.MINOR,


### PR DESCRIPTION
As of 5.1 NIN no longer has three combos. The only other skill suggestion would be Aeolian Edge.