### PR TITLE
Fix Provoke cooldown duration

### DIFF
--- a/src/data/ACTIONS/root/ROLE.ts
+++ b/src/data/ACTIONS/root/ROLE.ts
@@ -22,7 +22,7 @@ export const ROLE = ensureActions({
 		id: 7533,
 		name: 'Provoke',
 		icon: 'https://xivapi.com/i/000000/000803.png',
-		cooldown: 40,
+		cooldown: 30,
 	},
 
 	REPRISAL: {


### PR DESCRIPTION
Provoke is a 30s CD, not 40s.