### PR TITLE
DRG: Update potencies and mark support for 5.4

### DIFF
--- a/src/data/ACTIONS/layers/patch5.4.ts
+++ b/src/data/ACTIONS/layers/patch5.4.ts
@@ -12,5 +12,8 @@ export const patch540: Layer<ActionRoot> = {
 			from: 2240,
 			potency: 340,
 		}},
+		// DRG 5.4 potency changes
+		FANG_AND_CLAW: {potency: 370},
+		WHEELING_THRUST: {potency: 370},
 	},
 }

--- a/src/parser/jobs/drg/index.js
+++ b/src/parser/jobs/drg/index.js
@@ -13,7 +13,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.3',
+		to: '5.4',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Just potency changes this time around.