### PR TITLE
Fix Aspected Benefic's ability id

### DIFF
--- a/src/data/ACTIONS/root/AST.ts
+++ b/src/data/ACTIONS/root/AST.ts
@@ -103,7 +103,7 @@ export const AST = ensureActions({
 		charges: 2,
 	},
 
-	ASPECTED_HELIOS: {
+	ASPECTED_HELIOS: { // Diurnal Variant
 		id: 3601,
 		name: 'Aspected Helios',
 		icon: 'https://xivapi.com/i/003000/003130.png',
@@ -121,8 +121,8 @@ export const AST = ensureActions({
 		mpCost: 1000,
 	},
 
-	ASPECTED_BENEFIC: {
-		id: 835,
+	ASPECTED_BENEFIC: { // Diurnal Variant
+		id: 3595,
 		name: 'Aspected Benefic',
 		icon: 'https://xivapi.com/i/003000/003127.png',
 		onGcd: true,

--- a/src/parser/jobs/ast/index.tsx
+++ b/src/parser/jobs/ast/index.tsx
@@ -40,7 +40,7 @@ export default new Meta({
 		{
 			date: new Date('2020-12-01'),
 			Changes: () => <>
-				Fixed <ActionLink {...ACTIONS.ASPECTED_BENEFIC} /> detection.
+				Fix incorrect action ID and timeline view for Diurnal Sect <ActionLink {...ACTIONS.ASPECTED_BENEFIC} />.
 			</>,
 			contributors: [CONTRIBUTORS.CASUALSUPERMAN],
 		},

--- a/src/parser/jobs/ast/index.tsx
+++ b/src/parser/jobs/ast/index.tsx
@@ -38,6 +38,13 @@ export default new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2020-12-01'),
+			Changes: () => <>
+				Fixed <ActionLink {...ACTIONS.ASPECTED_BENEFIC} /> detection.
+			</>,
+			contributors: [CONTRIBUTORS.CASUALSUPERMAN],
+		},
+		{
 			date: new Date('2020-10-05'),
 			Changes: () => <>
 				Fixed <ActionLink {...ACTIONS.EARTHLY_STAR} /> drift calculation.

--- a/src/parser/jobs/ast/modules/Sect/Sect.tsx
+++ b/src/parser/jobs/ast/modules/Sect/Sect.tsx
@@ -6,7 +6,6 @@ import STATUSES from 'data/STATUSES'
 import {BuffEvent, CastEvent} from 'fflogs'
 import _ from 'lodash'
 import Module, {dependency} from 'parser/core/Module'
-import Combatants from 'parser/core/modules/Combatants'
 import PrecastAction from 'parser/core/modules/PrecastAction'
 import {Statistics} from 'parser/core/modules/Statistics'
 import Suggestions, {SEVERITY, Suggestion} from 'parser/core/modules/Suggestions'
@@ -14,13 +13,6 @@ import React from 'react'
 import SectStatistic from './SectStatistic'
 
 const NO_SECT_ICON = 'https://xivapi.com/i/064000/064017.png'
-
-const ASPECTED_ACTIONS = [
-	ACTIONS.ASPECTED_BENEFIC.id,
-	ACTIONS.ASPECTED_HELIOS.id,
-	ACTIONS.CELESTIAL_INTERSECTION.id,
-	ACTIONS.CELESTIAL_OPPOSITION.id,
-]
 
 const DIURNAL_SECT_STATUSES = [
 	STATUSES.ASPECTED_BENEFIC.id,
@@ -37,24 +29,32 @@ const NOCTURNAL_SECT_STATUSES = [
 	STATUSES.DIURNAL_BALANCE.id,
 ]
 
-const ACTION_STATUS_MAP = {
-	[ACTIONS.ASPECTED_BENEFIC.id]: [
-		STATUSES.ASPECTED_BENEFIC.id,
-		STATUSES.NOCTURNAL_FIELD.id,
-	],
-	[ACTIONS.ASPECTED_HELIOS.id]: [
+const SECT_BUFF_STATUSES = [...NOCTURNAL_SECT_STATUSES, ...DIURNAL_SECT_STATUSES]
+
+const ACTION_STATUS_MAP: Map<number, number[]> = new Map([
+	[ACTIONS.ASPECTED_HELIOS.id, [
 		STATUSES.ASPECTED_HELIOS.id,
+	]],
+	[ACTIONS.ASPECTED_HELIOS_NOCTURNAL.id, [
 		STATUSES.NOCTURNAL_FIELD.id,
-	],
-	[ACTIONS.CELESTIAL_INTERSECTION.id]: [
+	]],
+	[ACTIONS.ASPECTED_BENEFIC.id, [
+		STATUSES.ASPECTED_BENEFIC.id,
+	]],
+	[ACTIONS.ASPECTED_BENEFIC_NOCTURNAL.id, [
+		STATUSES.NOCTURNAL_FIELD.id,
+	]],
+	[ACTIONS.CELESTIAL_INTERSECTION.id, [
 		STATUSES.DIURNAL_INTERSECTION.id,
 		STATUSES.NOCTURNAL_INTERSECTION.id,
-	],
-	[ACTIONS.CELESTIAL_OPPOSITION.id]: [
+	]],
+	[ACTIONS.CELESTIAL_OPPOSITION.id, [
 		STATUSES.DIURNAL_OPPOSITION.id,
 		STATUSES.NOCTURNAL_OPPOSITION.id,
-	],
-}
+	]],
+])
+
+const ASPECTED_ACTIONS: number[] = [...ACTION_STATUS_MAP.keys()]
 
 const SECT_ACTIONS = [
 	ACTIONS.DIURNAL_SECT.id,
@@ -113,12 +113,10 @@ export default class Sect extends Module {
 				aspectedCast = event
 
 			} else if (aspectedCast
-				&& (event.type === 'applybuff' || event.type === 'refreshbuff') && [...NOCTURNAL_SECT_STATUSES, ...DIURNAL_SECT_STATUSES].includes(event.ability.guid)) {
+				&& (event.type === 'applybuff' || event.type === 'refreshbuff') && SECT_BUFF_STATUSES.includes(event.ability.guid)) {
 				// This is an applybuff event of a sect buff that came after an aspected action
 
-				if (this.mapCastToBuff(aspectedCast.ability.guid).includes(event.ability.guid)
-					&& [...DIURNAL_SECT_STATUSES, ...NOCTURNAL_SECT_STATUSES].includes(event.ability.guid)) {
-
+				if (this.mapCastToBuff(aspectedCast.ability.guid).includes(event.ability.guid)) {
 					const SECT_ABILITY = DIURNAL_SECT_STATUSES.includes(event.ability.guid) ? DIURNAL_SECT_BUFF_ABILITY : NOCTURNAL_SECT_BUFF_ABILITY
 
 					// Fab a sect buff event at the start of the fight
@@ -217,10 +215,12 @@ export default class Sect extends Module {
 	}
 
 	// Helpers
-	public mapCastToBuff(actionId: number) {
-		if (ASPECTED_ACTIONS.includes(actionId)) {
-			return ACTION_STATUS_MAP[actionId]
+	public mapCastToBuff(actionId: number) : number[] {
+		const match = ACTION_STATUS_MAP.get(actionId)
+		if (match) {
+			return match
 		}
+		this.debug('Failed to identify cast from buff', actionId)
 		return []
 	}
 


### PR DESCRIPTION
Fixes #1045

The incorrect ID appears to be Diurnal's Aspected Benefic. I created [this minimal log](https://www.fflogs.com/reports/26y8HKtg97WfZzDC) with a few casts in each sect to verify. The first encounter is in Nocturnal, the second is Diurnal.

After updating the diurnal id, the casts appear in the timeline for me in both sects.
I found some mismatched buffs in the sect detection module while tracking this down, so I corrected those as well.