### PR TITLE
WAR - added combo to mythril tempest

### DIFF
--- a/src/data/ACTIONS/root/MRD.ts
+++ b/src/data/ACTIONS/root/MRD.ts
@@ -22,7 +22,9 @@ export const MRD = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000254.png',
 		onGcd: true,
 		potency: 130,
-		breaksCombo: true,
+		combo: {
+			start: true,
+		},
 	},
 
 	TOMAHAWK: {

--- a/src/data/ACTIONS/root/WAR.ts
+++ b/src/data/ACTIONS/root/WAR.ts
@@ -32,6 +32,7 @@ export const WAR = ensureActions({
 		combo: {
 			from: 41,
 			potency: 200,
+			end: true,
 		},
 	},
 

--- a/src/parser/jobs/sam/modules/Sen.tsx
+++ b/src/parser/jobs/sam/modules/Sen.tsx
@@ -10,7 +10,6 @@ import _ from 'lodash'
 import Module, {dependency} from 'parser/core/Module'
 import {ComboEvent} from 'parser/core/modules/Combos'
 import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
-import Downtime from 'parser/core/modules/Downtime'
 import Suggestions, {SEVERITY, TieredSuggestion, Suggestion} from 'parser/core/modules/Suggestions'
 import {Timeline} from 'parser/core/modules/Timeline'
 import React, {Fragment} from 'react'
@@ -71,7 +70,7 @@ const KENKI_PER_SEN = 10
 
 const SEN_HANDLING = {
 	NONE: {priority: 0, message: <> No errors </>},
-	OVERWROTE_SEN: {priority: 20, message: <Trans id = "sam.sen.sen_handling.overwrote_sen"> Contains an Overwritten Sen. </Trans>},
+	OVERWROTE_SEN: {priority: 20, message: <Trans id = "sam.sen.sen_handling.overwrote_sen"> Contains a Overwritten Sen. </Trans>},
 	OVERWROTE_SENS: {priority: 25, message: <Trans id = "sam.sen.sen_handling.overwrote_sens"> Contains Overwritten Sens. </Trans>},
 	HAGAKURE: {priority: 10, message: <Trans id = "sam.sen.sen_handling.hagakure"> Contains a Standard Filler Hagakure. </Trans>},
 	D_HAGAKURE: {priority: 15, message: <Trans id = "sam.sen.sen_handling.d_hagakure"> Contains a Non-Standard use of Hagakure. </Trans>},
@@ -135,9 +134,8 @@ export default class Sen extends Module {
 	static handle = 'sen'
 	static title = t('sam.sen.title')`Non-Standard Sen Windows`
 
-	@dependency private downtime!: Downtime
-	@dependency private kenki!: Kenki
 	@dependency private suggestions!: Suggestions
+	@dependency private kenki!: Kenki
 	@dependency private timeline!: Timeline
 
 	private wasted = 0
@@ -237,8 +235,6 @@ export default class Sen extends Module {
 
 // Function that handles SenState check, if no senState call the maker and then push to the rotation
 	private checkCastAndPush(event: CastEvent) {
-
-		if (this.downtime.isDowntime()) { return }
 
 		// step 1: set action
 		const action = event.ability.guid
@@ -414,7 +410,7 @@ export default class Sen extends Module {
 							targetsData: {
 								setsu: {
 									actual: (window.currentSetsu + window.overwriteSetsus),
-									expected: 3,
+									// expected: window.setsu,
 								},
 								getsu: {
 									actual: (window.currentGetsu + window.overwriteGetsus),

--- a/src/parser/jobs/sam/modules/Sen.tsx
+++ b/src/parser/jobs/sam/modules/Sen.tsx
@@ -10,6 +10,7 @@ import _ from 'lodash'
 import Module, {dependency} from 'parser/core/Module'
 import {ComboEvent} from 'parser/core/modules/Combos'
 import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
+import Downtime from 'parser/core/modules/Downtime'
 import Suggestions, {SEVERITY, TieredSuggestion, Suggestion} from 'parser/core/modules/Suggestions'
 import {Timeline} from 'parser/core/modules/Timeline'
 import React, {Fragment} from 'react'
@@ -70,7 +71,7 @@ const KENKI_PER_SEN = 10
 
 const SEN_HANDLING = {
 	NONE: {priority: 0, message: <> No errors </>},
-	OVERWROTE_SEN: {priority: 20, message: <Trans id = "sam.sen.sen_handling.overwrote_sen"> Contains a Overwritten Sen. </Trans>},
+	OVERWROTE_SEN: {priority: 20, message: <Trans id = "sam.sen.sen_handling.overwrote_sen"> Contains an Overwritten Sen. </Trans>},
 	OVERWROTE_SENS: {priority: 25, message: <Trans id = "sam.sen.sen_handling.overwrote_sens"> Contains Overwritten Sens. </Trans>},
 	HAGAKURE: {priority: 10, message: <Trans id = "sam.sen.sen_handling.hagakure"> Contains a Standard Filler Hagakure. </Trans>},
 	D_HAGAKURE: {priority: 15, message: <Trans id = "sam.sen.sen_handling.d_hagakure"> Contains a Non-Standard use of Hagakure. </Trans>},
@@ -134,8 +135,9 @@ export default class Sen extends Module {
 	static handle = 'sen'
 	static title = t('sam.sen.title')`Non-Standard Sen Windows`
 
-	@dependency private suggestions!: Suggestions
+	@dependency private downtime!: Downtime
 	@dependency private kenki!: Kenki
+	@dependency private suggestions!: Suggestions
 	@dependency private timeline!: Timeline
 
 	private wasted = 0
@@ -235,6 +237,8 @@ export default class Sen extends Module {
 
 // Function that handles SenState check, if no senState call the maker and then push to the rotation
 	private checkCastAndPush(event: CastEvent) {
+
+		if (this.downtime.isDowntime()) { return }
 
 		// step 1: set action
 		const action = event.ability.guid
@@ -410,7 +414,7 @@ export default class Sen extends Module {
 							targetsData: {
 								setsu: {
 									actual: (window.currentSetsu + window.overwriteSetsus),
-									// expected: window.setsu,
+									expected: 3,
 								},
 								getsu: {
 									actual: (window.currentGetsu + window.overwriteGetsus),


### PR DESCRIPTION
Fixed a bug that was, err, bugging me.

Before:
![image](https://user-images.githubusercontent.com/65056303/89369474-34656280-d6ac-11ea-9fe2-12ea7e2f3629.png)

(00:31, 03:06, 03:16, 03:20 were all combo'd tempests)

After:
![image](https://user-images.githubusercontent.com/65056303/89369502-48a95f80-d6ac-11ea-83fa-b7488210fff4.png)

(finished combos are no longer showing, also overpower combo breaks are now showing correctly, nice)

Log: https://www.fflogs.com/reports/aQRgcM8fXK41xrVz#fight=10&type=casts&source=3&view=events