### PR TITLE
Add a CooldownDowntime module to NIN

### DIFF
--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -261,7 +261,7 @@ export const NIN = ensureActions({
 		name: 'Ten Chi Jin',
 		icon: 'https://xivapi.com/i/002000/002922.png',
 		onGcd: false,
-		cooldown: 100,
+		cooldown: 120,
 		statusesApplied: ['TEN_CHI_JIN'],
 	},
 

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -21,6 +21,11 @@ export default new Meta({
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},
 	],
 	changelog: [{
+		date: new Date('2020-05-25'),
+		Changes: () => <>Included OGCD usage tracking in the checklist.</>,
+		contributors: [CONTRIBUTORS.TOASTDEIB],
+	},
+	{
 		date: new Date('2019-11-22'),
 		Changes: () => <>Updated the Kassatsu module to check for Fuma/Raiton uses.</>,
 		contributors: [CONTRIBUTORS.TOASTDEIB],

--- a/src/parser/jobs/nin/modules/OGCDDowntime.js
+++ b/src/parser/jobs/nin/modules/OGCDDowntime.js
@@ -1,0 +1,58 @@
+import ACTIONS from 'data/ACTIONS'
+import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
+
+const KASSATSU_FIRST_USE_OFFSET = 1000 // After opening Suiton
+const MUG_FIRST_USE_OFFSET = 6000 // After second combo GCD
+const BUNSHIN_FIRST_USE_OFFSET = 7000 // After second combo GCD (second weave)
+const TRICK_FIRST_USE_OFFSET = 10000 // After fourth combo GCD
+const DWAD_FIRST_USE_OFFSET = 12250 // After SF
+const TCJ_FIRST_USE_OFFSET = 17250 // After two Ninjutsu
+const MEISUI_FIRST_USE_OFFSET = 20750 // After TCJ
+
+export default class OGCDDowntime extends CooldownDowntime {
+	trackedCds = [
+		{
+			cooldowns: [ACTIONS.KASSATSU],
+			firstUseOffset: KASSATSU_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.MUG],
+			firstUseOffset: MUG_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.BUNSHIN],
+			firstUseOffset: BUNSHIN_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.TRICK_ATTACK],
+			firstUseOffset: TRICK_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.DREAM_WITHIN_A_DREAM],
+			firstUseOffset: DWAD_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.TEN_CHI_JIN],
+			firstUseOffset: TCJ_FIRST_USE_OFFSET,
+		},
+		{
+			cooldowns: [ACTIONS.MEISUI],
+			firstUseOffset: MEISUI_FIRST_USE_OFFSET,
+		},
+	]
+
+	_dreamTimestamps = []
+
+	countUsage(event) {
+		if (event.ability.guid !== ACTIONS.DREAM_WITHIN_A_DREAM.id) {
+			return true
+		}
+
+		if (this._dreamTimestamps.indexOf(event.timestamp) > -1) {
+			return false
+		}
+
+		this._dreamTimestamps.push(event.timestamp)
+		return true
+	}
+}

--- a/src/parser/jobs/nin/modules/index.js
+++ b/src/parser/jobs/nin/modules/index.js
@@ -4,6 +4,7 @@ import Huton from './Huton'
 import Kassatsu from './Kassatsu'
 import Ninjutsu from './Ninjutsu'
 import Ninki from './Ninki'
+import OGCDDowntime from './OGCDDowntime'
 //import ShadowFang from './ShadowFang' // Leaving a placeholder since this module will be revived shortly
 import TrickAttackUsage from './TrickAttackUsage'
 import TrickAttackWindow from './TrickAttackWindow'
@@ -15,6 +16,7 @@ export default [
 	Kassatsu,
 	Ninjutsu,
 	Ninki,
+	OGCDDowntime,
 	//ShadowFang,
 	TrickAttackUsage,
 	TrickAttackWindow,


### PR DESCRIPTION
What it says on the tin. Also, to address one question before it gets asked; I deliberately excluded Shadow Fang from the CDDT module (at least for now) because its cooldown is affected by Huton. Since we aren't properly accounting for that in calculations, it acts as though it's 70s no matter what and throws off the math.