### PR TITLE
MCH - flag double weaves after a hypercharge GCD as weaving issues

### DIFF
--- a/src/parser/jobs/dnc/modules/Weaving.ts
+++ b/src/parser/jobs/dnc/modules/Weaving.ts
@@ -1,24 +1,30 @@
-import ACTIONS from 'data/ACTIONS'
+import {ActionRoot} from 'data/ACTIONS/root'
 import {CastEvent} from 'fflogs'
 import CoreWeaving, {WeaveInfo} from 'parser/core/modules/Weaving'
 import DISPLAY_ORDER from '../DISPLAY_ORDER'
 
-const FINISH_IDS = [
-	ACTIONS.SINGLE_STANDARD_FINISH.id,
-	ACTIONS.DOUBLE_STANDARD_FINISH.id,
-	ACTIONS.SINGLE_TECHNICAL_FINISH.id,
-	ACTIONS.DOUBLE_TECHNICAL_FINISH.id,
-	ACTIONS.TRIPLE_TECHNICAL_FINISH.id,
-	ACTIONS.QUADRUPLE_TECHNICAL_FINISH.id,
+const FINISH_IDS: Array<keyof ActionRoot> = [
+	'SINGLE_STANDARD_FINISH',
+	'DOUBLE_STANDARD_FINISH',
+	'SINGLE_TECHNICAL_FINISH',
+	'DOUBLE_TECHNICAL_FINISH',
+	'TRIPLE_TECHNICAL_FINISH',
+	'QUADRUPLE_TECHNICAL_FINISH',
 ]
 
 export default class Weaving extends CoreWeaving {
 	static displayOrder = DISPLAY_ORDER.WEAVING
+	private FINISH_IDS: number[] = []
+
+	protected init() {
+		super.init()
+		this.FINISH_IDS = FINISH_IDS.map(actionKey => this.data.actions[actionKey].id)
+	}
 
 	isBadWeave(weave: WeaveInfo) {
 		const leadingGcd = weave.leadingGcdEvent as CastEvent
 
-		if (leadingGcd && leadingGcd.ability && FINISH_IDS.includes(leadingGcd.ability.guid)) {
+		if (leadingGcd && leadingGcd.ability && this.FINISH_IDS.includes(leadingGcd.ability.guid)) {
 			// Only permit single weaves after a dance finish
 			return weave.weaves.length > 1
 		}

--- a/src/parser/jobs/mch/modules/Weaving.ts
+++ b/src/parser/jobs/mch/modules/Weaving.ts
@@ -1,17 +1,24 @@
-import ACTIONS from 'data/ACTIONS'
+import {ActionRoot} from 'data/ACTIONS/root'
 import {CastEvent} from 'fflogs'
 import CoreWeaving, {WeaveInfo} from 'parser/core/modules/Weaving'
 
-const HYPERCHARGE_ACTION_IDS = [
-	ACTIONS.AUTO_CROSSBOW.id,
-	ACTIONS.HEAT_BLAST.id,
+const HYPERCHARGE_ACTION_IDS: Array<keyof ActionRoot> = [
+	'AUTO_CROSSBOW',
+	'HEAT_BLAST',
 ]
 
 export default class Weaving extends CoreWeaving {
+	private HYPERCHARGE_ACTION_IDS: number[] = []
+
+	protected init() {
+		super.init()
+		this.HYPERCHARGE_ACTION_IDS = HYPERCHARGE_ACTION_IDS.map(actionKey => this.data.actions[actionKey].id)
+	}
+
 	isBadWeave(weave: WeaveInfo) {
 		const leadingGcd = weave.leadingGcdEvent as CastEvent
 
-		if (leadingGcd && leadingGcd.ability && HYPERCHARGE_ACTION_IDS.includes(leadingGcd.ability.guid)) {
+		if (leadingGcd && leadingGcd.ability && this.HYPERCHARGE_ACTION_IDS.includes(leadingGcd.ability.guid)) {
 			// Only permit single weaves after heat blast / ACB
 			return weave.weaves.length > 1
 		}

--- a/src/parser/jobs/mch/modules/Weaving.ts
+++ b/src/parser/jobs/mch/modules/Weaving.ts
@@ -1,0 +1,21 @@
+import ACTIONS from 'data/ACTIONS'
+import {CastEvent} from 'fflogs'
+import CoreWeaving, {WeaveInfo} from 'parser/core/modules/Weaving'
+
+const HYPERCHARGE_ACTION_IDS = [
+	ACTIONS.AUTO_CROSSBOW.id,
+	ACTIONS.HEAT_BLAST.id,
+]
+
+export default class Weaving extends CoreWeaving {
+	isBadWeave(weave: WeaveInfo) {
+		const leadingGcd = weave.leadingGcdEvent as CastEvent
+
+		if (leadingGcd && leadingGcd.ability && HYPERCHARGE_ACTION_IDS.includes(leadingGcd.ability.guid)) {
+			// Only permit single weaves after heat blast / ACB
+			return weave.weaves.length > 1
+		}
+
+		return super.isBadWeave(weave)
+	}
+}

--- a/src/parser/jobs/mch/modules/index.js
+++ b/src/parser/jobs/mch/modules/index.js
@@ -7,6 +7,7 @@ import Heat from './Heat'
 import MultiHitSkills from './MultiHitSkills'
 import Reassemble from './Reassemble'
 import Tincture from './Tincture'
+import Weaving from './Weaving'
 import Wildfire from './Wildfire'
 import YassQueen from './YassQueen'
 
@@ -20,6 +21,7 @@ export default [
 	MultiHitSkills,
 	Reassemble,
 	Tincture,
+	Weaving,
 	Wildfire,
 	YassQueen,
 ]


### PR DESCRIPTION
Sequel to #1086, these GCDs have a fixed 1.5s recast and we really really don't want to double weave after them. 