### PR TITLE
Knoweth thy Fist

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -560,6 +560,7 @@
   "mnk.rof.suggestions.tackle.content": "",
   "mnk.rof.suggestions.tackle.why": "",
   "mnk.rof.table.header.gcds": "GCDs",
+  "mnk.rof.table.unknownfist": "",
   "mnk.rof.title": "",
   "mnk.steppies.checklist.description": "<0/> ist dein stärkster Form-Angriff mit globaler Abklingzeit, wenn du ihn vorab mit <1/> buffst.",
   "mnk.steppies.checklist.name": "Schlag auf Schlag buffen",

--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -536,6 +536,8 @@
   "mnk.fists.suggestions.fow.why": "",
   "mnk.fists.suggestions.stanceless.content": "",
   "mnk.fists.suggestions.stanceless.why": "",
+  "mnk.fists.suggestions.unknownfist.content": "",
+  "mnk.fists.suggestions.unknownfist.why": "",
   "mnk.fists.title": "",
   "mnk.forms.suggestions.dropped.content": "",
   "mnk.forms.suggestions.dropped.why": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -560,6 +560,7 @@
   "mnk.rof.suggestions.tackle.content": "Try to use both charges of <0/> during <1/>, unless you need to hold a charge for strategic purposes.",
   "mnk.rof.suggestions.tackle.why": "{riddlesWithOneTackle, plural, one {# use} other {# uses}} of <0/> contained only one use of <1/>.",
   "mnk.rof.table.header.gcds": "GCDs",
+  "mnk.rof.table.unknownfist": "No Fist transition was detected over the fight. The expected number of GCDs in each <0/> window are most likely inaccurate.",
   "mnk.rof.title": "Riddle of Fire",
   "mnk.steppies.checklist.description": "<0/> is your strongest form GCD when you buff it by using <1/> beforehand.",
   "mnk.steppies.checklist.name": "Buff Bootshine",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -536,6 +536,8 @@
   "mnk.fists.suggestions.fow.why": "<0/> was activated {0, plural, one {# time} other {# times}} below max stacks.",
   "mnk.fists.suggestions.stanceless.content": "Fist buffs are one of your biggest DPS contributors, either directly with <0/>, or outright more GCDs with <1/>.",
   "mnk.fists.suggestions.stanceless.why": "{0, plural, one {# GCD} other {# GCDs}} had no Fists buff active.",
+  "mnk.fists.suggestions.unknownfist.content": "Try to use <0/> up to GL{MAX_STACKS} and <1/> for GL{MAX_FASTER}.",
+  "mnk.fists.suggestions.unknownfist.why": "No Fist transition was detected over the fight.",
   "mnk.fists.title": "Fists",
   "mnk.forms.suggestions.dropped.content": "Avoid dropping Forms. You may need to use a gap closer or stay closer to the enemy to avoid your combo timing out. This usually indicates a bigger problem.",
   "mnk.forms.suggestions.dropped.why": "Form was dropped {0, plural, one {# time.} other {# times.}}",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -560,7 +560,7 @@
   "mnk.rof.suggestions.tackle.content": "Try to use both charges of <0/> during <1/>, unless you need to hold a charge for strategic purposes.",
   "mnk.rof.suggestions.tackle.why": "{riddlesWithOneTackle, plural, one {# use} other {# uses}} of <0/> contained only one use of <1/>.",
   "mnk.rof.table.header.gcds": "GCDs",
-  "mnk.rof.table.unknownfist": "No Fist transition was detected over the fight. The expected number of GCDs in each <0/> window are most likely inaccurate.",
+  "mnk.rof.table.unknownfist": "No Fist transition was detected over the fight. The expected number of GCDs in each <0/> window is most likely inaccurate.",
   "mnk.rof.title": "Riddle of Fire",
   "mnk.steppies.checklist.description": "<0/> is your strongest form GCD when you buff it by using <1/> beforehand.",
   "mnk.steppies.checklist.name": "Buff Bootshine",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -560,6 +560,7 @@
   "mnk.rof.suggestions.tackle.content": "Essayez d'utiliser les deux charges de <0/> pendant <1/>, à moins que vous n'ayez besoin de garder une charge à des fins stratégiques.",
   "mnk.rof.suggestions.tackle.why": "{riddlesWithOneTackle, plural,one {#utilisation}other {#utilisations}} de <0/> contenant seulement une utilisation de <1/>.",
   "mnk.rof.table.header.gcds": "GCDs",
