### PR TITLE
Add filter builder helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "postcss-modules-values-replace": "^3.1.0",
     "raw-loader": "^4.0.2",
     "style-loader": "^2.0.0",
+    "ts-toolbelt": "^8.0.7",
     "typescript": "~4.1",
     "url-loader": "^4.1.1",
     "webpack": "^5.11.1",

--- a/src/data/ACTIONS/index.ts
+++ b/src/data/ACTIONS/index.ts
@@ -6,6 +6,8 @@ import {Action} from './type'
 const DEFAULT_GCD_CASTTIME = 0
 const DEFAULT_GCD_COOLDOWN = 2.5
 
+export type ActionKey = keyof ActionRoot
+
 /**
  * Adds default (re)cast times to GCD actions.
  * Note that this _only_ operates on the root data set. Actions that are changed to GCD in a layer

--- a/src/data/STATUSES/index.ts
+++ b/src/data/STATUSES/index.ts
@@ -5,6 +5,8 @@ import {Status} from './type'
 
 export const STATUS_ID_OFFSET = 1000000
 
+export type StatusKey = keyof StatusRoot
+
 /**
  * Presumably because WoW statuses and spells share the same ID space, FFLogs adds 1m to every status ID.
  * I'm not gonna get everyone to do that in here, so just automating it.

--- a/src/parser/core/__tests__/filter.ts
+++ b/src/parser/core/__tests__/filter.ts
@@ -1,4 +1,6 @@
-import {filter} from '../filter'
+import {filter, oneOf} from '../filter'
+
+/* eslint-disable @typescript-eslint/no-magic-numbers */
 
 type TestShape = typeof testShape
 const testShape = {
@@ -43,5 +45,14 @@ describe('filter', () => {
 		expect(called).toBeFalse()
 		expect(testFilter(testShape)).toBeTrue()
 		expect(called).toBeTrue()
+	})
+})
+
+describe('matchers', () => {
+	test('oneOf', () => {
+		const matcher = oneOf(1, 2)
+		expect(matcher(1)).toBeTrue()
+		expect(matcher(2)).toBeTrue()
+		expect(matcher(3)).toBeFalse()
 	})
 })

--- a/src/parser/core/__tests__/filter.ts
+++ b/src/parser/core/__tests__/filter.ts
@@ -1,0 +1,47 @@
+import {filter} from '../filter'
+
+type TestShape = typeof testShape
+const testShape = {
+	example: 'value',
+	second: 1,
+}
+
+describe('filter', () => {
+	it('accepts matching shapes', () => {
+		const testFilter = filter<TestShape>()
+			.example('value')
+
+		expect(testFilter(testShape)).toBeTrue()
+		expect(testFilter({...testShape, second: 42})).toBeTrue()
+	})
+
+	it('rejects non-matching shapes', () => {
+		const testFilter = filter<TestShape>()
+			.example('will not match')
+
+		expect(testFilter(testShape)).toBeFalse()
+		// @ts-expect-error Only possible in JS context
+		expect(testFilter({})).toBeFalse()
+	})
+
+	it('accepts any shape when empty', () => {
+		const testFilter = filter<TestShape>()
+
+		expect(testFilter(testShape)).toBeTrue()
+		// @ts-expect-error Only possible in JS context
+		expect(testFilter({})).toBeTrue()
+	})
+
+	it('delegates to provided matchers', () => {
+		let called = false
+		const testFilter = filter<TestShape>()
+			.example((input): input is 'value' => {
+				called = true
+				return input === 'value'
+			})
+
+		expect(called).toBeFalse()
+		expect(testFilter(testShape)).toBeTrue()
+		expect(called).toBeTrue()
+	})
+})

--- a/src/parser/core/filter.ts
+++ b/src/parser/core/filter.ts
@@ -70,26 +70,10 @@ type HasKey<Union, Key extends DistributedKeyof<Union>> =
 			: never
 		: never
 
-// For union BaseValues, select members which Value extends
-type SelectMatchingBases<BaseValues, Value> =
-	BaseValues extends unknown
-		? Value extends BaseValues
-			? BaseValues
-			: never
-		: never
-
 // Resolve Value to the loosest type matching the type of each Shape at Key
