### PR TITLE
DRG: OGCD Downtime changes for adjusted opener

### DIFF
--- a/src/parser/jobs/drg/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drg/modules/OGCDDowntime.ts
@@ -7,10 +7,11 @@ import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 const BUFF_FIRST_USE_OFFSET = 7000
 
 // ordering for jumps and GSK can shift, though LS is constant
-const JUMP_FIRST_USE_OFFSET = 17500
+// Currenly, last jump (DFD usually) is used before 9th GCD
+const JUMP_FIRST_USE_OFFSET = 24500
 
 // always before Full Thrust, the 8th GCD
-const LIFE_SURGE_FIRST_USE_OFFSET = 20000
+const LIFE_SURGE_FIRST_USE_OFFSET = 22000
 
 export default class OGCDDowntime extends CooldownDowntime {
 	defaultFirstUseOffset = BUFF_FIRST_USE_OFFSET


### PR DESCRIPTION
DRG opener recently recommended pushing back jumps by two GCDs, so the first use offset is a little too tight now. When reviewing this change, I noticed that the 2s buffer put in for parser timing wiggly-ness for buff use wasn't added to jumps or life surge, so I put it back.

New first use timings with 2.5s GCD:

- Jumps: 22.5s (before 9th GCD) + 2s buffer = 24.5s
- Life Surge: 20s (before 8th GCD) + 2s buffer = 22.0s