### PR TITLE
BRD - PrecastStatus Bug Fix

### DIFF
--- a/src/data/ACTIONS/root/ARC.ts
+++ b/src/data/ACTIONS/root/ARC.ts
@@ -7,7 +7,6 @@ export const ARC = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000358.png',
 		onGcd: true,
 		potency: 180,
-		statusesApplied: ['STRAIGHT_SHOT_READY'],
 	},
 	VENOMOUS_BITE: {
 		id: 100,


### PR DESCRIPTION
Currently there's a bug where almost every bard log will have a synthed Heavy Shot cast at the beginning of the timeline because the status Straight Shot Ready is applied by many actions, but only Heavy Shot has SSR as an applied status in the data files. Adding SSR to all the relevant actions doesn't solve the problem because of the way PrecastStatus looks for corresponding statuses, and anyway there is no current need for SSR being tracked as an applied status, so this bandaid fix seems appropriate for now.

cc @AzariahAeroborn 