### PR TITLE
BLM: Fix RotationWatchdog to stop flagging Jp Opener

### DIFF
--- a/src/parser/jobs/blm/index.js
+++ b/src/parser/jobs/blm/index.js
@@ -64,5 +64,10 @@ export default new Meta({
 		date: new Date('2020-04-27'),
 		Changes: () => <>Added a Thunder module that lists how much you clipped your DoT.</>,
 		contributors: [CONTRIBUTORS.FURST],
+	},
+	{
+		date: new Date('2020-05-26'),
+		Changes: () => <>(Modified) Jp Opener is no longer falsely flagged.</>,
+		contributors: [CONTRIBUTORS.FURST],
 	}],
 })

--- a/src/parser/jobs/blm/modules/RotationWatchdog.tsx
+++ b/src/parser/jobs/blm/modules/RotationWatchdog.tsx
@@ -111,6 +111,11 @@ class Cycle {
 		let expectedCount = (this.gaugeStateBeforeFire.umbralHearts === 0 && this.casts.filter(cast => cast.ability.guid === ACTIONS.FIRE_I.id).length === 0)
 			? NO_UH_EXPECTED_FIRE4 : EXPECTED_FIRE4
 
+		/**
+		 * A bit hacky but, when we are in the opener and start with F3 it will be the only cycle that doesn't include any B3, Freeze, US.
+		 * Since we are in the opener, and specifically opening with F3, we are doing the (mod) Jp Opener, which drops the expected count by 1
+		 */
+		expectedCount -= (this.casts.filter(cast => CYCLE_ENDPOINTS.includes(cast.ability.guid)).length === 0 ? 1 : 0)
 		// Adjust expected count if the cycle included manafont
 		expectedCount += this.hasManafont ? FIRE4_FROM_MANAFONT : 0
 


### PR DESCRIPTION
Currently the jp Opener is shown as bad on the watchdog, despite being a recommended opener in quite a big SpS range. This fix gets rid of the false negative