### PR TITLE
BugFix Tech Window opening when player not in the targets

### DIFF
--- a/src/parser/core/modules/NormalisedEvents.ts
+++ b/src/parser/core/modules/NormalisedEvents.ts
@@ -256,6 +256,12 @@ export class NormalisedEvents extends Module {
 			// Not a supported event type for normalisation
 			return
 		}
+
+		if (this.parser.report.friendlyPets.filter(pet => pet.id === event.targetID).length > 0) {
+			// We're choosing to ignore events that only target pets, since those aren't useful to keep track of
+			return
+		}
+
 		let normalisedEvent = this.findRelatedEvent(event)
 
 		if (!normalisedEvent) {

--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -62,7 +62,7 @@ export const changelog = [
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 	{
-		date: new Date('2019-05-13'),
+		date: new Date('2020-05-13'),
 		Changes: () => <>Adjust Esprit generation simulation and Technical Windows table to account for multi-dancer parties.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -85,22 +85,13 @@ export default class Technicalities extends Module {
 		// If it was already open (because another Dancer went first), we'll keep using it
 		const lastWindow: TechnicalWindow | undefined = this.tryOpenWindow(event)
 
-		if (!lastWindow) {
-			return
-		}
-
 		// Find out how many players we hit with the buff.
 		if (!lastWindow.playersBuffed) {
 			lastWindow.playersBuffed = event.confirmedEvents.filter(hit => this.parser.fightFriendlies.findIndex(f => f.id === hit.targetID) >= 0).length
 		}
 	}
 
-	private tryOpenWindow(event: NormalisedApplyBuffEvent): TechnicalWindow | undefined {
-		// There've been a few logs that have odd extra application events that don't hit the player, don't count those...
-		// Seems to mostly come as a passthrough from countTechBuffs
-		if (event.successfulHits.filter(applyEvent => applyEvent.targetID === this.parser.player.id).length !== 1) {
-			return
-		}
+	private tryOpenWindow(event: NormalisedApplyBuffEvent): TechnicalWindow {
 		const lastWindow: TechnicalWindow | undefined = _.last(this.history)
 
 		// Handle multiple dancer's buffs overwriting each other, we'll have a remove then an apply with the same timestamp


### PR DESCRIPTION
Some of the normalized buff events that pass through from countTechBuffs were hitting other actors somehow, which was in some cases (found with this report: https://www.fflogs.com/reports/Q9g8P4n6VktfWzCw#fight=6&source=3) causing an extra technical finish window to 'open' inappropriately, and also potentially tripping the 'there's another dancer here' check because of it.

Updating the tryOpenWindow function to exclude those events, and correcting the source<->player ID comparison.

Also noticed I derfed the year for the multi-dnc changelog entry in one of the merges somehow...