### PR TITLE
DRG: Adjust first use offset, remove old suggestion

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -379,8 +379,6 @@
   "drg.blood.suggestions.buffsed-stardiver.why": "Als <0/> gebufft werden könnte, hast du es {noBuffSd, plural, one {# time} other {# mal}} nicht gebufft genutzt.",
   "drg.blood.suggestions.eyes.content": "Vermeide es, <0/> zu benutzen, wenn du schon {MAX_EYES} Augen hast. Verschwendete Augen verzögern dein Drachengeist-Fenster und kosten potenziell eine Menge DPS.",
   "drg.blood.suggestions.eyes.why": "Du hast Illusionssprung {0, plural, one {# mal} other {# mal}} benutzt, während du schon {MAX_EYES} Augen hattest.",
-  "drg.blood.suggestions.gk.content": "",
-  "drg.blood.suggestions.gk.why": "",
   "drg.blood.table.action": "",
   "drg.blood.table.statuses": "",
   "drg.blood.table.time": "Zeit",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -379,8 +379,6 @@
   "drg.blood.suggestions.buffsed-stardiver.why": "When <0/> could have been buffed, you used it {noBuffSd, plural, one {# time} other {# times}} without a buff.",
   "drg.blood.suggestions.eyes.content": "Avoid using <0/> when you already have {MAX_EYES} Eyes. Wasting Eyes will delay your Life of the Dragon windows and potentially cost you a lot of DPS.",
   "drg.blood.suggestions.eyes.why": "You used Mirage Dive {0, plural, one {# time} other {# times}} when you already had {MAX_EYES} Eyes.",
-  "drg.blood.suggestions.gk.content": "Remember to use <0/> as much as possible, without delaying your Life of the Dragon windows. The number of casts should be within 1 of the number of <1/> casts.",
-  "drg.blood.suggestions.gk.why": "Your <0/> casts differed from your <1/> casts by {gkDiff}.",
   "drg.blood.table.action": "Action",
   "drg.blood.table.statuses": "Personal Buffs",
   "drg.blood.table.time": "Time",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -379,8 +379,6 @@
   "drg.blood.suggestions.buffsed-stardiver.why": "Lorsque <0/> aurait pu être buffé, vous l'avez utilisé {noBuffSd} fois sans buff.",
   "drg.blood.suggestions.eyes.content": "Éviter d'utiliser <0/> quand vous avez déjà {MAX_EYES} yeux. Gâcher des yeux retarde votre fenêtre de Vie du Dragon et peut potentiellement vous faire perdre beaucoup de DPS.",
   "drg.blood.suggestions.eyes.why": "Vous avez utiliser Piqué mirage {0, plural,one {#fois}other {#fois}} quand vous aviez déja vos {MAX_EYES} yeux.",
-  "drg.blood.suggestions.gk.content": "Rappellez vous d'utilisez <0/> autant que possible, sans pour autant retarder votre fenêtre de vie du dragon. le nombre d'utilisation doit être dans 1 d'un des <1/> utilisations.",
-  "drg.blood.suggestions.gk.why": "Vos utilisations de <0/> sont différent de vos utilisation de <1/> utilser par {gkDiff}.",
   "drg.blood.table.action": "Action",
   "drg.blood.table.statuses": "Buff personel",
   "drg.blood.table.time": "Temps",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -379,8 +379,6 @@
   "drg.blood.suggestions.buffsed-stardiver.why": "<0/>をバフありで使えたときに、{noBuffSd, plural, other {# 回}}バフなしで使いました。",
   "drg.blood.suggestions.eyes.content": "</>がプロックしている時は<0/> と</> の使用は避けて下さい。使用すると上書きされ、紅の竜血になることを遅延させ、潜在的に多くのDPSを犠牲にする可能性があります。",
   "drg.blood.suggestions.eyes.why": "{MAX_EYES} があったのに、ミラージュダイブを {0, plural, other {# 回}}使ってしまいました。",
