### PR TITLE
MCH - Tinctures

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -521,6 +521,7 @@
   "mch.reassemble.suggestions.bad-gcds.why": "",
   "mch.reassemble.suggestions.dropped.content": "",
   "mch.reassemble.suggestions.dropped.why": "",
+  "mch.tincture.suggestions.trackedActions.content": "",
   "mch.wildfire.accordion.message": "",
   "mch.wildfire.panel-count": "",
   "mch.wildfire.panel-count-spoofed": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -521,6 +521,7 @@
   "mch.reassemble.suggestions.bad-gcds.why": "You used Reassemble on a non-optimal GCD {0, plural, one {# time} other {# times}}.",
   "mch.reassemble.suggestions.dropped.content": "Avoid using <0/> when a boss is about to go untargetable so you don't waste the buff.",
   "mch.reassemble.suggestions.dropped.why": "You allowed Reassemble to fall off unused {0, plural, one {# time} other {# times}}.",
+  "mch.tincture.suggestions.trackedActions.content": "Try to cover as much damage as possible with your Infusions of Dexterity.",
   "mch.wildfire.accordion.message": "Every <0/> window should ideally contain at least {WILDFIRE_GCD_TARGET} GCDs to maximize its potency. Each Wildfire window below indicates how many GCDs it contained and the total damage it hit for, and will display all the damaging casts in the window if expanded.",
   "mch.wildfire.panel-count": "{0} {1, plural, one {GCD} other {GCDs}}, {2} damage",
   "mch.wildfire.panel-count-spoofed": "? GCDs, {0} damage",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -521,7 +521,7 @@
   "mch.reassemble.suggestions.bad-gcds.why": "You used Reassemble on a non-optimal GCD {0, plural, one {# time} other {# times}}.",
   "mch.reassemble.suggestions.dropped.content": "Avoid using <0/> when a boss is about to go untargetable so you don't waste the buff.",
   "mch.reassemble.suggestions.dropped.why": "You allowed Reassemble to fall off unused {0, plural, one {# time} other {# times}}.",
-  "mch.tincture.suggestions.trackedActions.content": "Try to cover as much damage as possible with your Infusions of Dexterity.",
+  "mch.tincture.suggestions.trackedActions.content": "Try to cover as much damage as possible with your Tinctures of Dexterity.",
   "mch.wildfire.accordion.message": "Every <0/> window should ideally contain at least {WILDFIRE_GCD_TARGET} GCDs to maximize its potency. Each Wildfire window below indicates how many GCDs it contained and the total damage it hit for, and will display all the damaging casts in the window if expanded.",
   "mch.wildfire.panel-count": "{0} {1, plural, one {GCD} other {GCDs}}, {2} damage",
   "mch.wildfire.panel-count-spoofed": "? GCDs, {0} damage",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -521,6 +521,7 @@
   "mch.reassemble.suggestions.bad-gcds.why": "Vous avez utilisé Réassemblage sur un GCD non optimal {0, plural, one {# fois} other {# fois}}.",
   "mch.reassemble.suggestions.dropped.content": "Évitez d'utiliser <0/> lorsqu'un boss est sur le point de devenir non ciblable pour ne pas gaspiller le buff.",
   "mch.reassemble.suggestions.dropped.why": "Vous avez laissé tombé l'effet de Réassemblage{0, plural,one {# fois}other {# fois}}.",
+  "mch.tincture.suggestions.trackedActions.content": "",
   "mch.wildfire.accordion.message": "Chaque fenêtre <0/> doit idéalement contenir au moins {WILDFIRE_GCD_TARGET}. GCDs pour maximiser le potentiel. Chaque fenêtre de flambée ci-dessous indique le nombre de GCD qu'elle contenait et les dégâts totaux qu'elle a subis, et affichera tous les plâtres dommageables dans la fenêtre si elle est agrandie.",
   "mch.wildfire.panel-count": "{0} {1, plural, one {GCD} other {GCDs}},{2} dégats",
   "mch.wildfire.panel-count-spoofed": "? GCDs, {0} dégâts",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -521,6 +521,7 @@
   "mch.reassemble.suggestions.bad-gcds.why": "",
   "mch.reassemble.suggestions.dropped.content": "",
   "mch.reassemble.suggestions.dropped.why": "",
