### PR TITLE
[SAM] Sam Display Order

### DIFF
--- a/src/parser/jobs/sam/modules/DISPLAY_ORDER.js
+++ b/src/parser/jobs/sam/modules/DISPLAY_ORDER.js
@@ -1,0 +1,9 @@
+export default {
+	HIGANBANA: 1,
+	MEIKYO: 2,
+	SEN: 3,
+	//KAITEN: 4, Preallocating the slot for a future PR
+	KENKI: 5,
+	SHOHA: 6,
+	TINCTURES: 7,
+}

--- a/src/parser/jobs/sam/modules/Higanbana.js
+++ b/src/parser/jobs/sam/modules/Higanbana.js
@@ -12,6 +12,8 @@ import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
 import styles from './Higanbana.module.css'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 const STATUS_DURATION = {
 	[STATUSES.HIGANBANA.id]: 60000,
 }
@@ -22,6 +24,7 @@ const CLIPPING_SEVERITY = {
 	60000: SEVERITY.MAJOR,
 }
 export default class Higanbana extends Module {
+	static displayOrder = DISPLAY_ORDER.HIGANBANA
 	static handle = 'higanbana'
 	static title = t('sam.higanbana.title')`Higanbana`
 	static dependencies = [

--- a/src/parser/jobs/sam/modules/Kenki.js
+++ b/src/parser/jobs/sam/modules/Kenki.js
@@ -14,6 +14,8 @@ import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 import kenkiIcon from './kenki.png'
 import styles from './Kenki.module.css'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 const MAX_KENKI = 100
 
 const KENKI_ACTIONS = {
@@ -52,6 +54,7 @@ const MEDITATE_TICK_FREQUENCY = 3000
 const MAX_MEDITATE_TICKS = 5
 
 export default class Kenki extends Module {
+	static displayOrder = DISPLAY_ORDER.KENKI
 	static handle = 'kenki'
 	static title = t('sam.kenki.title')`Kenki`
 	static dependencies = [

--- a/src/parser/jobs/sam/modules/Meikyo.tsx
+++ b/src/parser/jobs/sam/modules/Meikyo.tsx
@@ -7,6 +7,8 @@ import STATUSES from 'data/STATUSES'
 import {BuffWindowModule, BuffWindowState} from 'parser/core/modules/BuffWindow'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 // Set for stuff to ignore TODO: revisit this and get it to show iaijutsu properly
 // const IGNORE_THIS = new Set([ACTIONS.MIDARE_SETSUGEKKA.id, ACTIONS.TENKA_GOKEN.id, ACTIONS.HIGANBANA.id, ACTIONS.KAESHI_SETSUGEKKA.id, ACTIONS.KAESHI_GOKEN.id, ACTIONS.KAESHI_HIGANBANA])
 const ONLY_SHOW = new Set([ACTIONS.HAKAZE.id, ACTIONS.JINPU.id, ACTIONS.ENPI.id, ACTIONS.SHIFU.id, ACTIONS.FUGA.id, ACTIONS.GEKKO.id, ACTIONS.MANGETSU.id, ACTIONS.KASHA.id, ACTIONS.OKA.id, ACTIONS.YUKIKAZE.id])
@@ -17,6 +19,7 @@ const SEN_GCDS = 3
 const SAM_BASE_GCD_SPEED_BUFFED = 2180
 
 export default class MeikyoShisui extends BuffWindowModule {
+	static displayOrder = DISPLAY_ORDER.MEIKYO
 	static handle = 'Meikyo'
 	static title = t('sam.ms.title')`Meikyo Shisui Windows`
 

--- a/src/parser/jobs/sam/modules/Sen.tsx
+++ b/src/parser/jobs/sam/modules/Sen.tsx
@@ -17,6 +17,8 @@ import {Icon, Message} from 'semantic-ui-react'
 
 import Kenki from './Kenki'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 // defining a const message to assign later via markdown
 
 const samWarningMessage = t('sam.sen.rotation-table.disclaimer')` This module labels a "Standard Sen Window" to be a window that with no Sen overwrites that ends on an Iaijutsu. Please consult The Balance Discord and this [Infograph](https://i.imgur.com/L0Y7d6C.png) for more details on looping Samurai gameplay.`
@@ -131,6 +133,7 @@ class SenState {
 }
 
 export default class Sen extends Module {
+	static displayOrder = DISPLAY_ORDER.SEN
 	static handle = 'sen'
 	static title = t('sam.sen.title')`Non-Standard Sen Windows`
 

--- a/src/parser/jobs/sam/modules/Shoha.tsx
+++ b/src/parser/jobs/sam/modules/Shoha.tsx
@@ -15,6 +15,8 @@ import Module, {dependency, DISPLAY_MODE} from 'parser/core/Module'
 import Checklist, {Requirement, Rule} from 'parser/core/modules/Checklist'
 import {Data} from 'parser/core/modules/Data'
 
+import DISPLAY_ORDER from './DISPLAY_ORDER'
+
 const GENERATORS = {
 	[ACTIONS.HIGANBANA.id]: 1,
 	[ACTIONS.KAESHI_HIGANBANA.id]: 1,
@@ -38,6 +40,7 @@ interface StackState {
 }
 
 export default class Shoha extends Module {
+	static displayOrder = DISPLAY_ORDER.SHOHA
 	static handle = 'shoha'
 	static title = t('sam.shoha.title')`Meditation Timeline`
 	static displayMode = DISPLAY_MODE.FULL


### PR DESCRIPTION
What is this, 2018? SAM has Display Order now.

Current Logic for display order in my head is:

1) Checklists
2) Suggestions
3) Stats that can be changed/ could have obvious errors (Dots, Buff Windows, etc.)
4) Stats like gauge amount and stacks of Shoha, This in my head is the normal "End of page" for SAM focused critique/Information
5) Things such as interrupted Casts that were stated as a suggestion before that are now expanded in detail.

I'm not sure if I should flip the last 2 slots though