### PR TITLE
DNC - stricter downtime forgiveness for Technical / Standard Step

### DIFF
--- a/src/parser/jobs/dnc/modules/OGCDDowntime.tsx
+++ b/src/parser/jobs/dnc/modules/OGCDDowntime.tsx
@@ -1,10 +1,24 @@
 import ACTIONS from 'data/ACTIONS'
 import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 
+/**
+ * The default allowance for dances is too lenient since in practice
+ * they're just GCDs and drifting them is heavily discouraged.
+ * 250 ms should be enough to forgive light clipping.
+ */
+const ALLOWED_DANCE_DOWNTIME = 250
+
 export default class OGCDDowntime extends CooldownDowntime {
 	trackedCds = [
-		{cooldowns: [ACTIONS.TECHNICAL_STEP]},
-		{cooldowns: [ACTIONS.STANDARD_STEP], firstUseOffset: -15000},
+		{
+			cooldowns: [ACTIONS.TECHNICAL_STEP],
+			allowedAverageDowntime: ALLOWED_DANCE_DOWNTIME,
+		},
+		{
+			cooldowns: [ACTIONS.STANDARD_STEP],
+			firstUseOffset: -15000,
+			allowedAverageDowntime: ALLOWED_DANCE_DOWNTIME,
+		},
 		{cooldowns: [ACTIONS.DEVILMENT]},
 		{cooldowns: [ACTIONS.FLOURISH]},
 	]


### PR DESCRIPTION
Since these abilities behave like GCDs in practice, and since drifting them is heavily discouraged, the default 1250ms allowed downtime is too lenient and frequently produces logs such as the one below. This PR reduces the allowed downtime to 250ms.

![image](https://user-images.githubusercontent.com/65056303/108457704-1d99ee00-7241-11eb-8f9d-57c7b027a8eb.png)