### PR TITLE
SMN - add check to onCommandIssued for fabricated egi commands

### DIFF
--- a/src/parser/jobs/smn/modules/EgiCommands.tsx
+++ b/src/parser/jobs/smn/modules/EgiCommands.tsx
@@ -4,7 +4,7 @@ import {ActionLink, StatusLink} from 'components/ui/DbLink'
 import {RotationTable} from 'components/ui/RotationTable'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-import {CastEvent} from 'fflogs'
+import {AbilityType, CastEvent} from 'fflogs'
 import Module, {dependency} from 'parser/core/Module'
 import {Invulnerability} from 'parser/core/modules/Invulnerability'
 import Suggestions, {SEVERITY, Suggestion, TieredSuggestion} from 'parser/core/modules/Suggestions'
@@ -141,6 +141,9 @@ export default class EgiCommands extends Module {
 	}
 
 	private onCommandIssued(event: CastEvent) {
+		// Ignore fabricated casts
+		if (event.ability.type === AbilityType.SPECIAL) { return }
+
 		this.activeCommands.push(event)
 		this.debug(`Issued ${event.ability.name} at ${this.parser.formatTimestamp(event.timestamp)} (${event.timestamp}). ${this.activeCommands.length} commands now pending.`)
 	}


### PR DESCRIPTION
This check ignores issued egi commands that were fabricated by CDDT (`type === AbilityType.special`). It has the effect of fixing this bug in prod: 

![image](https://user-images.githubusercontent.com/65056303/82010239-85326580-963f-11ea-9cfd-b33f7574e0de.png)