+  "mch.tincture.suggestions.trackedActions.content": "",
   "mch.wildfire.accordion.message": "",
   "mch.wildfire.panel-count": "{0, plural, other {GCD使用数: #}}",
   "mch.wildfire.panel-count-spoofed": "?GCD、 ダメージ: {0}",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -521,6 +521,7 @@
   "mch.reassemble.suggestions.bad-gcds.why": "정비를 올바르지않은 글쿨기에 총 {0, plural, other {#회}} 사용하엿습니다.",
   "mch.reassemble.suggestions.dropped.content": "대상이 곧 무적 상태로 진입할시 <0/>을 사용하는것을 피하십시오. 버프가 무의미해집니다.",
   "mch.reassemble.suggestions.dropped.why": "정비를 총 {0, plural, other {#회}}를 사용 후 끊어지게 놔두었습니다.",
+  "mch.tincture.suggestions.trackedActions.content": "",
   "mch.wildfire.accordion.message": "모든 <0/>구간은 적어도 {WILDFIRE_GCD_TARGET} 개의 글쿨과 최대한 많은 비글쿨기를 포함하여야 합니다. 아래의 창에는 각 소이탄 구간에서 사용된 글쿨과 총 데미지를 표시하며, 창을 확장하면 구간에서 사용된 모든 기술을 표시합니다.",
   "mch.wildfire.panel-count": "{0} {1, plural, one {#글쿨} other {#글쿨}}, {2} 데미지",
   "mch.wildfire.panel-count-spoofed": "? 글쿨 횟수, {0} 데미지",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -521,6 +521,7 @@
   "mch.reassemble.suggestions.bad-gcds.why": "{0, plural, one {# 次} other {# 次}}整备没有用在正确的技能上.",
   "mch.reassemble.suggestions.dropped.content": "在Boss下一秒即将进入不可选中状态时，不要使用<0/>，避免浪费掉这个buff。",
   "mch.reassemble.suggestions.dropped.why": "你有 {0, plural, one {# time} other {# 次}}整备buff结束了都没使用过战技。",
+  "mch.tincture.suggestions.trackedActions.content": "",
   "mch.wildfire.accordion.message": "理想情况下，每次<0/>都应该包含至少 {WILDFIRE_GCD_TARGET} 个GCD技能，下面的表格展示了每次野火中所包含的GCD技能，以及它们的伤害总和，展开后能看到全部内容。",
   "mch.wildfire.panel-count": "{1} 个 GCD，{2} 点伤害",
   "mch.wildfire.panel-count-spoofed": "？个GCD，{0} 点伤害",

