### PR TITLE
AST - Remove errant space in translation

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -35,7 +35,7 @@
   "ast.draw.suggestions.draw-no-usage.content": "No uses of <0/> at all.",
   "ast.draw.suggestions.draw-no-usage.why": "No draws used.",
   "ast.draw.suggestions.draw-uses.content": "Use <0/> as soon as its available to maximize both MP regen and the number of cards played.",
-  "ast.draw.suggestions.draw-uses.why": "About {drawsMissed, plural, one { # use} other {# uses}} of <0/> were missed by holding it for at least a total of {0}.",
+  "ast.draw.suggestions.draw-uses.why": "About {drawsMissed, plural, one {# use} other {# uses}} of <0/> were missed by holding it for at least a total of {0}.",
   "ast.draw.suggestions.sleeve-no-usage.content": "No uses of <0/> at all. It should be paired with every other <1/> to stack buffs at the same time. <2/> can be used to weave card abilities.",
   "ast.draw.suggestions.sleeve-no-usage.why": "No sleeve draws used.",
   "ast.draw.suggestions.sleeve-uses.content": "Use <0/> more frequently. It should be paired with every other <1/> to stack buffs at the same time. <2/> can be used to weave card abilities.",

--- a/src/parser/jobs/ast/modules/Draw.tsx
+++ b/src/parser/jobs/ast/modules/Draw.tsx
@@ -233,7 +233,7 @@ export default class Draw extends Module {
 				tiers: SEVERITIES.DRAW_HOLDING,
 				value: drawsMissed,
 				why: <Trans id="ast.draw.suggestions.draw-uses.why">
-					About <Plural value={drawsMissed} one=" # use" other="# uses" /> of <ActionLink {...this.data.actions.DRAW} /> were missed by holding it for at least a total of {this.parser.formatDuration(this.drawTotalDrift)}.
+					About <Plural value={drawsMissed} one="# use" other="# uses" /> of <ActionLink {...this.data.actions.DRAW} /> were missed by holding it for at least a total of {this.parser.formatDuration(this.drawTotalDrift)}.
 				</Trans>,
 			}))
 		}


### PR DESCRIPTION
¯\\\_(ツ)\_/¯