### PR TITLE
fix(pld.ts): total eclipse now starts a combo for prominence

### DIFF
--- a/src/data/ACTIONS/root/PLD.ts
+++ b/src/data/ACTIONS/root/PLD.ts
@@ -58,8 +58,10 @@ export const PLD = ensureActions({
 		name: 'Total Eclipse',
 		icon: 'https://xivapi.com/i/002000/002511.png',
 		onGcd: true,
-		breaksCombo: true,
 		potency: 110,
+		combo: {
+			start: true,
+		},
 	},
 	PROMINENCE: {
 		id: 16457,


### PR DESCRIPTION
Total Eclipse wasn't starting the combo correctly, making all usages of TE and Prominence result in an `Uncomboed` Prominence within the analysis