### PR TITLE
MCH - Fix Wildfire status in timeline

### DIFF
--- a/src/data/ACTIONS/root/MCH.ts
+++ b/src/data/ACTIONS/root/MCH.ts
@@ -159,7 +159,7 @@ export const MCH = ensureActions({
 		icon: 'https://xivapi.com/i/003000/003018.png',
 		onGcd: false,
 		cooldown: 120,
-		statusesApplied: ['WILDFIRE'],
+		statusesApplied: ['WILDFIRE_SELF'],
 	},
 
 	DETONATOR: {

--- a/src/data/STATUSES/root/MCH.ts
+++ b/src/data/STATUSES/root/MCH.ts
@@ -15,6 +15,13 @@ export const MCH = ensureStatuses({
 		duration: 10,
 	},
 
+	WILDFIRE_SELF: {
+		id: 1946,
+		name: 'Wildfire',
+		icon: 'https://xivapi.com/i/013000/013019.png',
+		duration: 10,
+	},
+
 	FLAMETHROWER: {
 		id: 1205,
 		name: 'Flamethrower',


### PR DESCRIPTION
Currently the detrimental (DoT) wildfire status is listed as the corresponding action's applied status. This PR replaces it with the beneficial status.

Before:
![image](https://user-images.githubusercontent.com/65056303/104851261-04102a00-58c2-11eb-9ea7-b7774e3df4a2.png)

After:
![image](https://user-images.githubusercontent.com/65056303/104851269-12f6dc80-58c2-11eb-96aa-f5b38bc55107.png)

