### PR TITLE
DRG: actually fix drift error

### DIFF
--- a/src/parser/jobs/drg/modules/Drift.tsx
+++ b/src/parser/jobs/drg/modules/Drift.tsx
@@ -76,10 +76,9 @@ export default class Drift extends Module {
 		let expectedUseTime = 0
 
 		if (this.downtime.isDowntime(plannedUseTime)) {
-			const downtimeWindow = this.downtime.getDowntimeWindows(plannedUseTime)[0]
+			const downtimeWindow = this.downtime.getDowntimeWindows(plannedUseTime, plannedUseTime)[0]
 
-			// there's a case where getDowntimeWindows will return null even though the planned use time is marked as downtime
-			// adding a fallback to ensure the parse is still viewable.
+			// in theory the second case shouldn't trigger, but just in case since we've had this break before...
 			expectedUseTime = downtimeWindow?.end ?? plannedUseTime
 		} else {
 			expectedUseTime = plannedUseTime


### PR DESCRIPTION
Turns out we should just use `getDowntimeWindows` correctly and then we won't have errors. Leaving in the safety check just in case. Thanks to Kelos for pointing this out. 