### PR TITLE
SMN - Move EF statusApplied from enkindle to FBT

### DIFF
--- a/src/data/ACTIONS/root/SMN.ts
+++ b/src/data/ACTIONS/root/SMN.ts
@@ -135,6 +135,7 @@ export const SMN = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002734.png',
 		cooldown: 55,
 		cooldownGroup: SMN_COOLDOWN_GROUP.TRANCE,
+		statusesApplied: ['EVERLASTING_FLIGHT'],
 	},
 
 	FOUNTAIN_OF_FIRE: {
@@ -156,7 +157,6 @@ export const SMN = ensureActions({
 		name: 'Enkindle Phoenix',
 		icon: 'https://xivapi.com/i/002000/002737.png',
 		cooldown: 10,
-		statusesApplied: ['EVERLASTING_FLIGHT'],
 	},
 
 	// Egi Assault, Egi Assault II, and Enkindle have unique ids depending on the summoned pet.


### PR DESCRIPTION
I believe this is just a longstanding typo from #636 since I can't find any justification for attaching Everlasting Flight to Enkindle Phoenix. Paging @ackwell just in case there's a good reason for having it this way that I missed.

Fixes a bug where PrecastStatus synths a cast of Enkindle Phoenix at the start of the timeline of most SMN logs. 