### PR TITLE
Add patch 5.3 actions layer to the index

### DIFF
--- a/src/data/ACTIONS/layers/index.ts
+++ b/src/data/ACTIONS/layers/index.ts
@@ -3,6 +3,7 @@ import {ActionRoot} from '../root'
 
 import {patch501} from './patch5.01'
 import {patch510} from './patch5.1'
+import {patch530} from './patch5.3'
 
 export const layers: Array<Layer<ActionRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -11,4 +12,5 @@ export const layers: Array<Layer<ActionRoot>> = [
 
 	patch501,
 	patch510,
+	patch530,
 ]


### PR DESCRIPTION
For some reason, patch 5.3 actions layer was never added to the layers index so these changes weren't actually being used. Ay feex.

Looks like 5.2 only had potency changes, so while we have that data, nothing seems to actually use it for the affected jobs and so there's no layer for it.