### PR TITLE
MCH - add AoE usages module, add Bioblaster to Drift 

### DIFF
--- a/src/parser/jobs/mch/index.js
+++ b/src/parser/jobs/mch/index.js
@@ -28,6 +28,11 @@ export default new Meta({
 		{user: CONTRIBUTORS.YUMIYAFANGIRL, role: ROLES.DEVELOPER},
 	],
 	changelog: [{
+		date: new Date('2020-05-13'),
+		Changes: () => <>Added a module that shows misused AoE actions.</>,
+		contributors: [CONTRIBUTORS.YUMIYAFANGIRL],
+	},
+	{
 		date: new Date('2020-05-10'),
 		Changes: () => <>Added a module for tracking GCD drift and a 'Use your cooldowns' checklist item.</>,
 		contributors: [CONTRIBUTORS.YUMIYAFANGIRL],

--- a/src/parser/jobs/mch/modules/Drift.tsx
+++ b/src/parser/jobs/mch/modules/Drift.tsx
@@ -4,21 +4,25 @@ import _ from 'lodash'
 import React, {Fragment} from 'react'
 import {Accordion, Message} from 'semantic-ui-react'
 
+import {Action} from 'data/ACTIONS'
 import {ActionLink} from 'components/ui/DbLink'
-import Rotation from 'components/ui/Rotation'
-import {getDataBy} from 'data'
 import ACTIONS from 'data/ACTIONS'
 import {CastEvent} from 'fflogs'
-import Module, {dependency} from 'parser/core/Module'
+import {getDataBy} from 'data'
 import Downtime from 'parser/core/modules/Downtime'
+import Module, {dependency} from 'parser/core/Module'
+import Rotation from 'components/ui/Rotation'
+
+
 
 // Buffer (ms) to forgive insignificant drift, we really only care about GCD drift here
 // and not log inconsistencies / sks issues / misguided weaving
 const DRIFT_BUFFER = 1500
 
 const DRIFT_GCDS = [
-	ACTIONS.DRILL.id,
 	ACTIONS.AIR_ANCHOR.id,
+	ACTIONS.BIOBLASTER.id,
+	ACTIONS.DRILL.id,
 ]
 
 const COOLDOWN_MS = {
@@ -44,6 +48,10 @@ class DriftWindow {
 			this.gcdRotation.push(event)
 		}
 	}
+
+	public getLastActionId(): number {
+		return this.gcdRotation.slice(-1)[0].ability.guid
+	}
 }
 
 export default class Drift extends Module {
@@ -55,8 +63,8 @@ export default class Drift extends Module {
 	private driftedWindows: DriftWindow[] = []
 
 	private currentWindows = {
-		[ACTIONS.DRILL.id]: new DriftWindow(ACTIONS.DRILL.id, this.parser.fight.start_time),
 		[ACTIONS.AIR_ANCHOR.id]: new DriftWindow(ACTIONS.AIR_ANCHOR.id, this.parser.fight.start_time),
+		[ACTIONS.DRILL.id]: new DriftWindow(ACTIONS.DRILL.id, this.parser.fight.start_time),
 	}
 
 	protected init() {
@@ -65,7 +73,13 @@ export default class Drift extends Module {
 	}
 
 	private onDriftableCast(event: CastEvent) {
-		const actionId = event.ability.guid
+		let actionId: number
+		if (event.ability.guid === ACTIONS.BIOBLASTER.id) {
+			actionId = ACTIONS.DRILL.id
+		} else {
+			actionId = event.ability.guid
+		}
+
 		const window = this.currentWindows[actionId]
 		window.end = event.timestamp
 		const downtime = this.downtime.getDowntime(window.start, window.end)
@@ -99,7 +113,7 @@ export default class Drift extends Module {
 						{this.parser.formatTimestamp(window.end)}
 						<span> - </span>
 						<Trans id="mch.drift.panel-drift">
-							<ActionLink {...getDataBy(ACTIONS, 'id', window.actionId)}/> drifted by {this.parser.formatDuration(window.drift)}
+							<ActionLink {...getDataBy(ACTIONS, 'id', window.getLastActionId())}/> drifted by {this.parser.formatDuration(window.drift)}
 						</Trans>
 					</Fragment>,
 				},

--- a/src/parser/jobs/mch/modules/Drift.tsx
+++ b/src/parser/jobs/mch/modules/Drift.tsx
@@ -1,18 +1,14 @@
 import {t} from '@lingui/macro'
 import {Trans} from '@lingui/react'
-import _ from 'lodash'
-import React, {Fragment} from 'react'
 import {Accordion, Message} from 'semantic-ui-react'
-
-import {Action} from 'data/ACTIONS'
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
 import {CastEvent} from 'fflogs'
-import {getDataBy} from 'data'
 import Downtime from 'parser/core/modules/Downtime'
+import {getDataBy} from 'data'
 import Module, {dependency} from 'parser/core/Module'
+import React, {Fragment} from 'react'
 import Rotation from 'components/ui/Rotation'
-
 
 
 // Buffer (ms) to forgive insignificant drift, we really only care about GCD drift here

--- a/src/parser/jobs/mch/modules/GeneralCDDowntime.tsx
+++ b/src/parser/jobs/mch/modules/GeneralCDDowntime.tsx
@@ -16,7 +16,7 @@ export default class GeneralCDDowntime extends CooldownDowntime {
 	}, {
 		cooldowns: [ACTIONS.REASSEMBLE],
 		allowedAverageDowntime: 5000,
-		firstUseOffset: 0,
+		firstUseOffset: -3000,
 	}, {
 		cooldowns: [ACTIONS.AIR_ANCHOR],
 		allowedAverageDowntime: DOWNTIME_ALLOWED_GCD,

--- a/src/parser/jobs/mch/modules/MultiHitSkills.ts
+++ b/src/parser/jobs/mch/modules/MultiHitSkills.ts
@@ -1,0 +1,26 @@
+import ACTIONS from 'data/ACTIONS'
+import {AoEUsages} from 'parser/core/modules/AoEUsages'
+
+export default class MultiHitSkills extends AoEUsages {
+	suggestionIcon = ACTIONS.SPREAD_SHOT.icon
+
+	trackedAbilities = [
+		{
+			aoeAbility: ACTIONS.BIOBLASTER,
+			stAbilities: [ACTIONS.DRILL],
+			minTargets: 2,
+		}, {
+			aoeAbility: ACTIONS.AUTO_CROSSBOW,
+			stAbilities: [ACTIONS.HEAT_BLAST],
+			minTargets: 3,
+		}, {
+			aoeAbility: ACTIONS.SPREAD_SHOT,
+			stAbilities: [
+				ACTIONS.HEATED_SPLIT_SHOT,
+				ACTIONS.HEATED_SLUG_SHOT,
+				ACTIONS.HEATED_CLEAN_SHOT,
+			],
+			minTargets: 3,
+		},
+	]
+}

--- a/src/parser/jobs/mch/modules/index.js
+++ b/src/parser/jobs/mch/modules/index.js
@@ -4,9 +4,11 @@ import Drift from './Drift'
 import Gauge from './Gauge'
 import GeneralCDDowntime from './GeneralCDDowntime'
 import Heat from './Heat'
-import YassQueen from './YassQueen'
+import MultiHitSkills from './MultiHitSkills'
 import Reassemble from './Reassemble'
 import Wildfire from './Wildfire'
+import YassQueen from './YassQueen'
+
 export default [
 	Combos,
 	Cooldowns,
@@ -14,6 +16,7 @@ export default [
 	Gauge,
 	GeneralCDDowntime,
 	Heat,
+	MultiHitSkills,
 	Reassemble,
 	Wildfire,
 	YassQueen,


### PR DESCRIPTION
- AoE usages suggestion:
![image](https://user-images.githubusercontent.com/65056303/81775203-5dfe5b80-94ba-11ea-8561-785178c1f8f7.png)
- AoE usages table:
![image](https://user-images.githubusercontent.com/65056303/81775217-69518700-94ba-11ea-9b80-f22f902ce7ae.png)
- Bioblaster sharing a recast with Drill accounted for in Drift module:
![image](https://user-images.githubusercontent.com/65056303/81775232-6f476800-94ba-11ea-9a52-7dabfb92f162.png)