+  "mnk.rof.table.unknownfist": "",
   "mnk.rof.title": "Énigme du feu",
   "mnk.steppies.checklist.description": "<0/> est votre plus puissant GCD quand vous le buffer en utilisant <1/> avant lancement.",
   "mnk.steppies.checklist.name": "Bonus de Volée de coups",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -536,6 +536,8 @@
   "mnk.fists.suggestions.fow.why": "<0/> était actif durant {0, plural,one {fois}other {#fois}} en dessous du niveau max.",
   "mnk.fists.suggestions.stanceless.content": "Les bonus de poing sont l'un de vos plus grands contributeurs de DPS, soit directement avec <0/> ou avec plus de Gcd avec <1/>.",
   "mnk.fists.suggestions.stanceless.why": "{0, plural,one {#GCD}other {#GCDs}} n'a pas de buff de poings activé.",
+  "mnk.fists.suggestions.unknownfist.content": "",
+  "mnk.fists.suggestions.unknownfist.why": "",
   "mnk.fists.title": "Poings",
   "mnk.forms.suggestions.dropped.content": "Évitez de laisser tomber les formes. Vous devrez peut-être utiliser un espace plus proche ou rester plus près de l'ennemi pour éviter que votre combo ne s'arrête. Cela indique généralement un problème plus important.",
   "mnk.forms.suggestions.dropped.why": "Position perdu {0, plural,one {fois.}other {#fois.}}",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -560,6 +560,7 @@
   "mnk.rof.suggestions.tackle.content": "<1/>の一定時間に、できれば<0/>を２回実行してください。ギミックや状況によって、チャージは残して大丈夫です。",
   "mnk.rof.suggestions.tackle.why": "<0/>の一定時間に、<1/>は1回しか実行していないことが {riddlesWithOneTackle, plural, other {#}} 回行いました。",
   "mnk.rof.table.header.gcds": "GCD回",
+  "mnk.rof.table.unknownfist": "",
   "mnk.rof.title": "紅蓮の極意",
   "mnk.steppies.checklist.description": "先に<1/>でバフしたら、<0/>はあなたの一番強い型のGCDなのです。",
   "mnk.steppies.checklist.name": "連撃をバフ",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -536,6 +536,8 @@
   "mnk.fists.suggestions.fow.why": "マックススタックがない状態で、<0/>が {0, plural, other {# 回}} 使ってしまいました。",
   "mnk.fists.suggestions.stanceless.content": "",
   "mnk.fists.suggestions.stanceless.why": "構えの型が付与されてい状態で、{0, plural, other {#}} つのGCDが実行してしまいました。",
+  "mnk.fists.suggestions.unknownfist.content": "",
+  "mnk.fists.suggestions.unknownfist.why": "",
   "mnk.fists.title": "構え",
   "mnk.forms.suggestions.dropped.content": "型の効果が落ちないように頑張ってください。GCDやコンボが続けるめに、できれば敵から離れないようにしてください。そうすると型の効果が更新されます。",
   "mnk.forms.suggestions.dropped.why": "型の効果時間が切れた回数：{0, plural, one {#回} other {#回}}",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -560,6 +560,7 @@
   "mnk.rof.suggestions.tackle.content": "특별한 전략적 이유가 없다면 <0/> 스택 둘다 <1/> 구간 안에 사용을 목표하십시오.",
   "mnk.rof.suggestions.tackle.why": "<1/> 구간내에 사용된 <0/> 횟수 {riddlesWithOneTackle, plural, one {# use} other {# 회}} ",
   "mnk.rof.table.header.gcds": "글쿨기",
