### PR TITLE
[BugFix] PrecastStatus - Round 2

### DIFF
--- a/src/parser/core/modules/PrecastStatus.js
+++ b/src/parser/core/modules/PrecastStatus.js
@@ -28,7 +28,7 @@ export default class PrecastStatus extends Module {
 			if (!statusInfo) {
 				if (event.type === 'cast' && event.ability?.guid) {
 					// Add cast to list of observed actions
-					this._combatantActions.push(event.ability.guid)
+					this.markActionAsTracked(event.ability.guid)
 				}
 
 				// No valid status data, skip to next event

--- a/src/parser/core/modules/PrecastStatus.js
+++ b/src/parser/core/modules/PrecastStatus.js
@@ -26,7 +26,7 @@ export default class PrecastStatus extends Module {
 
 			const statusInfo = this.data.getStatus(event.ability?.guid)
 			if (!statusInfo) {
-				if (event.type === 'cast' && event.ability.guid) {
+				if (event.type === 'cast' && event.ability?.guid) {
 					// Add cast to list of observed actions
 					this._combatantActions.push(event.ability.guid)
 				}

--- a/src/parser/core/modules/PrecastStatus.js
+++ b/src/parser/core/modules/PrecastStatus.js
@@ -26,6 +26,11 @@ export default class PrecastStatus extends Module {
 
 			const statusInfo = this.data.getStatus(event.ability?.guid)
 			if (!statusInfo) {
+				if (event.type === 'cast' && event.ability.guid) {
+					// Add cast to list of observed actions
+					this._combatantActions.push(event.ability.guid)
+				}
+
 				// No valid status data, skip to next event
 				continue
 			}


### PR DESCRIPTION
Updates combatantactions with observed cast events so we don't synth casts that actually happened post-pull.