-  "drg.blood.suggestions.gk.content": "紅の竜血を遅らせないように、<0/>を可能な限り使うようにしましょう。<1/>の使用回数との差は1以内であるべきです。",
-  "drg.blood.suggestions.gk.why": "<0/>と<1/>の使用回数の差が{gkDiff} です。",
   "drg.blood.table.action": "アクション",
   "drg.blood.table.statuses": "自己バフ",
   "drg.blood.table.time": "時間",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -379,8 +379,6 @@
   "drg.blood.suggestions.buffsed-stardiver.why": "<0/>이 버프로 강화될 수 있는데도 불구하고 {noBuffSd, plural, one {# 회} other {# 회}}를 버프 없이 사용하였습니다.",
   "drg.blood.suggestions.eyes.content": "{MAX_EYES} 개의 눈이 있는 상태에서 <0/>를 사용하지 마세요. 눈을 낭비하는 것은 붉은 용혈 구간을 늦추며 상당한 DPS 손실이 될 가능성이 큽니다.",
   "drg.blood.suggestions.eyes.why": "이미 {MAX_EYES} 개의 눈이 있는 상태에서 {0, plural, one {#회} other {#회}}의 환영 강타를 사용했습니다.",
-  "drg.blood.suggestions.gk.content": "붉은 용혈 구간이 미루어지는것을 피하되 최대한 <0/>을 자주 사용하십시오. <1/> 사용 횟수 기준 1회 이내 정도 차이가 나야합니다.",
-  "drg.blood.suggestions.gk.why": "<0/> 시전 타이밍이 <1/>과 {gkDiff} 만큼 차이가 있습니다.",
   "drg.blood.table.action": "사용 기술",
   "drg.blood.table.statuses": "개인 버프",
   "drg.blood.table.time": "시간",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -379,8 +379,6 @@
   "drg.blood.suggestions.buffsed-stardiver.why": "<0/>需要在持有buff的情况下使用，你一共有{noBuffSd, plural,one {#次}other {#次}}在没有buff的情况下使用了该技能。",
   "drg.blood.suggestions.eyes.content": "不要在已经有 {MAX_EYES} 档龙眼的时候使用<0/>。浪费龙眼会延后你的红莲龙血状态，可能会使你的DPS明显降低。",
   "drg.blood.suggestions.eyes.why": "你在已经有 {MAX_EYES} 档龙眼的时候使用了{0, plural, other {# 次}}幻象冲。",
-  "drg.blood.suggestions.gk.content": "为了不延后你的红龙血，你应该尽可能的使用<0/>，并且和使用<1/>的次数差应该控制在1次以内。",
-  "drg.blood.suggestions.gk.why": "<0/>和<1/>的使用次数差了{gkDiff}。",
   "drg.blood.table.action": "技能",
   "drg.blood.table.statuses": "个人增益",
   "drg.blood.table.time": "时间",

