### PR TITLE
MNK 5.3 support

### DIFF
--- a/src/data/ACTIONS/layers/patch5.3.ts
+++ b/src/data/ACTIONS/layers/patch5.3.ts
@@ -10,5 +10,8 @@ export const patch530: Layer<ActionRoot> = {
 		BURST_SHOT: {potency: 240},
 		SIDEWINDER: {potency: [100, 200, 350]},
 		REFULGENT_ARROW: {potency: 340},
+
+		// MNK 5.3 cooldown changes
+		PERFECT_BALANCE: {cooldown: 90},
 	},
 }

--- a/src/parser/jobs/mnk/index.tsx
+++ b/src/parser/jobs/mnk/index.tsx
@@ -18,7 +18,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.2',
+		to: '5.3',
 	},
 
 	contributors: [
@@ -26,6 +26,13 @@ export default new Meta({
 		{user: CONTRIBUTORS.LHEA, role: ROLES.DEVELOPER},
 	],
 	changelog: [
+		{
+			date: new Date('2020-08-11'),
+			Changes: () => <>
+				Update MNK support for patch 5.3.
+			</>,
+			contributors: [CONTRIBUTORS.ACCHAN],
+		},
 		{
 			date: new Date('2020-02-25'),
 			Changes: () => <>

--- a/src/parser/jobs/mnk/modules/Gauge.ts
+++ b/src/parser/jobs/mnk/modules/Gauge.ts
@@ -25,7 +25,7 @@ const GL_GRANTERS: number[] = [
 
 // Actions that refresh the timer without granting stacks.
 const GL_REFRESHERS: number[] = [
-	// kinda weird, only when going Coeurl->Opo-Opo and you need at least one stack
+	// kinda weird, only when going Coeurl->Opo-Opo (pre-5.3) and you need at least one stack
 	ACTIONS.FORM_SHIFT.id,
 	ACTIONS.SIX_SIDED_STAR.id,
 ]
@@ -94,11 +94,13 @@ export default class Gauge extends CoreGauge {
 		this._timer.start()
 	}
 
-	// If they're using Form Shift but don't have Coeurl Form, it does nothing
+	// If they're using Form Shift but don't have Coeurl Form, it does nothing before 5.3
 	private onRefresh(event: BuffEvent | CastEvent): void {
-		if (event.ability.guid === ACTIONS.FORM_SHIFT.id && !this.combatants.selected.hasStatus(STATUSES.COEURL_FORM.id)) {
-			return
-		}
+		if (
+			event.ability.guid === ACTIONS.FORM_SHIFT.id &&
+			this.parser.patch.before('5.3') &&
+			!this.combatants.selected.hasStatus(STATUSES.COEURL_FORM.id)
+		) { return }
 
 		this._timer.refresh()
 	}


### PR DESCRIPTION
Mince, L'PR est Australienne (no Miu's were hurt in the typing of this message).

PB to 90s, Form Shift no longer requires you to be a Coeurly boi. Keeping support for pre-5.3 tho.
![image](https://user-images.githubusercontent.com/28627120/89806558-91fd2180-db7a-11ea-9061-f302e74ad868.png)
