### PR TITLE
[Bug Fix] [Core] BuffWindow's reduceExpectedGCDsEndOfFight Function

### DIFF
--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -219,7 +219,13 @@ export abstract class BuffWindowModule extends Module {
 
 			if (windowDurationMillis >= fightTimeRemaining) {
 				const gcdEstimate = this.globalCooldown.getEstimate()
-				return Math.ceil((windowDurationMillis - fightTimeRemaining) / gcdEstimate)
+				const newExpectedGCDs = Math.ceil((windowDurationMillis - fightTimeRemaining) / gcdEstimate)
+
+				if ( this.expectedGCDs ) {
+					if ( newExpectedGCDs <= this.expectedGCDs.expectedPerWindow ) {
+						return newExpectedGCDs
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
BuffWindow's reduceExpectedGCDsEndOfFight function could make Samurai's expectedGCD go negative. Instead of making an override for it in SAM's BuffWindow file, I've fixed Core to only reduce if the new calculated expectedGCD is less than the current one. to avoid getting 0 or -X expected GCDs for other jobs that may have a similar problem now or in the future.

If this is an issue, I can just override SAM's BuffWindow and leave core alone.