+  "mnk.rof.table.unknownfist": "",
   "mnk.rof.title": "홍련의 극의",
   "mnk.steppies.checklist.description": "<1/> 버프가 적용된 <0/>은 가장 강력한 위력을 가진 글쿨기 입니다.",
   "mnk.steppies.checklist.name": "강화 연격",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -536,6 +536,8 @@
   "mnk.fists.suggestions.fow.why": "최대 스택미만 상태에서 <0/> 전환하는 실수를 {0, plural, one {# 회} other {# 회}} 하였습니다.",
   "mnk.fists.suggestions.stanceless.content": "태세는 <0/>에 직접적인 영향을 주거나 <1/>과 연계하여 글쿨기 횟수를 늘리는등 딜 기여에 가장 중요한 요소입니다.",
   "mnk.fists.suggestions.stanceless.why": "{0, plural, one {#개} other {#개}}의 글쿨 동안 아무 태세도 켜지지 않았습니다.",
+  "mnk.fists.suggestions.unknownfist.content": "",
+  "mnk.fists.suggestions.unknownfist.why": "",
   "mnk.fists.title": "태세",
   "mnk.forms.suggestions.dropped.content": "품새를 상시 유지하십시오. 돌진기를 사용하거나 보스에 붙어있어야 유지가능하며 실패시 이는 일반적으로 더 큰 문제점이 있기 떄문입니다.",
   "mnk.forms.suggestions.dropped.why": "품새 유지를 {0, plural, other {# 회}} 실패하엿습니다.",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -560,6 +560,7 @@
   "mnk.rof.suggestions.tackle.content": "",
   "mnk.rof.suggestions.tackle.why": "",
   "mnk.rof.table.header.gcds": "GCD技能",
+  "mnk.rof.table.unknownfist": "",
   "mnk.rof.title": "红莲极意",
   "mnk.steppies.checklist.description": "当您提前使用<1/>以增益<0/>时，该技能就是您威力最高的GCD技能。",
   "mnk.steppies.checklist.name": "连击效果提高",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -536,6 +536,8 @@
   "mnk.fists.suggestions.fow.why": "",
   "mnk.fists.suggestions.stanceless.content": "",
   "mnk.fists.suggestions.stanceless.why": "存在 {0} 个GCD无体势加成。",
+  "mnk.fists.suggestions.unknownfist.content": "",
+  "mnk.fists.suggestions.unknownfist.why": "",
   "mnk.fists.title": "体势",
   "mnk.forms.suggestions.dropped.content": "避免失去身形。你可能需要突进技或保持更小的距离来避免你的连击因超时而中断。这通常意味着更大的问题",
   "mnk.forms.suggestions.dropped.why": "",

--- a/src/parser/jobs/mnk/modules/Fists.tsx
+++ b/src/parser/jobs/mnk/modules/Fists.tsx
@@ -13,7 +13,7 @@ import Module, {dependency} from 'parser/core/Module'
 import Combatants from 'parser/core/modules/Combatants'
 import {Data} from 'parser/core/modules/Data'
 import {PieChartStatistic, Statistics} from 'parser/core/modules/Statistics'
-import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
+import Suggestions, {SEVERITY, Suggestion, TieredSuggestion} from 'parser/core/modules/Suggestions'
 
 import {EntityStatuses} from '../../../core/modules/EntityStatuses'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
