### PR TITLE
MCH: add detonator to actions

### DIFF
--- a/src/data/ACTIONS/root/MCH.ts
+++ b/src/data/ACTIONS/root/MCH.ts
@@ -162,6 +162,14 @@ export const MCH = ensureActions({
 		statusesApplied: ['WILDFIRE'],
 	},
 
+	DETONATOR: {
+		id: 16766,
+		name: 'Detonator',
+		icon: 'https://xivapi.com/i/003000/003039.png',
+		onGCD: false,
+		cooldown: 1,
+	},
+
 	ROOK_AUTOTURRET: {
 		id: 2864,
 		name: 'Rook Autoturret',

--- a/src/parser/jobs/mch/modules/Cooldowns.js
+++ b/src/parser/jobs/mch/modules/Cooldowns.js
@@ -4,6 +4,7 @@ import ACTIONS from 'data/ACTIONS'
 export default class Cooldowns extends CoreCooldowns {
 	static cooldownOrder = [
 		ACTIONS.WILDFIRE.id,
+		ACTIONS.DETONATOR.id,
 		ACTIONS.GAUSS_ROUND.id,
 		ACTIONS.RICOCHET.id,
 		ACTIONS.HYPERCHARGE.id,
@@ -11,7 +12,6 @@ export default class Cooldowns extends CoreCooldowns {
 		ACTIONS.REASSEMBLE.id,
 		ACTIONS.AUTOMATON_QUEEN.id,
 		ACTIONS.QUEEN_OVERDRIVE.id,
-		ACTIONS.DETONATOR.id,
 		ACTIONS.TACTICIAN.id,
 		ACTIONS.FLAMETHROWER.id,
 	]

--- a/src/parser/jobs/mch/modules/Cooldowns.js
+++ b/src/parser/jobs/mch/modules/Cooldowns.js
@@ -11,6 +11,7 @@ export default class Cooldowns extends CoreCooldowns {
 		ACTIONS.REASSEMBLE.id,
 		ACTIONS.AUTOMATON_QUEEN.id,
 		ACTIONS.QUEEN_OVERDRIVE.id,
+		ACTIONS.DETONATOR.id,
 		ACTIONS.TACTICIAN.id,
 		ACTIONS.FLAMETHROWER.id,
 	]


### PR DESCRIPTION
Detonator now shows up on the timeline and as an incorrect weave (when applicable). Doesn't appear to affect any other MCH modules. Here's a log where detonator is weaved incorrectly (2:48 weave window): https://www.fflogs.com/reports/fHgM438FwAXWt9KJ