### PR TITLE
Mark NIN and MCH as supported for 5.4

### DIFF
--- a/src/data/ACTIONS/layers/index.ts
+++ b/src/data/ACTIONS/layers/index.ts
@@ -4,6 +4,7 @@ import {ActionRoot} from '../root'
 import {patch501} from './patch5.01'
 import {patch510} from './patch5.1'
 import {patch530} from './patch5.3'
+import {patch540} from './patch5.4'
 
 export const layers: Array<Layer<ActionRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -13,4 +14,5 @@ export const layers: Array<Layer<ActionRoot>> = [
 	patch501,
 	patch510,
 	patch530,
+	patch540,
 ]

--- a/src/data/ACTIONS/layers/patch5.4.ts
+++ b/src/data/ACTIONS/layers/patch5.4.ts
@@ -1,0 +1,16 @@
+import {Layer} from 'data/layer'
+import {ActionRoot} from '../root'
+
+// tslint:disable:no-magic-numbers
+
+export const patch540: Layer<ActionRoot> = {
+	patch: '5.4',
+	data: {
+		// NIN 5.4 potency changes
+		SPINNING_EDGE: {potency: 230},
+		GUST_SLASH: {combo: {
+			from: 2240,
+			potency: 340,
+		}},
+	},
+}

--- a/src/data/ACTIONS/root/ROG.ts
+++ b/src/data/ACTIONS/root/ROG.ts
@@ -10,7 +10,7 @@ export const ROG = ensureActions({
 		name: 'Spinning Edge',
 		icon: 'https://xivapi.com/i/000000/000601.png',
 		onGcd: true,
-		potency: 230,
+		potency: 220,
 		combo: {
 			start: true,
 		},
@@ -24,7 +24,7 @@ export const ROG = ensureActions({
 		potency: 100,
 		combo: {
 			from: 2240,
-			potency: 340,
+			potency: 330,
 		},
 	},
 

--- a/src/data/ACTIONS/root/ROG.ts
+++ b/src/data/ACTIONS/root/ROG.ts
@@ -10,7 +10,7 @@ export const ROG = ensureActions({
 		name: 'Spinning Edge',
 		icon: 'https://xivapi.com/i/000000/000601.png',
 		onGcd: true,
-		potency: 220,
+		potency: 230,
 		combo: {
 			start: true,
 		},
@@ -24,7 +24,7 @@ export const ROG = ensureActions({
 		potency: 100,
 		combo: {
 			from: 2240,
-			potency: 330,
+			potency: 340,
 		},
 	},
 

--- a/src/parser/jobs/mch/index.js
+++ b/src/parser/jobs/mch/index.js
@@ -14,7 +14,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.3',
+		to: '5.4',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -15,7 +15,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.1',
-		to: '5.3',
+		to: '5.4',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Updated the potencies on Spinning Edge/Gust Slash per the patch notes, but neither job has any other changes whatsoever.