-// The actual logic of this resolution is primarily encapsulated in SelectMatchingBases,
-// This is effectively a wrapper to handle the special case of boolean widening
 type ResolveValue<Value, Shape, Key extends keyof Shape> =
-	Shape extends unknown ?
-		// If boolean extends the target, then the target contains at least a full
-		// boolean union. If it does, and Value is at least partially boolean, widen
-		// to the full type.
-		boolean extends Shape[Key] ? Value extends boolean ? boolean
-		// Otherwise, fall back to the non-special cased check
-		: SelectMatchingBases<Shape[Key], Value>
-		: SelectMatchingBases<Shape[Key], Value>
+	Shape extends unknown
+	? Value extends Shape[Key] ? Shape[Key] : never
 	: never
 
 // Matchers are predicate functions

--- a/src/parser/core/filter.ts
+++ b/src/parser/core/filter.ts
@@ -1,6 +1,10 @@
 import _ from 'lodash'
 import * as TB from 'ts-toolbelt'
 
+// -----
+// #region Core filter logic
+// ----
+
 const proxyInner = (() => { /* unused */ }) as object
 
 const customiser: _.isMatchWithCustomizer = (objValue, filterValue) => {
@@ -29,6 +33,19 @@ const filterInternal = <Base, Current extends Partial<Base>>(current: Current) =
 // This is just a pass-through to fitlerInternal for type wrangling purposes.
 export const filter = <Base>() => filterInternal<Base, {}>({})
 
+// -----
+// #endregion
+// #region Matchers
+// -----
+
+// Extending primitive so TS narrows the type as far as it can
+export const oneOf = <T extends TB.Misc.Primitive>(...values: T[]): Matcher<T> =>
+	(objValue): objValue is T => values.includes(objValue)
+
+// -----
+// #endregion
+// #region Filter types
+// -----
 /*
 -------------------------------- W A R N I N G --------------------------------
 While I've tried to document it as best I can, the "code" below is some pretty
@@ -114,3 +131,7 @@ export type Filter<Base, Current extends Partial<Base> = {}> =
 	}
 	// Call signature for the filter
 	& {(value: Base): value is TB.Any.Compute<TB.Union.Select<Required<Base>, Current>>}
+
+// -----
+// #endregion
+// -----

--- a/src/parser/core/filter.ts
+++ b/src/parser/core/filter.ts
@@ -1,0 +1,104 @@
+import _ from 'lodash'
+import * as TB from 'ts-toolbelt'
+
+const proxyInner = (() => { /* unused */ }) as object
+
+// Actual filter logic
+const filterInternal = <Base, Current extends Partial<Base>>(current: Current) =>
+	new Proxy(proxyInner, {
+		// Property access generates a new filter with a narrowed Current, i.e.
+		// filter<Base, {}>.key(value) results in current={[key]:value}
+		get: (target, key) =>
+			(value: unknown) =>
+				filterInternal({...current, [key]: value}),
+
+		// Calling the filter directly execute the filter on the value passed in
+		// the first argument. The exposed return type is a predicate.
+		apply: (target, thisArg, [toCheck]) => _.isMatch(toCheck, current),
+	}) as Filter<Base, Current>
+
+/** Create a filter builder for the shape of Base. */
+// This is just a pass-through to fitlerInternal for type wrangling purposes.
+export const filter = <Base>() => filterInternal<Base, {}>({})
+
+/*
+-------------------------------- W A R N I N G --------------------------------
+While I've tried to document it as best I can, the "code" below is some pretty
+hefty typescript generic shenanigans that power and strongly-type the proxy
+magic above. If you just want to use the filter as a consumer, I'd recommend
+not reading any further.
+
+That said, if you're interested in how it works, have a read! Let me know if
+you've got any questions or anything, I spent quite a bit on time on this, and
+I'd be more than happy to explain how it works!
+-------------------------------------------------------------------------------
+*/
+
+// For the given Union, resolve to union of keys of all members
+type DistributedKeyof<Union> = Union extends unknown ? keyof Union : never
+
+// For the given Union of Objects, select members that contain key Key with any value
+type HasKey<Union, Key extends DistributedKeyof<Union>> =
+	Union extends unknown
+		? Required<Union> extends {[_ in Key]: unknown}
+			? Union
+			: never
+		: never
+
+// For union BaseValues, select members which Value extends
+type SelectMatchingBases<BaseValues, Value> =
+	BaseValues extends unknown
+		? Value extends BaseValues
+			? BaseValues
+			: never
+		: never
+
+// Resolve Value to the loosest type matching the type of each Shape at Key
+// The actual logic of this resolution is primarily encapsulated in SelectMatchingBases,
+// This is effectively a wrapper to handle the special case of boolean widening
+type ResolveValue<Value, Shape, Key extends keyof Shape> =
+	Shape extends unknown ?
+		// If boolean extends the target, then the target contains at least a full
+		// boolean union. If it does, and Value is at least partially boolean, widen
+		// to the full type.
+		boolean extends Shape[Key] ? Value extends boolean ? boolean
+		// Otherwise, fall back to the non-special cased check
+		: SelectMatchingBases<Shape[Key], Value>
+		: SelectMatchingBases<Shape[Key], Value>
+	: never
+
+// Build a filter function for Key in Base, given constraints in Current
+type FilterFunction<
+	Base,
+	Current extends Partial<Base>,
+	Key extends DistributedKeyof<Base>
+> = (
+	// Resolve WithKey to members of Base constrained by Current that contain Key
+	// Constrain parameter to types permitted on the above via Value.
+	// Return a new filter, passing down base and extending current with the resolved Value.
+	<
+		WithKey extends HasKey<TB.Union.Select<Required<Base>, Current>, Key>,
+		Value extends WithKey[Key]
+	>(
+		_value: Value
+	) => (
+		Filter<Base, TB.Any.Compute<
+			& Current
+			& {[_ in Key]: ResolveValue<Value, WithKey, Key>}
+		>>
+	)
+)
+
+// Build a filter object for Base, given constraints in Current
+export type Filter<Base, Current extends Partial<Base> = {}> =
+	// Chaining builder methods
+	& {
+		[Key in Exclude<
+			DistributedKeyof<TB.Union.Select<Required<Base>, Current>>,
+			keyof Current
+		>]:
+		// @ts-expect-error TS is failing to infer that Select is creating a subset
+		FilterFunction<Base, Current, Key>
+	}
+	// Call signature for the filter
+	& {(value: Base): value is TB.Any.Compute<TB.Union.Select<Required<Base>, Current>>}

