### PR TITLE
Add dates for global 5.4 and CN 5.3 patches

### DIFF
--- a/src/data/PATCHES.ts
+++ b/src/data/PATCHES.ts
@@ -107,7 +107,13 @@ const PATCHES = {
 	},
 	'5.3': {
 		date: {
-			[GameEdition.GLOBAL]: 1597140000, // 11/08/20 10:00:00 GMT
+			[GameEdition.GLOBAL]: 1597140000, // 11/08/20 09:00:00 GMT
+			[GameEdition.CHINESE]: 1606809600, // 01/12/20 08:00:00 GMT
+		},
+	},
+	'5.4': {
+		date: {
+			[GameEdition.GLOBAL]: 1607418000, // 08/12/20 09:00:00 GMT
 		},
 	},
 }

--- a/src/data/PATCHES.ts
+++ b/src/data/PATCHES.ts
@@ -107,7 +107,7 @@ const PATCHES = {
 	},
 	'5.3': {
 		date: {
-			[GameEdition.GLOBAL]: 1597140000, // 11/08/20 09:00:00 GMT
+			[GameEdition.GLOBAL]: 1597136400, // 11/08/20 09:00:00 GMT
 			[GameEdition.CHINESE]: 1606809600, // 01/12/20 08:00:00 GMT
 		},
 	},


### PR DESCRIPTION
Changed the time in the comment for 5.3 global too, it was written as BST but labelled GMT. Patch times for global are actually based on JST but that's useless for anyone reading the document to use as an easy reference.

CN 5.3 is this Tuesday, December 1st as per https://ff.web.sdo.com/web8/index.html#/newstab/newscont/323473

Global 5.4 is next Tuesday, December 8th, as per https://eu.finalfantasyxiv.com/shadowbringers/patch_5_4