### PR TITLE
BuffWindow - handle simple statuses as tracked actions

### DIFF
--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -46,8 +46,12 @@ export class BuffWindowState {
 
 	getTrackedActionCount(action: BuffWindowTrackedAction): number {
 		if (action.status) {
+			const gcdTimestamps = this.rotation
+				.filter(e => this.data.getAction(e.ability.guid)?.onGcd)
+				.map(e => e.timestamp)
+
 			return this.expiredStatuses
-				.filter(e => e.ability.guid === action.status?.id)
+				.filter(e => e.ability.guid === action.status?.id && gcdTimestamps.includes(e.timestamp))
 				.length
 		}
 
@@ -81,6 +85,10 @@ interface BuffWindowTrackedActions {
 
 export interface BuffWindowTrackedAction {
 	action: Action
+	/**
+	 * Implementing modules can optionally specify a Status if the trackedAction is a weaponskill modifier
+	 * (e.g. Barrage, Life Surge, Reassemble)
+	 */
 	status?: Status
 	expectedPerWindow: number
 }

--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -102,15 +102,15 @@ export abstract class BuffWindowModule extends Module {
 	 */
 	protected requiredGCDs?: BuffWindowRequiredGCDs
 	/**
-	 * Optionally, you can also specify additional cooldowns to track usage of, indicating the number of expected usages per window.
-	 * - trackedCooldowns will require a MINIMUM of trackedCooldown.expectedPerWindow uses of the specified action in each window
+	 * Optionally, you can also specify additional actions to track usage of, indicating the number of expected usages per window.
+	 * - trackedActions will require a MINIMUM of trackedAction.expectedPerWindow uses of the specified action in each window
 	 *     and will provide data in the RotationTable about the number used as well as a suggestion based on missed uses
 	 */
 	protected trackedActions?: BuffWindowTrackedActions
 	/**
-	 * Optionally, you can also specify additional cooldowns to track usage of, indicating the number of expected usages per window.
-	 *  - trackedBadCooldowns will require NO MORE THAN trackedBadCooldown.expectedPerWindow uses of the specified action in each window
-	 *     (usually, this number should be 0), and will provide a suggestion if the BadCooldown is being used more than the expected threshold
+	 * Optionally, you can also specify additional actions to track usage of, indicating the number of expected usages per window.
+	 *  - trackedBadActions will require NO MORE THAN trackedBadAction.expectedPerWindow uses of the specified action in each window
+	 *     (usually, this number should be 0), and will provide a suggestion if the BadAction is being used more than the expected threshold
 	 */
 	protected trackedBadActions?: BuffWindowTrackedActions
 	/**

--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -46,10 +46,8 @@ export class BuffWindowState {
 
 	getTrackedActionCount(action: BuffWindowTrackedAction): number {
 		if (action.status) {
-			const status = action.status as Status
-
 			return this.expiredStatuses
-				.filter(e => e.ability.guid === status.id)
+				.filter(e => e.ability.guid === action.status?.id)
 				.length
 		}
 

--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -45,13 +45,15 @@ export class BuffWindowState {
 	}
 
 	getTrackedActionCount(action: BuffWindowTrackedAction): number {
-		if (!action.status) {
-			return this.getActionCountByIds([action.action.id])
-		} else {
+		if (action.status) {
+			const status = action.status as Status
+
 			return this.expiredStatuses
-				.filter(e => e.ability.guid === action.status!.id)
+				.filter(e => e.ability.guid === status.id)
 				.length
 		}
+
+		return this.getActionCountByIds([action.action.id])
 	}
 }
 

--- a/src/parser/jobs/brd/modules/RagingStrikes.tsx
+++ b/src/parser/jobs/brd/modules/RagingStrikes.tsx
@@ -62,6 +62,7 @@ export default class RagingStrikes extends BuffWindowModule {
 		actions: [
 			{
 				action: this.data.actions.BARRAGE,
+				status: this.data.statuses.BARRAGE,
 				expectedPerWindow: 1,
 			},
 			{

--- a/src/parser/jobs/mch/modules/Tincture.tsx
+++ b/src/parser/jobs/mch/modules/Tincture.tsx
@@ -25,6 +25,7 @@ export default class Tincture extends CoreTincture {
 			},
 			{
 				action: this.data.actions.REASSEMBLE,
+				status: this.data.statuses.REASSEMBLED,
 				expectedPerWindow: 1,
 			},
 			{
@@ -49,13 +50,7 @@ export default class Tincture extends CoreTincture {
 	changeExpectedTrackedActionClassLogic(buffWindow: BuffWindowState, action: BuffWindowTrackedAction): number {
 		const bufferedWindowStart = buffWindow.start - TINCTURE_BUFFER
 
-		if (action.action === this.data.actions.REASSEMBLE) {
-			// Reassemble might be used prepull or during downtime
-			if (bufferedWindowStart <= this.parser.fight.start_time || this.downtime.isDowntime(bufferedWindowStart)) {
-				return -1
-			}
-
-		} else if (action.action === this.data.actions.PILE_BUNKER) {
+		if (action.action === this.data.actions.PILE_BUNKER) {
 			// We don't have queen in the opener
 			if (bufferedWindowStart <= this.parser.fight.start_time) {
 				return -1


### PR DESCRIPTION
Adds an optional status field to BuffWindowTrackedActions. When this field is present, usages are counted by RemoveBuff events rather than CastEvents. This allows for actions like Reassemble and Barrage to behave properly as trackedActions (the necessary changes for both are also included in this PR).

Before:
![image](https://user-images.githubusercontent.com/65056303/105616255-ae48ef80-5da3-11eb-8549-c6e8c2d978f1.png)

After:
![image](https://user-images.githubusercontent.com/65056303/105616260-b6a12a80-5da3-11eb-8f1b-fef8fa1a1b99.png)

https://xivanalysis.com/fflogs/zjtxA4GQLZgkC2Ph/10/8