### PR TITLE
BRD - Apex Arrow bugfix 

### DIFF
--- a/src/parser/jobs/brd/modules/ApexArrow.tsx
+++ b/src/parser/jobs/brd/modules/ApexArrow.tsx
@@ -57,7 +57,7 @@ export default class ApexArrow extends Module {
 	}
 
 	private onApex(event: NormalisedDamageEvent) {
-		if (event.hitCount === 0) {
+		if (event.confirmedEvents.length === 0) {
 			this.ghostedApexCasts++
 			return
 		}


### PR DESCRIPTION
Turns out hitCount includes ghosted hits, so it could sometimes be nonzero while still having no confirmed events. Fixes the error for the two sentry logs that had ghosted apex casts.