### PR TITLE
Dualcast severity update for missed casts.

### DIFF
--- a/src/parser/jobs/rdm/index.js
+++ b/src/parser/jobs/rdm/index.js
@@ -32,7 +32,7 @@ export default new Meta({
 	changelog: [
 		{
 			date: new Date('2020-09-29'),
-			Changes: () => <>Changed Severity ratings for Missed Dualcasts per Meru 1 missed is now medium, 2 missed is now major.</>,
+			Changes: () => <>Changed Severity ratings for Missed Dualcasts 1 missed is now medium, 2 missed is now major.</>,
 			contributors: [CONTRIBUTORS.LEYLIA],
 		},
 		{

--- a/src/parser/jobs/rdm/index.js
+++ b/src/parser/jobs/rdm/index.js
@@ -31,6 +31,11 @@ export default new Meta({
 
 	changelog: [
 		{
+			date: new Date('2020-09-29'),
+			Changes: () => <>Changed Severity ratings for Missed Dualcasts per Meru 1 missed is now medium, 2 missed is now major.</>,
+			contributors: [CONTRIBUTORS.LEYLIA],
+		},
+		{
 			date: new Date('2020-08-10'),
 			Changes: () => <>Added support for patch 5.3</>,
 			contributors: [CONTRIBUTORS.LEYLIA],

--- a/src/parser/jobs/rdm/modules/Dualcast.js
+++ b/src/parser/jobs/rdm/modules/Dualcast.js
@@ -36,9 +36,8 @@ export default class DualCast extends Module {
 	//The last timestamp for a change in CastType
 	_castTypeLastChanged = null
 	_severityMissedDualcast = {
-		1: SEVERITY.MINOR,
-		2: SEVERITY.MEDIUM,
-		3: SEVERITY.MAJOR,
+		1: SEVERITY.MEDIUM,
+		2: SEVERITY.MAJOR,
 	}
 	_severityWastedDualcast = {
 		1: SEVERITY.MINOR,


### PR DESCRIPTION
Per Meru updated the severity rating for missed Dual Casts shifting values down one and dropping minor as missing is never considered minor.