### PR TITLE
RotationTable - add optional comparator function for cell highlighting

### DIFF
--- a/src/parser/jobs/war/modules/InnerRelease.tsx
+++ b/src/parser/jobs/war/modules/InnerRelease.tsx
@@ -3,7 +3,7 @@ import {Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-import {BuffWindowModule, BuffWindowState} from 'parser/core/modules/BuffWindow'
+import {BuffWindowModule} from 'parser/core/modules/BuffWindow'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
 

--- a/src/parser/jobs/war/modules/InnerRelease.tsx
+++ b/src/parser/jobs/war/modules/InnerRelease.tsx
@@ -3,10 +3,9 @@ import {Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-import {BuffWindowModule, BuffWindowState, BuffWindowTrackedAction} from 'parser/core/modules/BuffWindow'
+import {BuffWindowModule, BuffWindowState} from 'parser/core/modules/BuffWindow'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
-import {RotationTargetOutcome} from 'components/ui/RotationTable'
 
 export default class InnerRelease extends BuffWindowModule {
 	static handle = 'ir'

--- a/src/parser/jobs/war/modules/InnerRelease.tsx
+++ b/src/parser/jobs/war/modules/InnerRelease.tsx
@@ -3,9 +3,10 @@ import {Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-import {BuffWindowModule} from 'parser/core/modules/BuffWindow'
+import {BuffWindowModule, BuffWindowState, BuffWindowTrackedAction} from 'parser/core/modules/BuffWindow'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
+import {RotationTargetOutcome} from 'components/ui/RotationTable'
 
 export default class InnerRelease extends BuffWindowModule {
 	static handle = 'ir'


### PR DESCRIPTION
For rotation target outcomes that don't follow the default pattern of ">= threshold good, else bad", RotationTarget accessors may optionally provide a custom comparator function defining the criteria for positive/negative usage highlighting. Existing behaviour for highlighting is used by default. Also added a method `changeComparisonClassLogic(buffWindow, action)` to BuffWindow that implementing modules can use as in the following example:

```typescript
export default class SomeBuff extends BuffWindowModule {
	// ...
	private someActionOutcome(actual: number, expected?: number): RotationTargetOutcome {
		return {
                        // positive ONLY if actual uses is exactly equal to expected
			positive: expected === undefined ? false : actual === expected,
                        // never negative
			negative: false,
		}
	}

	protected changeComparisonClassLogic(buffWindow: BuffWindowState, action: BuffWindowTrackedAction) {
		if (action.action === ACTIONS.SOME_ACTION) {
			return this.someActionOutcome
		}
               // else undefined, default behaviour is used
	}
	// ...
}
```