### PR TITLE
Updated NIN data files for two additional TCJ Fuma variants

### DIFF
--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -86,8 +86,25 @@ export const NIN = ensureActions({
 		gcdRecast: 1.5,
 	},
 
-	FUMA_SHURIKEN_TCJ: {
+	// I swear to shit, SE
+	FUMA_SHURIKEN_TCJ_TEN: {
 		id: 18873,
+		name: 'Fuma Shuriken',
+		icon: 'https://xivapi.com/i/002000/002907.png',
+		onGcd: true,
+		gcdRecast: 1,
+	},
+
+	FUMA_SHURIKEN_TCJ_CHI: {
+		id: 18874,
+		name: 'Fuma Shuriken',
+		icon: 'https://xivapi.com/i/002000/002907.png',
+		onGcd: true,
+		gcdRecast: 1,
+	},
+
+	FUMA_SHURIKEN_TCJ_JIN: {
+		id: 18875,
 		name: 'Fuma Shuriken',
 		icon: 'https://xivapi.com/i/002000/002907.png',
 		onGcd: true,


### PR DESCRIPTION
Turns out there are 3 different versions of TCJ Fuma, one for each mudra, and it throws off the Trick window module when one of the two that wasn't there is used. SE pls.