--- a/src/parser/core/modules/Data.ts
+++ b/src/parser/core/modules/Data.ts
@@ -1,8 +1,19 @@
 import {getDataBy} from 'data'
-import {Action, layers as actionLayers, root as actionRoot} from 'data/ACTIONS'
+import {
+	Action,
+	ActionKey,
+	layers as actionLayers,
+	root as actionRoot,
+} from 'data/ACTIONS'
 import {applyLayer, Layer} from 'data/layer'
-import {layers as statusLayers, root as statusRoot, Status} from 'data/STATUSES'
+import {
+	layers as statusLayers,
+	root as statusRoot,
+	Status,
+	StatusKey,
+} from 'data/STATUSES'
 import {Analyser} from 'parser/core/Analyser'
+import {oneOf} from 'parser/core/filter'
 
 export class Data extends Analyser {
 	static handle = 'data'
@@ -23,6 +34,14 @@ export class Data extends Analyser {
 
 	getStatus(id: Status['id']) {
 		return getDataBy(this.statuses, 'id', id)
+	}
+
+	matchActionId(...keys: ActionKey[]) {
+		return oneOf(...keys.map(key => this.actions[key].id))
+	}
+
+	matchStatusId(...keys: StatusKey[]) {
+		return oneOf(...keys.map(key => this.statuses[key].id))
 	}
 
 	private getAppliedData<R>(root: R, layers: Array<Layer<R>>): R {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9773,6 +9773,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+ts-toolbelt@^8.0.7:
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-8.0.7.tgz#4dad2928831a811ee17dbdab6eb1919fc0a295bf"
+  integrity sha512-KICHyKxc5Nu34kyoODrEe2+zvuQQaubTJz7pnC5RQ19TH/Jged1xv+h8LBrouaSD310m75oAljYs59LNHkLDkQ==
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"


### PR DESCRIPTION
Adds a the primary filter builder, following a fluent-esque api. Also adds the `oneOf` helper (for matching against one of a number of options), and extensions of `oneOf` for action/status keys in `core/Data`.