--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.js
@@ -50,8 +50,6 @@ export default class BloodOfTheDragon extends Module {
 	_lastEventTime = this.parser.fight.start_time
 	_eyes = 0
 	_lostEyes = 0
-	_gkCount = 0
-	_jumpCount = 0
 
 	constructor(...args) {
 		super(...args)
@@ -62,7 +60,6 @@ export default class BloodOfTheDragon extends Module {
 		this.addEventHook('normaliseddamage', {by: 'player', abilityId: ACTIONS.GEIRSKOGUL.id}, this._onGeirskogulCast)
 		this.addEventHook('normaliseddamage', {by: 'player', abilityId: ACTIONS.NASTROND.id}, this._onNastrondCast)
 		this.addEventHook('cast', {by: 'player', abilityId: ACTIONS.STARDIVER.id}, this._onStardiverCast)
-		this.addEventHook('cast', {by: 'player', abilityId: ACTIONS.HIGH_JUMP.id}, this._onJumpCast)
 		this.addEventHook('death', {to: 'player'}, this._onDeath)
 		this.addEventHook('raise', {to: 'player'}, this._onRaise)
 		this.addEventHook('complete', this._onComplete)
@@ -143,10 +140,6 @@ export default class BloodOfTheDragon extends Module {
 		this._bloodDuration = DRAGON_DEFAULT_DURATION_MILLIS
 	}
 
-	_onJumpCast() {
-		this._jumpCount += 1
-	}
-
 	_onMirageDiveCast() {
 		this._updateGauge()
 		if (this._lifeWindows.current !== null || this._bloodDuration > 0) {
@@ -161,7 +154,6 @@ export default class BloodOfTheDragon extends Module {
 
 	_onGeirskogulCast() {
 		this._updateGauge()
-		this._gkCount += 1
 
 		if (this._eyes === MAX_EYES) {
 			// LotD tiiiiiime~
@@ -361,29 +353,6 @@ export default class BloodOfTheDragon extends Module {
 			},
 			why: <Trans id="drg.suggestions.nastrond.why">{noFullNsLife} of your Life of the Dragon windows were missing one or more <ActionLink {...ACTIONS.NASTROND}/> uses.</Trans>,
 		}))
-
-		// GK count should be within 1 of the number of jumps used in the fight
-		// (current balance tip reference, section 2)
-		const gkDiff = this._jumpCount - this._gkCount
-		// more jumps than GKs
-		if (gkDiff > 1) {
-			this.suggestions.add(new TieredSuggestion({
-				icon: ACTIONS.GEIRSKOGUL.icon,
-				content: <Trans id="drg.blood.suggestions.gk.content">
-					Remember to use <ActionLink {...ACTIONS.GEIRSKOGUL}/> as much as possible, without delaying your Life of the Dragon windows. The number of casts should be within 1 of the number of <ActionLink {...ACTIONS.HIGH_JUMP} /> casts.
-				</Trans>,
-				value: gkDiff,
-				tiers: {
-					2: SEVERITY.MINOR,
-					3: SEVERITY.MEDIUM,
-				},
-				why: <Trans id="drg.blood.suggestions.gk.why">
-					Your <ActionLink {...ACTIONS.GEIRSKOGUL}/> casts differed from your <ActionLink {...ACTIONS.HIGH_JUMP}/> casts by {gkDiff}.
-				</Trans>,
-			}))
-		}
-		// less jumps than GKs??? different tip then, which is basically use jumps more??
-		// not going to output something here as that should be covered by the oGCD downtime checklist
 
 		// this suggestion only counts places where a stardiver could be buffed
 		// if a window cannot be delayed and has no buffs, it doesn't count

--- a/src/parser/jobs/drg/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drg/modules/OGCDDowntime.ts
@@ -6,15 +6,11 @@ import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 // however all are used before the third GCD
 const BUFF_FIRST_USE_OFFSET = 7000
 
-// the high sks opener delays jumps to better line up with later windows,
-// but isn't used with current sets. Timings listed here should work
-// for both openers, if the high sks build ever becomes relevant.
-const JUMP_FIRST_USE_OFFSET = 16100		// before 7th gcd
-const SSD_FIRST_USE_OFFSET = 20800		// before 9th gcd
-const DFD_FIRST_USE_OFFSET = 23500		// before 10th gcd
+// ordering for jumps and GSK can shift, though LS is constant
+const JUMP_FIRST_USE_OFFSET = 17500
 
 // always before Full Thrust, the 8th GCD
-const LIFE_SURGE_FIRST_USE_OFFSET = 19500
+const LIFE_SURGE_FIRST_USE_OFFSET = 20000
 
 export default class OGCDDowntime extends CooldownDowntime {
 	defaultFirstUseOffset = BUFF_FIRST_USE_OFFSET
@@ -25,14 +21,15 @@ export default class OGCDDowntime extends CooldownDowntime {
 		},
 		{
 			cooldowns: [ACTIONS.GEIRSKOGUL],
+			firstUseOffset: JUMP_FIRST_USE_OFFSET,
 		},
 		{
 			cooldowns: [ACTIONS.SPINESHATTER_DIVE],
-			firstUseOffset: SSD_FIRST_USE_OFFSET,
+			firstUseOffset: JUMP_FIRST_USE_OFFSET,
 		},
 		{
 			cooldowns: [ACTIONS.DRAGONFIRE_DIVE],
-			firstUseOffset: DFD_FIRST_USE_OFFSET,
+			firstUseOffset: JUMP_FIRST_USE_OFFSET,
 		},
 		{
 			cooldowns: [ACTIONS.LIFE_SURGE],


### PR DESCRIPTION
With GSK in the OGCD tracker, the old suggestion to keep GSK uses close to High Jump uses is no longer needed.