--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -106,6 +106,11 @@ export abstract class BuffWindowModule extends Module {
 	 */
 	protected trackedBadActions?: BuffWindowTrackedActions
 	/**
+	 * Optionally, you can also specify pet actions to track. These actions will show up in the rotation section and can be
+	 *   included in trackedActions
+	 */
+	protected petActions?: Action[]
+	/**
 	 * Implementing modules MAY provide a value to override the "Rotation" title in the header of the rotation section
 	 * If implementing, you MUST provide a JSX.Element <Trans> or <Fragment> tag (Trans tag preferred)
 	 */
@@ -135,10 +140,13 @@ export abstract class BuffWindowModule extends Module {
 
 	protected init() {
 		this.addEventHook('cast', {by: 'player'}, this.onCast)
-		this.addEventHook('cast', {by: 'pet'}, this.onPetCast)
 		this.addEventHook('applybuff', {to: 'player'}, this.onApplyBuff)
 		this.addEventHook('removebuff', {to: 'player'}, this.onRemoveBuff)
 		this.addEventHook('complete', this.onComplete)
+
+		if (this.petActions && this.petActions.length) {
+			this.addEventHook('cast', {by: 'pet', abilityId: this.petActions.map(a => a.id)}, this.onCast)
+		}
 	}
 
 	private onCast(event: CastEvent) {
@@ -161,24 +169,6 @@ export abstract class BuffWindowModule extends Module {
 	 */
 	protected considerAction(action: Action) {
 		return true
-	}
-
-	private onPetCast(event: CastEvent) {
-		const action = this.data.getAction(event.ability.guid)
-		if (!action) { return }
-
-		if (this.activeBuffWindow && this.considerPetAction(action)) {
-			this.activeBuffWindow.rotation.push(event)
-		}
-	}
-
-	/**
-	 * This method MAY be overridden to return true or false, indicating whether or not this action should be considered within the buff window
-	 * If false is returned, the action will not be tracked AT ALL within the buff window, and will NOT appear within the Rotation column
-	 * @param action
-	 */
-	protected considerPetAction(action: Action) {
-		return false
 	}
 
 	private onApplyBuff(event: BuffEvent) {

--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -65,7 +65,7 @@ interface BuffWindowTrackedActions {
 	severityTiers: SeverityTiers
 }
 
-interface BuffWindowTrackedAction {
+export interface BuffWindowTrackedAction {
 	action: Action
 	expectedPerWindow: number
 }
@@ -135,6 +135,7 @@ export abstract class BuffWindowModule extends Module {
 
 	protected init() {
 		this.addEventHook('cast', {by: 'player'}, this.onCast)
+		this.addEventHook('cast', {by: 'pet'}, this.onPetCast)
 		this.addEventHook('applybuff', {to: 'player'}, this.onApplyBuff)
 		this.addEventHook('removebuff', {to: 'player'}, this.onRemoveBuff)
 		this.addEventHook('complete', this.onComplete)
@@ -160,6 +161,24 @@ export abstract class BuffWindowModule extends Module {
 	 */
 	protected considerAction(action: Action) {
 		return true
+	}
+
+	private onPetCast(event: CastEvent) {
+		const action = this.data.getAction(event.ability.guid)
+		if (!action) { return }
+
+		if (this.activeBuffWindow && this.considerPetAction(action)) {
+			this.activeBuffWindow.rotation.push(event)
+		}
+	}
+
+	/**
+	 * This method MAY be overridden to return true or false, indicating whether or not this action should be considered within the buff window
+	 * If false is returned, the action will not be tracked AT ALL within the buff window, and will NOT appear within the Rotation column
+	 * @param action
+	 */
+	protected considerPetAction(action: Action) {
+		return false
 	}
 
 	private onApplyBuff(event: BuffEvent) {

--- a/src/parser/jobs/mch/index.js
+++ b/src/parser/jobs/mch/index.js
@@ -21,6 +21,11 @@ export default new Meta({
 		{user: CONTRIBUTORS.YUMIYAFANGIRL, role: ROLES.DEVELOPER},
 	],
 	changelog: [{
+		date: new Date('2020-08-08'),
+		Changes: () => <>Added a module that shows Tincture windows.</>,
+		contributors: [CONTRIBUTORS.YUMIYAFANGIRL],
+	},
+	{
 		date: new Date('2020-05-13'),
 		Changes: () => <>Added a module that shows misused AoE actions.</>,
 		contributors: [CONTRIBUTORS.YUMIYAFANGIRL],

--- a/src/parser/jobs/mch/modules/Tincture.tsx
+++ b/src/parser/jobs/mch/modules/Tincture.tsx
@@ -1,0 +1,66 @@
+import {Trans} from '@lingui/react'
+import {ActionLink} from 'components/ui/DbLink'
+import ACTIONS, {Action} from 'data/ACTIONS'
+import Downtime from 'parser/core/modules/Downtime'
+import {dependency} from 'parser/core/Module'
+import {SEVERITY} from 'parser/core/modules/Suggestions'
+import {Tincture} from 'parser/core/modules/Tincture'
+import React from 'react'
+import {BuffWindowState, BuffWindowTrackedAction} from 'parser/core/modules/BuffWindow'
+
+export default class MchTincture extends Tincture {
+	buffAction = ACTIONS.INFUSION_DEX
+
+	@dependency private downtime!: Downtime
+
+	trackedActions = {
+		icon: ACTIONS.INFUSION_DEX.icon,
+		actions: [
+			{
+				action: ACTIONS.WILDFIRE,
+				expectedPerWindow: 1,
+			},
+			{
+				action: ACTIONS.REASSEMBLE,
+				expectedPerWindow: 1,
+			},
+			{
+				action: ACTIONS.PILE_BUNKER,
+				expectedPerWindow: 1,
+			},
+			{
+				action: ACTIONS.DRILL,
+				expectedPerWindow: 2,
+			},
+		],
+		suggestionContent: <Trans id="mch.tincture.suggestions.trackedActions.content">
+			Try to cover as much damage as possible with your Infusions of Dexterity.
+		</Trans>,
+		severityTiers: {
+			2: SEVERITY.MINOR,
+			4: SEVERITY.MEDIUM,
+			6: SEVERITY.MAJOR,
+		},
+	}
+
+	protected considerPetAction(action: Action) {
+		return action === ACTIONS.PILE_BUNKER
+	}
+
+	protected changeExpectedTrackedActionClassLogic(buffWindow: BuffWindowState, action: BuffWindowTrackedAction): number {
+		if (action.action === ACTIONS.REASSEMBLE) {
+			// Reassemble might be used prepull or during downtime
+			if (buffWindow.start <= this.parser.fight.start_time || this.downtime.isDowntime(buffWindow.start)) {
+				return -1
+			}
+
+		} else if (action.action === ACTIONS.PILE_BUNKER) {
+			// We don't have queen in the opener
+			if (buffWindow.start <= this.parser.fight.start_time) {
+				return -1
+			}
+		}
+
+		return 0
+	}
+}

--- a/src/parser/jobs/mch/modules/Tincture.tsx
+++ b/src/parser/jobs/mch/modules/Tincture.tsx
@@ -34,7 +34,7 @@ export default class MchTincture extends Tincture {
 			},
 		],
 		suggestionContent: <Trans id="mch.tincture.suggestions.trackedActions.content">
-			Try to cover as much damage as possible with your Infusions of Dexterity.
+			Try to cover as much damage as possible with your Tinctures of Dexterity.
 		</Trans>,
 		severityTiers: {
 			2: SEVERITY.MINOR,

--- a/src/parser/jobs/mch/modules/Tincture.tsx
+++ b/src/parser/jobs/mch/modules/Tincture.tsx
@@ -43,6 +43,8 @@ export default class MchTincture extends Tincture {
 		},
 	}
 
+	protected petActions = [ACTIONS.PILE_BUNKER]
+
 	protected considerPetAction(action: Action) {
 		return action === ACTIONS.PILE_BUNKER
 	}

--- a/src/parser/jobs/mch/modules/Tincture.tsx
+++ b/src/parser/jobs/mch/modules/Tincture.tsx
@@ -9,9 +9,11 @@ import React from 'react'
 import {BuffWindowState, BuffWindowTrackedAction} from 'parser/core/modules/BuffWindow'
 
 export default class MchTincture extends Tincture {
+	@dependency private downtime!: Downtime
+
 	buffAction = ACTIONS.INFUSION_DEX
 
-	@dependency private downtime!: Downtime
+	petActions = [ACTIONS.PILE_BUNKER]
 
 	trackedActions = {
 		icon: ACTIONS.INFUSION_DEX.icon,
@@ -43,13 +45,11 @@ export default class MchTincture extends Tincture {
 		},
 	}
 
-	protected petActions = [ACTIONS.PILE_BUNKER]
-
-	protected considerPetAction(action: Action) {
+	considerPetAction(action: Action) {
 		return action === ACTIONS.PILE_BUNKER
 	}
 
-	protected changeExpectedTrackedActionClassLogic(buffWindow: BuffWindowState, action: BuffWindowTrackedAction): number {
+	changeExpectedTrackedActionClassLogic(buffWindow: BuffWindowState, action: BuffWindowTrackedAction): number {
 		if (action.action === ACTIONS.REASSEMBLE) {
 			// Reassemble might be used prepull or during downtime
 			if (buffWindow.start <= this.parser.fight.start_time || this.downtime.isDowntime(buffWindow.start)) {

--- a/src/parser/jobs/mch/modules/Tincture.tsx
+++ b/src/parser/jobs/mch/modules/Tincture.tsx
@@ -45,10 +45,6 @@ export default class MchTincture extends Tincture {
 		},
 	}
 
-	considerPetAction(action: Action) {
-		return action === ACTIONS.PILE_BUNKER
-	}
-
 	changeExpectedTrackedActionClassLogic(buffWindow: BuffWindowState, action: BuffWindowTrackedAction): number {
 		if (action.action === ACTIONS.REASSEMBLE) {
 			// Reassemble might be used prepull or during downtime

--- a/src/parser/jobs/mch/modules/index.js
+++ b/src/parser/jobs/mch/modules/index.js
@@ -4,6 +4,7 @@ import Drift from './Drift'
 import Gauge from './Gauge'
 import GeneralCDDowntime from './GeneralCDDowntime'
 import Heat from './Heat'
+import MchTincture from './Tincture'
 import MultiHitSkills from './MultiHitSkills'
 import Reassemble from './Reassemble'
 import Wildfire from './Wildfire'
@@ -16,6 +17,7 @@ export default [
 	Gauge,
 	GeneralCDDowntime,
 	Heat,
+	MchTincture,
 	MultiHitSkills,
 	Reassemble,
 	Wildfire,


### PR DESCRIPTION
Adds a separate event hook for pet casts in BuffWindows. This hook is ignored unless an optional `petActions: Action[]` exists and is non-empty. These actions will be considered in the rotation section of the table, and can also be added to trackedActions if desired (here we're tracking Pile Bunker since it's by far the biggest flexible damage cd MCH has). 

![image](https://user-images.githubusercontent.com/65056303/89710273-592d3480-d94f-11ea-81a7-6d77fd10b575.png)
