### PR TITLE
DRG: Fix hard crash on drift error

### DIFF
--- a/src/parser/jobs/drg/modules/Drift.tsx
+++ b/src/parser/jobs/drg/modules/Drift.tsx
@@ -77,7 +77,11 @@ export default class Drift extends Module {
 
 		if (this.downtime.isDowntime(plannedUseTime)) {
 			const downtimeWindow = this.downtime.getDowntimeWindows(plannedUseTime)[0]
-			expectedUseTime = downtimeWindow.end
+
+			// there's a case where getDowntimeWindows will return null even though the planned use time is marked as downtime
+			// unsure the root cause but it looks like this occurs when invulns aren't properly configed for a fight yet
+			// adding a fallback to ensure the parse is still viewable.
+			expectedUseTime = (downtimeWindow) ? downtimeWindow.end : plannedUseTime
 		} else {
 			expectedUseTime = plannedUseTime
 		}

--- a/src/parser/jobs/drg/modules/Drift.tsx
+++ b/src/parser/jobs/drg/modules/Drift.tsx
@@ -79,7 +79,6 @@ export default class Drift extends Module {
 			const downtimeWindow = this.downtime.getDowntimeWindows(plannedUseTime)[0]
 
 			// there's a case where getDowntimeWindows will return null even though the planned use time is marked as downtime
-			// unsure the root cause but it looks like this occurs when invulns aren't properly configed for a fight yet
 			// adding a fallback to ensure the parse is still viewable.
 			expectedUseTime = (downtimeWindow) ? downtimeWindow.end : plannedUseTime
 		} else {

--- a/src/parser/jobs/drg/modules/Drift.tsx
+++ b/src/parser/jobs/drg/modules/Drift.tsx
@@ -80,7 +80,7 @@ export default class Drift extends Module {
 
 			// there's a case where getDowntimeWindows will return null even though the planned use time is marked as downtime
 			// adding a fallback to ensure the parse is still viewable.
-			expectedUseTime = (downtimeWindow) ? downtimeWindow.end : plannedUseTime
+			expectedUseTime = downtimeWindow?.end ?? plannedUseTime
 		} else {
 			expectedUseTime = plannedUseTime
 		}


### PR DESCRIPTION
Fixes hard crash on instances where `downtime.isDowntime()` returns true, but `downtime.getDowntimeWindows()` returns nothing. Doesn't fix the root cause, but now checks for the existence of a window and falls back to assuming there is no downtime if the window isn't defined.