### PR TITLE
Remaining invuln config for 5.4 content

### DIFF
--- a/src/data/BOSSES.ts
+++ b/src/data/BOSSES.ts
@@ -47,6 +47,8 @@ const BOSSES = ensureBosses({
 	RUBY_WEAPON_1: {logId: 1051},
 	RUBY_WEAPON_2: {logId: 1052},
 	VARIS_YAE_GALVUS: {logId: 1053},
+	EMERALD_WEAPON_1: {logId: 1056},
+	EMERALD_WEAPON_2: {logId: 1055}, // Yes, they're in the wrong order.
 
 	// Raids (savage and normal share log boss IDs)
 	E1: {logId: 65},
@@ -58,6 +60,10 @@ const BOSSES = ensureBosses({
 	E7: {logId: 71},
 	E8: {logId: 72},
 	E9: {logId: 73},
+	E10: {logId: 74},
+	E11: {logId: 75},
+	E12_1: {logId: 76},
+	E12_2: {logId: 77},
 
 	// Ultimates
 	TEA: {logId: 1050},

--- a/src/parser/AVAILABLE_MODULES.ts
+++ b/src/parser/AVAILABLE_MODULES.ts
@@ -30,10 +30,13 @@ import {exHades} from './bosses/exHades'
 import {exRuby1} from './bosses/exRuby1'
 import {exRuby2} from './bosses/exRuby2'
 import {exVaris} from './bosses/exVaris'
+import {exEmerald1} from './bosses/exEmerald1'
+import {exEmerald2} from './bosses/exEmerald2'
 import {e4} from './bosses/e4'
 import {e7} from './bosses/e7'
 import {e8} from './bosses/e8'
 import {e9} from './bosses/e9'
+import {e121} from './bosses/e12_1'
 import {tea} from './bosses/tea'
 
 interface AvailableModules {
@@ -79,11 +82,14 @@ const AVAILABLE_MODULES: AvailableModules = {
 		[BOSSES.RUBY_WEAPON_1.logId]: exRuby1,
 		[BOSSES.RUBY_WEAPON_2.logId]: exRuby2,
 		[BOSSES.VARIS_YAE_GALVUS.logId]: exVaris,
+		[BOSSES.EMERALD_WEAPON_1.logId]: exEmerald1,
+		[BOSSES.EMERALD_WEAPON_2.logId]: exEmerald2,
 
 		[BOSSES.E4.logId]: e4,
 		[BOSSES.E7.logId]: e7,
 		[BOSSES.E8.logId]: e8,
 		[BOSSES.E9.logId]: e9,
+		[BOSSES.E12_1.logId]: e121,
 
 		[BOSSES.TEA.logId]: tea,
 	},

--- a/src/parser/bosses/e12_1/index.ts
+++ b/src/parser/bosses/e12_1/index.ts
@@ -1,0 +1,5 @@
+import {Meta} from 'parser/core/Meta'
+
+export const e121 = new Meta({
+	modules: () => import('./modules' /* webpackChunkName: "bosses-e121" */),
+})

--- a/src/parser/bosses/e12_1/modules/Invulnerability.ts
+++ b/src/parser/bosses/e12_1/modules/Invulnerability.ts
@@ -1,0 +1,17 @@
+import {
+	Invulnerability as CoreInvulnerability,
+	ActorsConfig,
+} from 'parser/core/modules/Invulnerability'
+
+export class Invulnerability extends CoreInvulnerability {
+	protected actorConfig: ActorsConfig = {
+		// Unnamed? - mechanic source
+		11501: {exclude: true},
+		// Eden's Promise - Primary boss, no TAU (Savage)
+		12441: {start: 'firstTap', end: 'overkill'},
+		// NM sculptures - targetable during adds phase, no TAU
+		12433: {start: 'firstTap', end: 'overkill'}, // Lissom
+		12434: {start: 'firstTap', end: 'overkill'}, // Chiseled
+		12435: {start: 'firstTap', end: 'overkill'}, // Beastly
+	}
+}

--- a/src/parser/bosses/e12_1/modules/index.ts
+++ b/src/parser/bosses/e12_1/modules/index.ts
@@ -1,0 +1,3 @@
+import {Invulnerability} from './Invulnerability'
+
+export default [Invulnerability]

--- a/src/parser/bosses/exEmerald1/index.ts
+++ b/src/parser/bosses/exEmerald1/index.ts
@@ -1,0 +1,5 @@
+import {Meta} from 'parser/core/Meta'
+
+export const exEmerald1 = new Meta({
+	modules: () => import('./modules' /* webpackChunkName: "bosses-exEmerald1" */),
+})

--- a/src/parser/bosses/exEmerald1/modules/Invulnerability.ts
+++ b/src/parser/bosses/exEmerald1/modules/Invulnerability.ts
@@ -5,8 +5,9 @@ import {
 
 export class Invulnerability extends CoreInvulnerability {
 	protected actorConfig: ActorsConfig = {
-		// Cloud of darkness – from start to finish, she's available
-		12374: {start: 'firstTap', end: 'overkill'}, // NM
-		12379: {start: 'firstTap', end: 'overkill'}, // Savage
+		// The Emerald Weapon - Primary boss, no TAU
+		12353: {start: 'firstTap', end: 'overkill'},
+		// Ghost Emerald Weapon actor - presumably mechanic source
+		12659: {exclude: true},
 	}
 }

--- a/src/parser/bosses/exEmerald1/modules/index.ts
+++ b/src/parser/bosses/exEmerald1/modules/index.ts
@@ -1,0 +1,3 @@
+import {Invulnerability} from './Invulnerability'
+
+export default [Invulnerability]

--- a/src/parser/bosses/exEmerald2/index.ts
+++ b/src/parser/bosses/exEmerald2/index.ts
@@ -1,0 +1,5 @@
+import {Meta} from 'parser/core/Meta'
+
+export const exEmerald2 = new Meta({
+	modules: () => import('./modules' /* webpackChunkName: "bosses-exEmerald2" */),
+})

--- a/src/parser/bosses/exEmerald2/modules/Invulnerability.ts
+++ b/src/parser/bosses/exEmerald2/modules/Invulnerability.ts
@@ -5,8 +5,8 @@ import {
 
 export class Invulnerability extends CoreInvulnerability {
 	protected actorConfig: ActorsConfig = {
-		// Cloud of darkness – from start to finish, she's available
-		12374: {start: 'firstTap', end: 'overkill'}, // NM
-		12379: {start: 'firstTap', end: 'overkill'}, // Savage
+		// Ghost Emerald Weapon actors - presumably mechanic source
+		12657: {exclude: true},
+		12660: {exclude: true},
 	}
 }

--- a/src/parser/bosses/exEmerald2/modules/index.ts
+++ b/src/parser/bosses/exEmerald2/modules/index.ts
@@ -1,0 +1,3 @@
+import {Invulnerability} from './Invulnerability'
+
+export default [Invulnerability]

--- a/src/parser/core/modules/Invulnerability.tsx
+++ b/src/parser/core/modules/Invulnerability.tsx
@@ -54,6 +54,9 @@ interface InvulnWindow {
 
 type LegacyLastHit = Record<InvulnType, number>
 
+/** Data stored in cache for ephemeral actors */
+type ActorData = Pick<Actor, 'guid' | 'name'>
+
 export class Invulnerability extends Module {
 	static handle = 'invuln'
 	static debug = false
@@ -68,7 +71,7 @@ export class Invulnerability extends Module {
 
 	private invulns = new Map<InvulnActor, Map<InvulnInstance, InvulnWindow[]>>()
 	private firstTaps = new Set<string>()
-	private guidCache = new Map<Actor['id'], Actor['guid'] | undefined>()
+	private actorCache = new Map<Actor['id'], ActorData | undefined>()
 
 	private get legacyMode() {
 		const implDate = TARGETABLE_EVENT_IMPLEMENTATION_DATE.getTime() / 1000
@@ -250,7 +253,7 @@ export class Invulnerability extends Module {
 		if (event.target?.type === ActorType.UNKNOWN) { return }
 
 		// Try to get a guid - if we can't, bail early
-		const guid = this.getEventTargetGuid(event)
+		const guid = this.getEventTargetActor(event)?.guid
 		if (guid == null) { return }
 
 		// Grab the actor config if there is any. Explicitly excluded actors can bail early.
@@ -283,24 +286,27 @@ export class Invulnerability extends Module {
 		checks.forEach(check => check.call(this, target, config, event))
 	}
 
-	private getEventTargetGuid(event: Event) {
+	private getEventTargetActor(event: Event) {
 		// There's a few places guids are stored in log data - derive the guid for
 		// the target of the event, caching if appropriate
-		let guid = event.target?.guid
-		if (guid != null) { return guid }
+		if (event.target != null) {
+			this.actorCache.set(event.target.id, event.target)
+			return event.target
+		}
 
 		if (event.targetID == null) {
 			return undefined
 		}
 
-		if (this.guidCache.has(event.targetID)) {
-			return this.guidCache.get(event.targetID)
+		if (this.actorCache.has(event.targetID)) {
+			return this.actorCache.get(event.targetID)
 		}
 
-		guid = this.parser.report.enemies.find(enemy => enemy.id === event.targetID)?.guid
-		this.guidCache.set(event.targetID, guid)
+		const actor = this.parser.report.enemies
+			.find(enemy => enemy.id === event.targetID)
+		this.actorCache.set(event.targetID, actor)
 
-		return guid
+		return actor
 	}
 
 	private getEventTargetKey = (event: Event): InvulnTarget =>
@@ -481,7 +487,10 @@ export class Invulnerability extends Module {
 		}))
 
 		this.invulns.forEach((value, actorId) => {
-			const actor = this.parser.report.enemies.find(enemy => enemy.id === actorId)
+			const actor = typeof actorId === 'number'
+				? this.actorCache.get(actorId)
+				: undefined
+
 			const actorRow = parentRow.addRow(new SimpleRow({
 				label: actor != null
 					? `(${actor.guid}) ${actor.name}`


### PR DESCRIPTION
Title.
Also tweaks core implementation so debug mode will print names/guids for ephemeral actors, which was a bit of a hold up in dev-general re: emerald.

Gorgeous
![image](https://user-images.githubusercontent.com/534235/102498369-fe120800-40cd-11eb-8b2f-de5879b8727e.png)