@@ -170,41 +170,56 @@ export default class Fists extends Module {
 		// Flush the last stance
 		this.fistory.push({...this.activeFist, end: this.parser.fight.end_time})
 
-		this.suggestions.add(new TieredSuggestion({
-			icon: ACTIONS.FISTS_OF_FIRE.icon,
-			content: <Trans id="mnk.fists.suggestions.stanceless.content">
-				Fist buffs are one of your biggest DPS contributors, either directly with <ActionLink {...ACTIONS.FISTS_OF_FIRE} />, or outright more GCDs with <ActionLink {...ACTIONS.FISTS_OF_WIND} />.
-			</Trans>,
-			why: <Trans id="mnk.fists.suggestions.stanceless.why">
-				<Plural value={this.getFistGCDCount(FISTLESS)} one="# GCD" other="# GCDs"	/> had no Fists buff active.
-			</Trans>,
-			tiers: FIST_SEVERITY.FISTLESS,
-			value: this.getFistGCDCount(FISTLESS),
-		}))
+		const unknownFist = this.fistory.length === 1 && this.fistory[0].id === FISTLESS
 
-		this.suggestions.add(new TieredSuggestion({
-			icon: ACTIONS.FISTS_OF_EARTH.icon,
-			content: <Trans id="mnk.fists.suggestions.foe.content">
-				When using <ActionLink {...ACTIONS.RIDDLE_OF_EARTH} />, remember to change back to <StatusLink {...STATUSES.FISTS_OF_WIND} /> as soon as possible.
-			</Trans>,
-			tiers: FIST_SEVERITY.FISTS_OF_EARTH,
-			why: <Trans id="mnk.fists.suggestions.foe.why">
-				<StatusLink {...STATUSES.FISTS_OF_EARTH} /> was active for <Plural value={this.getFistGCDCount(STATUSES.FISTS_OF_EARTH.id)} one="# GCD" other="# GCDs"/>.
-			</Trans>,
-			value: this.getFistGCDCount(STATUSES.FISTS_OF_EARTH.id),
-		}))
+		if (unknownFist) {
+			this.suggestions.add(new Suggestion({
+				icon: ACTIONS.FISTS_OF_FIRE.icon,
+				content: <Trans id="mnk.fists.suggestions.unknownfist.content">
+					Try to use <StatusLink {...STATUSES.FISTS_OF_FIRE} /> up to GL{MAX_STACKS} and <StatusLink {...STATUSES.FISTS_OF_WIND}/> for GL{MAX_FASTER}.
+				</Trans>,
+				severity: SEVERITY.MAJOR,
+				why: <Trans id="mnk.fists.suggestions.unknownfist.why">
+					No Fist transition was detected over the fight.
+				</Trans>,
+			}))
+		} else {
+			this.suggestions.add(new TieredSuggestion({
+				icon: ACTIONS.FISTS_OF_FIRE.icon,
+				content: <Trans id="mnk.fists.suggestions.stanceless.content">
+					Fist buffs are one of your biggest DPS contributors, either directly with <ActionLink {...ACTIONS.FISTS_OF_FIRE} />, or outright more GCDs with <ActionLink {...ACTIONS.FISTS_OF_WIND} />.
+				</Trans>,
+				why: <Trans id="mnk.fists.suggestions.stanceless.why">
+					<Plural value={this.getFistGCDCount(FISTLESS)} one="# GCD" other="# GCDs"	/> had no Fists buff active.
+				</Trans>,
+				tiers: FIST_SEVERITY.FISTLESS,
+				value: this.getFistGCDCount(FISTLESS),
+			}))
 
-		this.suggestions.add(new TieredSuggestion({
-			icon: ACTIONS.FISTS_OF_WIND.icon,
-			content: <Trans id="mnk.fists.suggestions.fow.content">
-				Avoid swapping to <StatusLink {...STATUSES.FISTS_OF_WIND}/> while below {MAX_STACKS} stacks until you're about to execute a <StatusLink {...STATUSES.COEURL_FORM} /> skill. <StatusLink {...STATUSES.FISTS_OF_FIRE} /> offers more damage until you can get to GL{MAX_FASTER}.
-			</Trans>,
-			why: <Trans id="mnk.fists.suggestions.fow.why">
-				<StatusLink {...STATUSES.FISTS_OF_WIND}/> was activated <Plural value={this.foulWinds} one="# time" other="# times" /> below max stacks.
-			</Trans>,
-			tiers: FIST_SEVERITY.FISTS_OF_WIND,
-			value: this.foulWinds,
-		}))
+			this.suggestions.add(new TieredSuggestion({
+				icon: ACTIONS.FISTS_OF_EARTH.icon,
+				content: <Trans id="mnk.fists.suggestions.foe.content">
+					When using <ActionLink {...ACTIONS.RIDDLE_OF_EARTH} />, remember to change back to <StatusLink {...STATUSES.FISTS_OF_WIND} /> as soon as possible.
+				</Trans>,
+				tiers: FIST_SEVERITY.FISTS_OF_EARTH,
+				why: <Trans id="mnk.fists.suggestions.foe.why">
+					<StatusLink {...STATUSES.FISTS_OF_EARTH} /> was active for <Plural value={this.getFistGCDCount(STATUSES.FISTS_OF_EARTH.id)} one="# GCD" other="# GCDs"/>.
+				</Trans>,
+				value: this.getFistGCDCount(STATUSES.FISTS_OF_EARTH.id),
+			}))
+
+			this.suggestions.add(new TieredSuggestion({
+				icon: ACTIONS.FISTS_OF_WIND.icon,
+				content: <Trans id="mnk.fists.suggestions.fow.content">
+					Avoid swapping to <StatusLink {...STATUSES.FISTS_OF_WIND}/> while below {MAX_STACKS} stacks until you're about to execute a <StatusLink {...STATUSES.COEURL_FORM} /> skill. <StatusLink {...STATUSES.FISTS_OF_FIRE} /> offers more damage until you can get to GL{MAX_FASTER}.
+				</Trans>,
+				why: <Trans id="mnk.fists.suggestions.fow.why">
+					<StatusLink {...STATUSES.FISTS_OF_WIND}/> was activated <Plural value={this.foulWinds} one="# time" other="# times" /> below max stacks.
+				</Trans>,
+				tiers: FIST_SEVERITY.FISTS_OF_WIND,
+				value: this.foulWinds,
+			}))
+		}
 
 		// Statistics
 		const uptimeKeys = _.uniq(this.fistory.map(fist => fist.id))
@@ -217,7 +232,7 @@ export default class Fists extends Module {
 				value,
 				color: CHART_COLOURS[id],
 				columns: [
-					this.getFistName(id),
+					this.getFistName(id, unknownFist),
 					this.parser.formatDuration(value),
 					this.getFistUptimePercent(id) + '%',
 				] as const,
@@ -242,17 +257,19 @@ export default class Fists extends Module {
 		return ((statusUptime / this.parser.fightDuration) * 100).toFixed(2)
 	}
 
-	getFistName(fistId: number): string {
-		if (fistId === FISTLESS) {
-			// NOTE: Do /not/ return a <Trans> here - it will cause Chart.js to try and clone the entire react tree.
-			// TODO: Work out how to translate this shit.
-			return 'Fistless'
-		}
+	getFistName(fistId: number, missingData: boolean): string {
+		if (!missingData) {
+			if (fistId === FISTLESS) {
+				// NOTE: Do /not/ return a <Trans> here - it will cause Chart.js to try and clone the entire react tree.
+				// TODO: Work out how to translate this shit.
+				return 'Fistless'
+			}
 
-		const status = this.data.getStatus(fistId)
+			const status = this.data.getStatus(fistId)
 
-		if (status) {
-			return status.name
+			if (status) {
+				return status.name
+			}
 		}
 
 		return 'Unknown'

--- a/src/parser/jobs/mnk/modules/RiddleOfFire.tsx
+++ b/src/parser/jobs/mnk/modules/RiddleOfFire.tsx
@@ -1,6 +1,7 @@
 import {t} from '@lingui/macro'
 import {Plural, Trans} from '@lingui/react'
 import React from 'react'
+import {Icon, Message} from 'semantic-ui-react'
 
 import {ActionLink, StatusLink} from 'components/ui/DbLink'
 import {RotationTable} from 'components/ui/RotationTable'
@@ -207,45 +208,60 @@ export default class RiddleOfFire extends Module {
 	}
 
 	output() {
-		return <RotationTable
-			targets={[
-				{
-					header: <Trans id="mnk.rof.table.header.gcds">GCDs</Trans>,
-					accessor: 'gcds',
-				},
-				{
-					header: <ActionLink showName={false} {...ACTIONS.ELIXIR_FIELD}/>,
-					accessor: 'elixirField',
-				},
-				{
-					header: <ActionLink showName={false} {...ACTIONS.SHOULDER_TACKLE}/>,
-					accessor: 'shoulderTackle',
-				},
-			]}
-			data={this.history
-				.map(riddle => ({
-					start: riddle.start - this.parser.fight.start_time,
-					end: riddle.end != null ?
-						riddle.end - this.parser.fight.start_time
-						: riddle.start - this.parser.fight.start_time,
-					targetsData: {
-						gcds: {
-							actual: riddle.gcds,
-							expected: riddle.expectedGcds,
-						},
-						elixirField: {
-							actual: riddle.elixirFields,
-							expected: EXPECTED_ELIXIR_FIELDS,
-						},
-						shoulderTackle: {
-							actual: riddle.tackles,
-							expected: EXPECTED_SHOULDER_TACKLES,
-						},
+		const unknownFist = this.history.reduce((total, riddle) => total + riddle.gcds - riddle.gcdsByFist(FISTLESS), 0) === 0
+
+		return <>
+			{unknownFist && (
+				<Message warning icon>
+					<Icon name="warning sign" />
+					<Message.Content>
+						<Trans id="mnk.rof.table.unknownfist">
+							No Fist transition was detected over the fight. The expected number of GCDs in each <StatusLink {...STATUSES.RIDDLE_OF_FIRE} /> window are most likely inaccurate.
+						</Trans>
+					</Message.Content>
+				</Message>
+			)}
+
+			<RotationTable
+				targets={[
+					{
+						header: <Trans id="mnk.rof.table.header.gcds">GCDs</Trans>,
+						accessor: 'gcds',
 					},
-					rotation: riddle.casts,
-				}))
-			}
-			onGoto={this.timeline.show}
-		/>
+					{
+						header: <ActionLink showName={false} {...ACTIONS.ELIXIR_FIELD}/>,
+						accessor: 'elixirField',
+					},
+					{
+						header: <ActionLink showName={false} {...ACTIONS.SHOULDER_TACKLE}/>,
+						accessor: 'shoulderTackle',
+					},
+				]}
+				data={this.history
+					.map(riddle => ({
+						start: riddle.start - this.parser.fight.start_time,
+						end: riddle.end != null ?
+							riddle.end - this.parser.fight.start_time
+							: riddle.start - this.parser.fight.start_time,
+						targetsData: {
+							gcds: {
+								actual: riddle.gcds,
+								expected: riddle.expectedGcds,
+							},
+							elixirField: {
+								actual: riddle.elixirFields,
+								expected: EXPECTED_ELIXIR_FIELDS,
+							},
+							shoulderTackle: {
+								actual: riddle.tackles,
+								expected: EXPECTED_SHOULDER_TACKLES,
+							},
+						},
+						rotation: riddle.casts,
+					}))
+				}
+				onGoto={this.timeline.show}
+			/>
+		</>
 	}
 }

--- a/src/parser/jobs/mnk/modules/RiddleOfFire.tsx
+++ b/src/parser/jobs/mnk/modules/RiddleOfFire.tsx
@@ -216,7 +216,7 @@ export default class RiddleOfFire extends Module {
 					<Icon name="warning sign" />
 					<Message.Content>
 						<Trans id="mnk.rof.table.unknownfist">
-							No Fist transition was detected over the fight. The expected number of GCDs in each <StatusLink {...STATUSES.RIDDLE_OF_FIRE} /> window are most likely inaccurate.
+							No Fist transition was detected over the fight. The expected number of GCDs in each <StatusLink {...STATUSES.RIDDLE_OF_FIRE} /> window is most likely inaccurate.
 						</Trans>
 					</Message.Content>
 				</Message>


### PR DESCRIPTION
When players pull in RoW (or any other Fist, or none really) and never change over the fight, we're unable to detect precisely what Fist they're in. This PR adds a suggestion for when we don't know, and updates the stats block for Fists and Table for RoF with the relevant information.

![image](https://user-images.githubusercontent.com/28627120/84661809-3a697d80-af5e-11ea-9ea4-edddfe0e344e.png)
![image](https://user-images.githubusercontent.com/28627120/84661836-435a4f00-af5e-11ea-8c77-c722572ea399.png)
