### PR TITLE
Add in the old IDs for Chi and Jin to fix buggy timelines

### DIFF
--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -41,7 +41,7 @@ export const NIN = ensureActions({
 		charges: 2,
 	},
 
-	TEN_KASSATSU: {
+	TEN_NEW: {
 		id: 18805,
 		name: 'Ten',
 		icon: 'https://xivapi.com/i/002000/002901.png',
@@ -51,6 +51,16 @@ export const NIN = ensureActions({
 	},
 
 	CHI: {
+		id: 2261,
+		name: 'Chi',
+		icon: 'https://xivapi.com/i/002000/002902.png',
+		onGcd: true,
+		cooldown: 20,
+		gcdRecast: 0.5,
+		charges: 2,
+	},
+
+	CHI_NEW: {
 		id: 18806,
 		name: 'Chi',
 		icon: 'https://xivapi.com/i/002000/002902.png',
@@ -61,6 +71,16 @@ export const NIN = ensureActions({
 	},
 
 	JIN: {
+		id: 2263,
+		name: 'Jin',
+		icon: 'https://xivapi.com/i/002000/002903.png',
+		onGcd: true,
+		cooldown: 20,
+		gcdRecast: 0.5,
+		charges: 2,
+	},
+
+	JIN_NEW: {
 		id: 18807,
 		name: 'Jin',
 		icon: 'https://xivapi.com/i/002000/002903.png',

--- a/src/parser/jobs/nin/modules/TrickAttackUsage.js
+++ b/src/parser/jobs/nin/modules/TrickAttackUsage.js
@@ -32,7 +32,9 @@ export default class TrickAttackUsage extends Module {
 	_onCast(event) {
 		const action = getDataBy(ACTIONS, 'id', event.ability.guid)
 		if (event.timestamp >= this.parser.fight.start_time && action && action.onGcd && !(
-			action.id === ACTIONS.TEN.id || action.id === ACTIONS.TEN_KASSATSU.id || action.id === ACTIONS.CHI.id || action.id === ACTIONS.JIN.id)) {
+			action.id === ACTIONS.TEN.id || action.id === ACTIONS.TEN_NEW.id ||
+			action.id === ACTIONS.CHI.id || action.id === ACTIONS.CHI_NEW.id ||
+			action.id === ACTIONS.JIN.id || action.id === ACTIONS.JIN_NEW.id)) {
 			// Don't count the individual mudras as GCDs for this - they'll make the count screw if Suiton wasn't set up pre-pull
 			this._gcdCount++
 		}

--- a/src/parser/jobs/nin/modules/TrickAttackUsage.js
+++ b/src/parser/jobs/nin/modules/TrickAttackUsage.js
@@ -10,6 +10,15 @@ import {Suggestion, TieredSuggestion, SEVERITY} from 'parser/core/modules/Sugges
 const TA_COOLDOWN_MILLIS = ACTIONS.TRICK_ATTACK.cooldown * 1000
 const OPTIMAL_GCD_COUNT = 5 // Opener should be Suiton > AE combo > SE before Trick
 
+const MUDRAS = [
+	ACTIONS.TEN.id,
+	ACTIONS.TEN_NEW.id,
+	ACTIONS.CHI.id,
+	ACTIONS.CHI_NEW.id,
+	ACTIONS.JIN.id,
+	ACTIONS.JIN_NEW.id,
+]
+
 export default class TrickAttackUsage extends Module {
 	static handle = 'taUsage'
 	static dependencies = [
@@ -31,10 +40,7 @@ export default class TrickAttackUsage extends Module {
 
 	_onCast(event) {
 		const action = getDataBy(ACTIONS, 'id', event.ability.guid)
-		if (event.timestamp >= this.parser.fight.start_time && action && action.onGcd && !(
-			action.id === ACTIONS.TEN.id || action.id === ACTIONS.TEN_NEW.id ||
-			action.id === ACTIONS.CHI.id || action.id === ACTIONS.CHI_NEW.id ||
-			action.id === ACTIONS.JIN.id || action.id === ACTIONS.JIN_NEW.id)) {
+		if (event.timestamp >= this.parser.fight.start_time && action && action.onGcd && MUDRAS.indexOf(action.id) === -1) {
 			// Don't count the individual mudras as GCDs for this - they'll make the count screw if Suiton wasn't set up pre-pull
 			this._gcdCount++
 		}

--- a/src/parser/jobs/nin/modules/TrickAttackWindow.js
+++ b/src/parser/jobs/nin/modules/TrickAttackWindow.js
@@ -90,7 +90,9 @@ export default class TrickAttackWindow extends BuffWindowModule {
 
 	considerAction(action) {
 		// Ten, Chi, and Jin should be ignored for purposes of GCD counts
-		return !(action.id === ACTIONS.TEN.id || action.id === ACTIONS.TEN_KASSATSU.id || action.id === ACTIONS.CHI.id || action.id === ACTIONS.JIN.id)
+		return !(action.id === ACTIONS.TEN.id || action.id === ACTIONS.TEN_NEW.id ||
+			action.id === ACTIONS.CHI.id || action.id === ACTIONS.CHI_NEW.id ||
+			action.id === ACTIONS.JIN.id || action.id === ACTIONS.JIN_NEW.id)
 	}
 
 	changeExpectedGCDsClassLogic(buffWindow) {

--- a/src/parser/jobs/nin/modules/TrickAttackWindow.js
+++ b/src/parser/jobs/nin/modules/TrickAttackWindow.js
@@ -13,6 +13,15 @@ const BASE_GCDS_PER_WINDOW = 7
 
 const FIRST_WINDOW_BUFFER = 30000
 
+const MUDRAS = [
+	ACTIONS.TEN.id,
+	ACTIONS.TEN_NEW.id,
+	ACTIONS.CHI.id,
+	ACTIONS.CHI_NEW.id,
+	ACTIONS.JIN.id,
+	ACTIONS.JIN_NEW.id,
+]
+
 export default class TrickAttackWindow extends BuffWindowModule {
 	static handle = 'taWindow'
 	static title = t('nin.taWindow.title')`Trick Attack Windows`
@@ -90,9 +99,7 @@ export default class TrickAttackWindow extends BuffWindowModule {
 
 	considerAction(action) {
 		// Ten, Chi, and Jin should be ignored for purposes of GCD counts
-		return !(action.id === ACTIONS.TEN.id || action.id === ACTIONS.TEN_NEW.id ||
-			action.id === ACTIONS.CHI.id || action.id === ACTIONS.CHI_NEW.id ||
-			action.id === ACTIONS.JIN.id || action.id === ACTIONS.JIN_NEW.id)
+		return MUDRAS.indexOf(action.id) === -1
 	}
 
 	changeExpectedGCDsClassLogic(buffWindow) {


### PR DESCRIPTION
What it says on the tin. I also refactored `TEN_KASSATSU` to `TEN_NEW` since my assumption about when 18805 gets used over 2259 doesn't apply to Chi and Jin and I'd rather keep their names consistent.