### PR TITLE
DRG: Adjust true north recharge buffer

### DIFF
--- a/src/parser/jobs/drg/modules/Positionals.js
+++ b/src/parser/jobs/drg/modules/Positionals.js
@@ -26,7 +26,7 @@ const NEXT_COMBO = {
 }
 
 const TRUE_NORTH_CHARGES = 2
-const TRUE_NORTH_CD_BUFFER = 200
+const TRUE_NORTH_CD_BUFFER = 500
 const TRUE_NORTH_CD = ACTIONS.TRUE_NORTH.cooldown * 1000 - TRUE_NORTH_CD_BUFFER
 
 export default class Positionals extends Module {


### PR DESCRIPTION
Simulated charges weren't giving enough of a buffer to account for TN being used on CD. Changed from 200 ms to 500 ms.

Demonstrated by this log: https://www.fflogs.com/reports/7zhtR1q3Hpfcg6rD#fight=43&source=56