### PR TITLE
DRG: mark supported for 5.3

### DIFF
--- a/src/parser/jobs/drg/index.js
+++ b/src/parser/jobs/drg/index.js
@@ -13,7 +13,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.2',
+		to: '5.3',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},


### PR DESCRIPTION
No patch notes, no problem. No changes to DRG in 5.3 so we're good over here.