### PR TITLE
[Bug Fix][Sam] Meikyo Window End of Fight rushing

### DIFF
--- a/src/parser/jobs/sam/modules/Meikyo.tsx
+++ b/src/parser/jobs/sam/modules/Meikyo.tsx
@@ -74,8 +74,8 @@ reduceExpectedGCDsEndOfFight(buffWindow: BuffWindowState): number  {
 			const fightTimeRemaining = this.parser.pull.duration - (buffWindow.start - this.parser.eventTimeOffset)
 
 			if (windowDurationMillis >= fightTimeRemaining) {
-				// const gcdEstimate = this.globalCooldown.getEstimate()
-				const possibleGCDs = Math.ceil(fightTimeRemaining / SAM_BASE_GCD_SPEED_BUFFED)
+				// This is using floor instead of ceiling to grant some forgiveness to first weave slot casts at the cost of 2nd weaves might be too forgiven
+				const possibleGCDs = Math.floor(fightTimeRemaining / SAM_BASE_GCD_SPEED_BUFFED)
 
 				if (possibleGCDs < SEN_GCDS) {
 					const reduceGCDsBy = (SEN_GCDS - possibleGCDs)

--- a/src/parser/jobs/sam/modules/Meikyo.tsx
+++ b/src/parser/jobs/sam/modules/Meikyo.tsx
@@ -14,8 +14,8 @@ const ONLY_SHOW = new Set([ACTIONS.HAKAZE.id, ACTIONS.JINPU.id, ACTIONS.ENPI.id,
 const SEN_GCDS = 3
 
 // A set const for SAM speed with 0 speed and shifu up, not sure I like this idea tbh but Aza requested it.
-// TODO: Check when adding Iais to table that this set speed doesn't cause missed skills to be not counted against
-const SAM_BASE_GCD_SPEED_BUFFED = 2.18
+// GCD = 2.18
+const SAM_BASE_GCD_SPEED_BUFFED = 2180
 
 export default class MeikyoShisui extends BuffWindowModule {
 	static handle = 'Meikyo'
@@ -75,7 +75,7 @@ reduceExpectedGCDsEndOfFight(buffWindow: BuffWindowState): number  {
 
 			if (windowDurationMillis >= fightTimeRemaining) {
 				// const gcdEstimate = this.globalCooldown.getEstimate()
-				const possibleGCDs = Math.ceil(fightTimeRemaining / SAM_GCD_SPEED_BUFFED)
+				const possibleGCDs = Math.ceil(fightTimeRemaining / SAM_BASE_GCD_SPEED_BUFFED)
 
 				if (possibleGCDs < SEN_GCDS) {
 					const reduceGCDsBy = (SEN_GCDS - possibleGCDs)

--- a/src/parser/jobs/sam/modules/Meikyo.tsx
+++ b/src/parser/jobs/sam/modules/Meikyo.tsx
@@ -13,6 +13,10 @@ import {BuffWindowState} from 'parser/core/modules/BuffWindow'
 const ONLY_SHOW = new Set([ACTIONS.HAKAZE.id, ACTIONS.JINPU.id, ACTIONS.ENPI.id, ACTIONS.SHIFU.id, ACTIONS.FUGA.id, ACTIONS.GEKKO.id, ACTIONS.MANGETSU.id, ACTIONS.KASHA.id, ACTIONS.OKA.id, ACTIONS.YUKIKAZE.id])
 const SEN_GCDS = 3
 
+// A set const for SAM speed with 0 speed and shifu up, not sure I like this idea tbh but Aza requested it.
+// TODO: Check when adding Iais to table that this set speed doesn't cause missed skills to be not counted against
+const SAM_BASE_GCD_SPEED_BUFFED = 2.18
+
 export default class MeikyoShisui extends BuffWindowModule {
 	static handle = 'Meikyo'
 	static title = t('sam.ms.title')`Meikyo Shisui Windows`
@@ -70,8 +74,8 @@ reduceExpectedGCDsEndOfFight(buffWindow: BuffWindowState): number  {
 			const fightTimeRemaining = this.parser.pull.duration - (buffWindow.start - this.parser.eventTimeOffset)
 
 			if (windowDurationMillis >= fightTimeRemaining) {
-				const gcdEstimate = this.globalCooldown.getEstimate()
-				const possibleGCDs = Math.ceil(fightTimeRemaining / gcdEstimate)
+				// const gcdEstimate = this.globalCooldown.getEstimate()
+				const possibleGCDs = Math.ceil(fightTimeRemaining / SAM_GCD_SPEED_BUFFED)
 
 				if (possibleGCDs < SEN_GCDS) {
 					const reduceGCDsBy = (SEN_GCDS - possibleGCDs)

--- a/src/parser/jobs/sam/modules/Meikyo.tsx
+++ b/src/parser/jobs/sam/modules/Meikyo.tsx
@@ -4,9 +4,8 @@ import React from 'react'
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS, {Action} from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-import {BuffWindowModule} from 'parser/core/modules/BuffWindow'
+import {BuffWindowModule, BuffWindowState} from 'parser/core/modules/BuffWindow'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
-import {BuffWindowState} from 'parser/core/modules/BuffWindow'
 
 // Set for stuff to ignore TODO: revisit this and get it to show iaijutsu properly
 // const IGNORE_THIS = new Set([ACTIONS.MIDARE_SETSUGEKKA.id, ACTIONS.TENKA_GOKEN.id, ACTIONS.HIGANBANA.id, ACTIONS.KAESHI_SETSUGEKKA.id, ACTIONS.KAESHI_GOKEN.id, ACTIONS.KAESHI_HIGANBANA])
@@ -68,23 +67,22 @@ considerAction(action: Action) {
 // override for end of fight reducing
 
 reduceExpectedGCDsEndOfFight(buffWindow: BuffWindowState): number  {
-		if ( this.buffStatus.duration ) {
-			// Check to see if this window is rushing due to end of fight - reduce expected GCDs accordingly
-			const windowDurationMillis = this.buffStatus.duration * 1000
-			const fightTimeRemaining = this.parser.pull.duration - (buffWindow.start - this.parser.eventTimeOffset)
+		let reduceGCDsBy = 0
 
-			if (windowDurationMillis >= fightTimeRemaining) {
-				// This is using floor instead of ceiling to grant some forgiveness to first weave slot casts at the cost of 2nd weaves might be too forgiven
-				const possibleGCDs = Math.floor(fightTimeRemaining / SAM_BASE_GCD_SPEED_BUFFED)
+		// Check to see if this window is rushing due to end of fight - reduce expected GCDs accordingly
+		const windowDurationMillis = this.buffStatus.duration * 1000
+		const fightTimeRemaining = this.parser.pull.duration - (buffWindow.start - this.parser.eventTimeOffset)
 
-				if (possibleGCDs < SEN_GCDS) {
-					const reduceGCDsBy = (SEN_GCDS - possibleGCDs)
-					return reduceGCDsBy
-				}
+		if (windowDurationMillis >= fightTimeRemaining) {
+			// This is using floor instead of ceiling to grant some forgiveness to first weave slot casts at the cost of 2nd weaves might be too forgiven
+			const possibleGCDs = Math.floor(fightTimeRemaining / SAM_BASE_GCD_SPEED_BUFFED)
+
+			if (possibleGCDs < SEN_GCDS) {
+				reduceGCDsBy += (SEN_GCDS - possibleGCDs)
 			}
 		}
 
-		// Default: no rushing reduction
-		return 0
-	}
+		return reduceGCDsBy
+}
+
 }


### PR DESCRIPTION
Sam has a bug currently that the default end of fight rushing can make the expected GCDs go negative. this PR fixes that problem.

There is however currently a minor problem in the way I reduce the GCDs. If a samurai uses Meikyo in the beginning of the weave window, the time stamp for the buff can sometimes cause the system to think they can get an extra GCD when in reality they can not. I'm unsure of how I can fix that at the moment and would love some ideas. 