### PR TITLE
Fix to avoid Ability Drift breaking on No Casts of HJ/GSK.

### DIFF
--- a/src/parser/jobs/drg/index.js
+++ b/src/parser/jobs/drg/index.js
@@ -22,6 +22,11 @@ export default new Meta({
 		{user: CONTRIBUTORS.RIETTY, role: ROLES.DEVELOPER},
 	],
 	changelog: [{
+		date: new Date('2020-06-20'),
+		Changes: () => <>Fixed a small issue with the Ability Drift module. It won't break now on using it on lower level content/or logs that have no casts of GSK or HJ.</>,
+		contributors: [CONTRIBUTORS.RIETTY],
+	},
+	{
 		date: new Date('2020-06-04'),
 		Changes: () => <>Added module to calculate and display drifting of High Jump and Geirskogul, which affects possible Life of the Dragon windows that may have been missed.</>,
 		contributors: [CONTRIBUTORS.RIETTY],

--- a/src/parser/jobs/drg/modules/Drift.tsx
+++ b/src/parser/jobs/drg/modules/Drift.tsx
@@ -99,6 +99,9 @@ export default class Drift extends Module {
 
 	private createDriftTable(casts: DriftWindow[]) {
 		let totalDrift = 0
+		if (casts[0] == null) { // Don't draw table if nothing was cast.
+			return
+		}
 		const action = getDataBy(ACTIONS, 'id', casts[0].actionId)
 		return <Table>
 			<Table.Header>

--- a/src/parser/jobs/drg/modules/Drift.tsx
+++ b/src/parser/jobs/drg/modules/Drift.tsx
@@ -99,7 +99,7 @@ export default class Drift extends Module {
 
 	private createDriftTable(casts: DriftWindow[]) {
 		let totalDrift = 0
-		if (casts[0] == null) { // Don't draw table if nothing was cast.
+		if (casts.length === 0) { // Don't draw table if nothing was cast.
 			return
 		}
 		const action = getDataBy(ACTIONS, 'id', casts[0].actionId)


### PR DESCRIPTION
Currently this module breaks if a log is posted of synced down/lower level content or a log that does not have any casts of HJ or GSK. Added a simple check that will bypass creating said table/only create the table for the correct skills to avoid showing an error. Useful for stuff like UWU and UCoB where HJ is synced down to Jump.