### PR TITLE
Break data for scholar because events from fflogs is coming in reverse

### DIFF
--- a/src/data/ACTIONS/root/SCH.ts
+++ b/src/data/ACTIONS/root/SCH.ts
@@ -132,7 +132,6 @@ export const SCH = ensureActions({
 		name: 'Dissipation',
 		icon: 'https://xivapi.com/i/002000/002810.png',
 		cooldown: 180,
-		statusesApplied: ['DISSIPATION'],
 	},
 
 	EXCOGITATION: {


### PR DESCRIPTION
Pretty much every event that uses dissipation within the first 240s of the fight conjures a precast synthesis to 'helpfully' pair up the event. This is because fflogs is sending the status before the associated cast event:

<img width="451" alt="Screen Shot 2020-12-17 at 4 21 52 PM" src="https://user-images.githubusercontent.com/53187143/102550761-fcbbed80-4083-11eb-8f57-cbab46a62cd0.png">

I can't think of anything in SCH analysis that gets broken by this change, only what it *fixes* in this case. Yes, this is gross.