### PR TITLE
GNB: Cart Timeline Update (Overcap + Extra Info)

### DIFF
--- a/src/parser/jobs/gnb/modules/Ammo.tsx
+++ b/src/parser/jobs/gnb/modules/Ammo.tsx
@@ -66,6 +66,7 @@ class AmmoState {
 class OvercapState {
 	t?: number
 	y?: number
+	wasted: number
 	source: string
 	timing: number
 }
@@ -155,8 +156,8 @@ export default class Ammo extends Module {
 			this.wasteBySource[abilityId] += waste
 			this.ammo = MAX_AMMO
 
-			this.pushToOvercapHistory(originalAmmo, OvercapTiming.BEFORE)
-			this.pushToOvercapHistory(originalAmmo + generatedAmmo, OvercapTiming.AFTER)
+			this.pushToOvercapHistory(originalAmmo, 0, OvercapTiming.BEFORE)
+			this.pushToOvercapHistory(originalAmmo + generatedAmmo, waste, OvercapTiming.AFTER)
 		}
 
 		this.pushToHistory(ActionImpact.GENERATOR)
@@ -190,11 +191,12 @@ export default class Ammo extends Module {
 		})
 	}
 
-	private pushToOvercapHistory(ammo: number, timing: number) {
+	private pushToOvercapHistory(ammo: number, waste: number, timing: number) {
 		const timestamp = this.parser.currentTimestamp - this.parser.fight.start_time
 		this.overcapHistory.push({
 			t: timestamp,
 			y: ammo,
+			wasted: waste,
 			source: this.currentAbility,
 			timing: timing,
 		})
@@ -358,7 +360,8 @@ export default class Ammo extends Module {
 								return 'Before ' + hoveredOvercapHistory.source
 							}
 							if (hoveredOvercapHistory.timing === OvercapTiming.AFTER) {
-								return 'After ' + hoveredOvercapHistory.source
+								return 'After ' + hoveredOvercapHistory.source + 
+								' \nWasted ' + hoveredOvercapHistory.wasted + ' Cartridge'
 							}
 						}
 

--- a/src/parser/jobs/gnb/modules/Ammo.tsx
+++ b/src/parser/jobs/gnb/modules/Ammo.tsx
@@ -28,6 +28,7 @@ const AMMO_SPENDERS = {
 	[ACTIONS.BURST_STRIKE.id]: 1,
 	[ACTIONS.FATED_CIRCLE.id]: 1,
 }
+
 const SINGLE_TARGET_CIRCLE_SEVERITY_TIERS = {
 	1: SEVERITY.MINOR,
 	2: SEVERITY.MEDIUM,
@@ -353,6 +354,7 @@ export default class Ammo extends Module {
 					},
 				}],
 			},
+			/* eslint-disable @typescript-eslint/no-explicit-any */
 			tooltips: {
 				callbacks: {
 					label: function (tooltipItem: any, data: any) {
@@ -363,9 +365,8 @@ export default class Ammo extends Module {
 						if (datasetIndex === TimelineDatasetIndex.OVERCAP_HISTORY &&
 							hoveredHistory.timing === OvercapTiming.BEFORE) {
 							return ' ' + hoveredHistory.y + ' Before <' + hoveredHistory.source + '> Overcapping'
-						} else {
-							return ' ' + hoveredHistory.y + ' After <' + hoveredHistory.source + '>'
 						}
+						return ' ' + hoveredHistory.y + ' After <' + hoveredHistory.source + '>'
 					},
 					afterBody: function(tooltipItems: any, data: any) {
 						const datasetIndex = tooltipItems[0].datasetIndex
@@ -393,6 +394,7 @@ export default class Ammo extends Module {
 				},
 			},
 		}
+		/* eslint-enable @typescript-eslint/no-explicit-any */
 		/* eslint-enable @typescript-eslint/no-magic-numbers */
 
 		return <Fragment>

--- a/src/parser/jobs/gnb/modules/Ammo.tsx
+++ b/src/parser/jobs/gnb/modules/Ammo.tsx
@@ -355,6 +355,18 @@ export default class Ammo extends Module {
 			},
 			tooltips: {
 				callbacks: {
+					label: function (tooltipItem: any, data: any) {
+						const datasetIndex = tooltipItem.datasetIndex
+						const valueIndex = tooltipItem.index
+						const hoveredHistory = data.datasets[datasetIndex].data[valueIndex]
+
+						if (datasetIndex === TimelineDatasetIndex.OVERCAP_HISTORY &&
+							hoveredHistory.timing === OvercapTiming.BEFORE) {
+							return ' ' + hoveredHistory.y + ' Before <' + hoveredHistory.source + '> Overcapping'
+						} else {
+							return ' ' + hoveredHistory.y + ' After <' + hoveredHistory.source + '>'
+						}
+					},
 					afterBody: function(tooltipItems: any, data: any) {
 						const datasetIndex = tooltipItems[0].datasetIndex
 						const valueIndex = tooltipItems[0].index
@@ -363,20 +375,16 @@ export default class Ammo extends Module {
 							const hoveredAmmoHistory = data.datasets[datasetIndex].data[valueIndex]
 
 							if (hoveredAmmoHistory.action === ActionImpact.GENERATOR) {
-								return 'Generator: ' + hoveredAmmoHistory.source
+								return '(Generator)'
 							}
 							if (hoveredAmmoHistory.action === ActionImpact.SPENDER) {
-								return 'Spender: ' + hoveredAmmoHistory.source
+								return '(Spender)'
 							}
 						} else if (datasetIndex === TimelineDatasetIndex.OVERCAP_HISTORY) {
 							const hoveredOvercapHistory = data.datasets[datasetIndex].data[valueIndex]
 
-							if (hoveredOvercapHistory.timing === OvercapTiming.BEFORE) {
-								return 'Before ' + hoveredOvercapHistory.source
-							}
 							if (hoveredOvercapHistory.timing === OvercapTiming.AFTER) {
-								return 'After ' + hoveredOvercapHistory.source +
-								' \nWasted ' + hoveredOvercapHistory.wasted + ' Cartridge'
+								return '(Wasted ' + hoveredOvercapHistory.wasted + ' Cartridge)'
 							}
 						}
 


### PR DESCRIPTION
Adding two features for the gunbreaker - 
1. Showing source for the ammo timeline.
2. Having "waste" or "overcap" part of the timeline, so players could see when it happend.

I am not sure how good the code is, would love to have some help with that to make it more maintain-able
but it does the work.
I can add comments if it helps.

This is how it looks:
Generator: https://cdn.discordapp.com/attachments/808985736962506752/809188772217880586/unknown.png
Spender: https://cdn.discordapp.com/attachments/808985736962506752/809188810121805884/unknown.png
Overcap Before: https://cdn.discordapp.com/attachments/808985736962506752/809188855710089286/unknown.png
Overcap After: https://cdn.discordapp.com/attachments/808985736962506752/809188883283443712/unknown.png