### PR TITLE
DRG: Fix LotD module showing a warning to delay past end of fight

### DIFF
--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.js
@@ -247,14 +247,19 @@ export default class BloodOfTheDragon extends Module {
 			// determine if it could be delayed
 			lifeWindow.buffsInDelayWindow = {}
 
+			// downtime overlap
 			lifeWindow.dtOverlapTime = this._intersectsDowntime((lifeWindow.start + ACTIONS.HIGH_JUMP.cooldown * 1000))
+
+			// flag for last life window
+			lifeWindow.isLast = lifeWindow.start + lifeWindow.duration > this.parser.fight.end_time
 
 			// A window should be delayed if:
 			// - there are no buffs off cooldown at any point in this window
 			// - there are no upcoming downtime windows (checked here)
 			// - there are buffs off cooldown in the theoretical delayed window
+			// - there could be another window in 30s (end of fight check)
 			let activeBuffsInWindow = lifeWindow.activeBuffs.length > 0
-			const shouldBeDelayed = lifeWindow.activeBuffs.length === 0 && lifeWindow.dtOverlapTime === null
+			const shouldBeDelayed = lifeWindow.activeBuffs.length === 0 && lifeWindow.dtOverlapTime === null && lifeWindow.start + LOTD_BUFF_DELAY_MIN < this.parser.fight.end_time
 
 			let buffsExistInDelayWindow = false
 
@@ -278,8 +283,6 @@ export default class BloodOfTheDragon extends Module {
 			// check the stardiver cast buffs
 			// count a miss if the window could be delayed
 			lifeWindow.missedSdBuff = (activeBuffsInWindow || lifeWindow.shouldDelay) && lifeWindow.stardivers.length === 1 && lifeWindow.stardivers[0].buffs.length === 0
-
-			lifeWindow.isLast = lifeWindow.start + lifeWindow.duration > this.parser.fight.end_time
 		}
 	}
 

--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.js
@@ -259,7 +259,7 @@ export default class BloodOfTheDragon extends Module {
 			// - there are buffs off cooldown in the theoretical delayed window
 			// - there could be another window in 30s (end of fight check)
 			let activeBuffsInWindow = lifeWindow.activeBuffs.length > 0
-			const shouldBeDelayed = lifeWindow.activeBuffs.length === 0 && lifeWindow.dtOverlapTime === null && lifeWindow.start + LOTD_BUFF_DELAY_MIN < this.parser.fight.end_time
+			const shouldBeDelayed = lifeWindow.activeBuffs.length === 0 && lifeWindow.dtOverlapTime === null && lifeWindow.start + LOTD_BUFF_DELAY_MAX < this.parser.fight.end_time
 
 			let buffsExistInDelayWindow = false
 


### PR DESCRIPTION
Before suggesting a delay, the module now checks to make sure a full delayed window can actually happen (as in there are at least 60 seconds left in the fight). Checking for possibility of a max duration delayed window prioritizes casts of Nastrond over buffing 1-3 casts.