### PR TITLE
DNC - flag double weaves after a finish as weaving issues

### DIFF
--- a/src/parser/jobs/dnc/DISPLAY_ORDER.ts
+++ b/src/parser/jobs/dnc/DISPLAY_ORDER.ts
@@ -3,4 +3,5 @@ export default {
 	TECHNICALITIES: 2,
 	ESPRIT: 3,
 	FEATHERS: 4,
+	WEAVING: 5,
 }

--- a/src/parser/jobs/dnc/modules/Weaving.ts
+++ b/src/parser/jobs/dnc/modules/Weaving.ts
@@ -1,0 +1,28 @@
+import ACTIONS from 'data/ACTIONS'
+import {CastEvent} from 'fflogs'
+import CoreWeaving, {WeaveInfo} from 'parser/core/modules/Weaving'
+import DISPLAY_ORDER from '../DISPLAY_ORDER'
+
+const FINISH_IDS = [
+	ACTIONS.SINGLE_STANDARD_FINISH.id,
+	ACTIONS.DOUBLE_STANDARD_FINISH.id,
+	ACTIONS.SINGLE_TECHNICAL_FINISH.id,
+	ACTIONS.DOUBLE_TECHNICAL_FINISH.id,
+	ACTIONS.TRIPLE_TECHNICAL_FINISH.id,
+	ACTIONS.QUADRUPLE_TECHNICAL_FINISH.id,
+]
+
+export default class Weaving extends CoreWeaving {
+	static displayOrder = DISPLAY_ORDER.WEAVING
+
+	isBadWeave(weave: WeaveInfo) {
+		const leadingGcd = weave.leadingGcdEvent as CastEvent
+
+		if (leadingGcd && leadingGcd.ability && FINISH_IDS.includes(leadingGcd.ability.guid)) {
+			// Only permit single weaves after a dance finish
+			return weave.weaves.length > 1
+		}
+
+		return super.isBadWeave(weave)
+	}
+}

--- a/src/parser/jobs/dnc/modules/index.ts
+++ b/src/parser/jobs/dnc/modules/index.ts
@@ -5,6 +5,7 @@ import FeatherGauge from './FeatherGauge'
 import OGCDDowntime from './OGCDDowntime'
 import Procs from './Procs'
 import Technicalities from './Technicalities'
+import Weaving from './Weaving'
 
 export default [
 	Combos,
@@ -14,4 +15,5 @@ export default [
 	FeatherGauge,
 	OGCDDowntime,
 	Technicalities,
+	Weaving,
 ]


### PR DESCRIPTION
Since the GCD of dance finishes is 1.5s, double weaving after a dance will certainly cause clipping and is thus discouraged.

![image](https://user-images.githubusercontent.com/65056303/104179296-981d5580-53d9-11eb-84fe-613c66dea008.png)
