### PR TITLE
Improve event adaption pipeline

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -163,6 +163,7 @@ export interface Resource {
 export interface Position {
 	x: number
 	y: number
+	heading: number
 }
 
 /** An actors parameters have been updated. */

--- a/src/event.ts
+++ b/src/event.ts
@@ -163,7 +163,7 @@ export interface Resource {
 export interface Position {
 	x: number
 	y: number
-	heading: number
+	bearing: number
 }
 
 /** An actors parameters have been updated. */

--- a/src/event.ts
+++ b/src/event.ts
@@ -155,8 +155,8 @@ interface EventHeal extends FieldsTargeted {
 
 /** Status of a single numeric resource. */
 export interface Resource {
-	maximum?: number
-	current?: number
+	maximum: number
+	current: number
 }
 
 /** Position of an actor. */
@@ -170,11 +170,11 @@ interface EventActorUpdate extends FieldsBase {
 	/** ID of the updated actor. */
 	actor: Actor['id']
 	/** Updated HP status. */
-	hp?: Resource
+	hp?: Partial<Resource>
 	/** Updated MP status. */
-	mp?: Resource
+	mp?: Partial<Resource>
 	/** Updated position. */
-	position?: Position
+	position?: Partial<Position>
 	/** Current targetability. */
 	targetable?: boolean
 }

--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -83,6 +83,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
+      "heading": -160,
       "x": 9999,
       "y": 10081,
     },
@@ -100,6 +101,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
+      "heading": -245,
       "x": 9260,
       "y": 10463,
     },
@@ -130,6 +132,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
+      "heading": -208,
       "x": 9887,
       "y": 10642,
     },
@@ -181,6 +184,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
+      "heading": -160,
       "x": 9999,
       "y": 10081,
     },
@@ -239,6 +243,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
+      "heading": -288,
       "x": 10601,
       "y": 9971,
     },

--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -136,23 +136,6 @@ Array [
     "timestamp": 7412071,
     "type": "actorUpdate",
   },
-  Object {
-    "actor": "3",
-    "hp": Object {
-      "current": 122214,
-      "maximum": 122214,
-    },
-    "mp": Object {
-      "current": 9800,
-      "maximum": 10000,
-    },
-    "position": Object {
-      "x": 9887,
-      "y": 10642,
-    },
-    "timestamp": 7412071,
-    "type": "actorUpdate",
-  },
 ]
 `;
 

--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -83,7 +83,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
-      "heading": -160,
+      "bearing": -160,
       "x": 9999,
       "y": 10081,
     },
@@ -101,7 +101,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
-      "heading": -245,
+      "bearing": -245,
       "x": 9260,
       "y": 10463,
     },
@@ -132,7 +132,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
-      "heading": -208,
+      "bearing": -208,
       "x": 9887,
       "y": 10642,
     },
@@ -184,7 +184,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
-      "heading": -160,
+      "bearing": -160,
       "x": 9999,
       "y": 10081,
     },
@@ -243,7 +243,7 @@ Array [
       "maximum": 10000,
     },
     "position": Object {
-      "heading": -288,
+      "bearing": -288,
       "x": 10601,
       "y": 9971,
     },

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -1,4 +1,5 @@
 import {GameEdition} from 'data/PATCHES'
+import {Events} from 'event'
 import {FflogsEvent, ReportLanguage} from 'fflogs'
 import {Report} from 'report'
 import {adaptEvents} from '../eventAdapter'
@@ -30,6 +31,13 @@ const report: Report = {
 // Below is a "fake" definition of every fflogs type we have typed in the codebase.
 // It's long - you'll probably want to collapse it
 // #region FFLogs event definitions
+
+const fakeAbility = {
+	name: 'Fake Ability',
+	guid: -1,
+	type: 0,
+	abilityIcon: 'fakeAbilityIcon',
+}
 
 // For stuff that will never have them
 const fakeBaseFields = {
@@ -490,5 +498,32 @@ describe('Event adapter', () => {
 			const event = fakeEvents[eventType as keyof typeof fakeEvents]
 			expect(adaptEvents(report, [event])).toMatchSnapshot()
 		}))
+	})
+
+	it('merges duplicate status data', () => {
+		const statusData = 10
+
+		const result = adaptEvents(report, [{
+			timestamp: 100,
+			type: 'applybuff',
+			sourceID: 1,
+			sourceIsFriendly: true,
+			targetID: 2,
+			targetIsFriendly: true,
+			ability: fakeAbility,
+		}, {
+			timestamp: 100,
+			type: 'applybuffstack',
+			sourceID: 1,
+			sourceIsFriendly: true,
+			targetID: 2,
+			targetIsFriendly: true,
+			ability: fakeAbility,
+			stack: statusData,
+		}])
+
+		expect(result).toHaveLength(1)
+		expect(result[0].type).toBe('statusApply')
+		expect((result[0] as Events['statusApply']).data).toBe(statusData)
 	})
 })

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -586,7 +586,7 @@ describe('Event adapter', () => {
 			actor: '1',
 			hp: {current: 100, maximum: 1000},
 			mp: {current: 100, maximum: 10000},
-			position: {x: 100, y: 100, heading: 0},
+			position: {x: 100, y: 100, bearing: 0},
 		}, {
 			timestamp: 200,
 			type: 'actorUpdate',

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -586,7 +586,7 @@ describe('Event adapter', () => {
 			actor: '1',
 			hp: {current: 100, maximum: 1000},
 			mp: {current: 100, maximum: 10000},
-			position: {x: 100, y: 100},
+			position: {x: 100, y: 100, heading: 0},
 		}, {
 			timestamp: 200,
 			type: 'actorUpdate',

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -2,6 +2,7 @@ import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
 import {Report} from 'report'
 import {AdapterStep} from './base'
+import {DeduplicateActorUpdateStep} from './deduplicateActorUpdates'
 import {DeduplicateStatusApplicationStep} from './deduplicateStatus'
 import {TranslateAdapterStep} from './translate'
 
@@ -18,6 +19,7 @@ class EventAdapter {
 		this.adaptionSteps = [
 			new TranslateAdapterStep({report}),
 			new DeduplicateStatusApplicationStep({report}),
+			new DeduplicateActorUpdateStep({report}),
 		]
 	}
 

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -1,0 +1,28 @@
+import {Event} from 'event'
+import {FflogsEvent} from 'fflogs'
+import {Report} from 'report'
+import {AdapterStep} from './base'
+import {TranslateAdapterStep} from './translate'
+
+/** Adapt an array of FFLogs APIv1 events to xiva representation. */
+export function adaptEvents(report: Report, events: FflogsEvent[]): Event[] {
+	const adapter = new EventAdapter({report})
+	return adapter.adaptEvents(events)
+}
+
+class EventAdapter {
+	private adaptionSteps: AdapterStep[]
+
+	constructor({report}: {report: Report}) {
+		this.adaptionSteps = [
+			new TranslateAdapterStep({report}),
+		]
+	}
+
+	adaptEvents(events: FflogsEvent[]): Event[] {
+		return events.flatMap(baseEvent => this.adaptionSteps.reduce(
+			(adaptedEvents, step) => step.adapt(baseEvent, adaptedEvents),
+			[] as Event[],
+		))
+	}
+}

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -2,6 +2,7 @@ import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
 import {Report} from 'report'
 import {AdapterStep} from './base'
+import {DeduplicateStatusApplicationStep} from './deduplicateStatus'
 import {TranslateAdapterStep} from './translate'
 
 /** Adapt an array of FFLogs APIv1 events to xiva representation. */
@@ -16,6 +17,7 @@ class EventAdapter {
 	constructor({report}: {report: Report}) {
 		this.adaptionSteps = [
 			new TranslateAdapterStep({report}),
+			new DeduplicateStatusApplicationStep({report}),
 		]
 	}
 

--- a/src/reportSources/legacyFflogs/eventAdapter/base.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/base.ts
@@ -1,0 +1,14 @@
+import {Event} from 'event'
+import {FflogsEvent} from 'fflogs'
+import {Report} from 'report'
+
+// This stuff will probably be moved to a shared location for other sources to use
+
+export abstract class AdapterStep {
+	protected report: Report
+	constructor(opts: {report: Report}) {
+		this.report = opts.report
+	}
+
+	abstract adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[]
+}

--- a/src/reportSources/legacyFflogs/eventAdapter/deduplicateActorUpdates.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/deduplicateActorUpdates.ts
@@ -1,0 +1,81 @@
+import {Event, Events, Position, Resource} from 'event'
+import {FflogsEvent} from 'fflogs'
+import _ from 'lodash'
+import {Actor} from 'report'
+import {AdapterStep} from './base'
+
+export class DeduplicateActorUpdateStep extends AdapterStep {
+	private actorState = new Map<Actor['id'], Events['actorUpdate']>()
+
+	adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
+		const out: Event[] = []
+		for (const event of adaptedEvents) {
+			const adapted = event.type === 'actorUpdate'
+				? this.adaptActorUpdate(event)
+				: event
+			adapted && out.push(adapted)
+		}
+		return out
+	}
+
+	private adaptActorUpdate(next: Events['actorUpdate']): Event | undefined {
+		// Grab the previous state of the actor - if there is nothing, the new state is all we know
+		const prev = this.actorState.get(next.actor)
+		if (prev == null) {
+			this.actorState.set(next.actor, next)
+			return next
+		}
+
+		// Build an object of changes since the previous values
+		const updates = this.denseObject([
+			['hp', this.resolveResource(prev.hp, next.hp)],
+			['mp', this.resolveResource(prev.mp, next.mp)],
+			['position', this.resolvePosition(prev.position, next.position)],
+		])
+
+		// If nothing has changed, we can noop this entire event
+		if (updates == null) {
+			return undefined
+		}
+
+		this.actorState.set(next.actor, _.merge({}, prev, updates))
+
+		return {
+			type: 'actorUpdate',
+			timestamp: next.timestamp,
+			actor: next.actor,
+			...updates,
+		}
+	}
+
+	private resolveResource(
+		prev?: Partial<Resource>,
+		next?: Partial<Resource>,
+	): Partial<Resource> | undefined {
+		return this.denseObject([
+			['current', this.resolveValue(prev?.current, next?.current)],
+			['maximum', this.resolveValue(prev?.maximum, next?.maximum)],
+		])
+	}
+
+	private resolvePosition(
+		prev?: Partial<Position>,
+		next?: Partial<Position>,
+	): Partial<Position> | undefined {
+		return this.denseObject([
+			['x', this.resolveValue(prev?.x, next?.x)],
+			['y', this.resolveValue(prev?.y, next?.y)],
+		])
+	}
+
+	private resolveValue<T>(prev?: T, next?: T): T | undefined {
+		return next !== prev ? next : undefined
+	}
+
+	private denseObject<T extends object>(entries: Array<[string, unknown]>): T | undefined {
+		const filtered = entries.filter(([, value]) => value != null)
+		return filtered.length === 0
+			? undefined
+			: Object.fromEntries(filtered) as T
+	}
+}

--- a/src/reportSources/legacyFflogs/eventAdapter/deduplicateActorUpdates.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/deduplicateActorUpdates.ts
@@ -65,6 +65,7 @@ export class DeduplicateActorUpdateStep extends AdapterStep {
 		return this.denseObject([
 			['x', this.resolveValue(prev?.x, next?.x)],
 			['y', this.resolveValue(prev?.y, next?.y)],
+			['bearing', this.resolveValue(prev?.bearing, next?.bearing)],
 		])
 	}
 

--- a/src/reportSources/legacyFflogs/eventAdapter/deduplicateStatus.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/deduplicateStatus.ts
@@ -1,0 +1,52 @@
+import {Event, Events} from 'event'
+import {FflogsEvent} from 'fflogs'
+import {AdapterStep} from './base'
+
+// Time between the apply and the applystack permitted for merging
+const PERMITTED_TIME_DELTA = 0
+
+/**
+ * FFLogs models the application of a status with a data field as an
+ * apply, followed by an applystack with duplicate info. We don't make
+ * the distinction (as it's irrelevant in XIV), merge the two back together.
+ */
+export class DeduplicateStatusApplicationStep extends AdapterStep {
+	private activeStatuses = new Map<string, Events['statusApply']>();
+
+	adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
+		const out: Event[] = []
+		for (const event of adaptedEvents) {
+			const adapted = event.type === 'statusApply'
+				? this.adaptStatusApply(event)
+				: event
+			adapted && out.push(adapted)
+		}
+		return out
+	}
+
+	private adaptStatusApply(event: Events['statusApply']): Event | undefined {
+		const key = buildStatusKey(event)
+
+		// No data, record it for later and pass on
+		if (event.data == null) {
+			this.activeStatuses.set(key, event)
+			return event
+		}
+
+		// If there's no previous application, or it was at a different timestamp, pass on
+		const previousApply = this.activeStatuses.get(key)
+		if (
+			previousApply == null ||
+			event.timestamp - previousApply.timestamp < PERMITTED_TIME_DELTA
+		) {
+			return event
+		}
+
+		// We got a match - update the previous event with the data, and noop this one
+		previousApply.data = event.data
+		return undefined
+	}
+}
+
+const buildStatusKey = (event: Events['statusApply']) =>
+	`${event.source}|${event.target}|${event.status}`

--- a/src/reportSources/legacyFflogs/eventAdapter/index.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/index.ts
@@ -1,0 +1,1 @@
+export {adaptEvents} from './adapter'

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -2,15 +2,14 @@ import * as Sentry from '@sentry/browser'
 import {STATUS_ID_OFFSET} from 'data/STATUSES'
 import {Event, Events, Cause, SourceModifier, TargetModifier} from 'event'
 import {ActorResources, BuffEvent, BuffStackEvent, CastEvent, DamageEvent, DeathEvent, EventActor, FflogsEvent, HealEvent, HitType, TargetabilityUpdateEvent} from 'fflogs'
-import {Actor, Report} from 'report'
+import {Actor} from 'report'
+import {AdapterStep} from './base'
 
 /*
 NOTES:
 - FFLogs uses an ID offset for statuses. It's currently handled throughout the application - once legacy handling is removed, we can safely contain the offset in the adaption.
 - FFLogs re-attributes limit break results to a special actor, resulting in two actions (one from the original, one from fabricated), then all follow-up data being on the fabricated actor. We should adapt that back to the caster.
 */
-
-type AdaptionStep = (baseEvent: FflogsEvent, adaptedEvents: Event[]) => Event[]
 
 /** Mapping from FFLogs hit types to source-originating modifiers. */
 const sourceHitType: Partial<Record<HitType, SourceModifier>> = {
@@ -27,56 +26,31 @@ const targetHitType: Partial<Record<HitType, TargetModifier>> = {
 	[HitType.IMMUNE]: TargetModifier.INVULNERABLE,
 }
 
-/** Adapt an array of FFLogs APIv1 events to xiva representation. */
-export function adaptEvents(report: Report, events: FflogsEvent[]): Event[] {
-	const adapter = new EventAdapter({report})
-	return adapter.adaptEvents(events)
-}
-
-class EventAdapter {
-	private adaptionSteps: AdaptionStep[] = [
-		this.translateEvent.bind(this),
-	]
-
-	/** xiva report representation. */
-	private report: Report
-
-	/** Set of event types marked as unhandled. Used to prevent duplicate warnings. */
+/** Translate an FFLogs APIv1 event to the xiva representation, if any exists. */
+export class TranslateAdapterStep extends AdapterStep {
 	private unhandledTypes = new Set<string>()
 
-	constructor(opts: {report: Report}) {
-		this.report = opts.report
-	}
-
-	adaptEvents(events: FflogsEvent[]): Event[] {
-		return events.flatMap(baseEvent => this.adaptionSteps.reduce(
-			(adaptedEvents, step) => step(baseEvent, adaptedEvents),
-			[] as Event[],
-		))
-	}
-
-	/** Translate an FFLogs APIv1 event to the xiva representation, if any exists. */
-	private translateEvent(event: FflogsEvent): Event[] {
-		switch (event.type) {
+	adapt(baseEvent: FflogsEvent, _adaptedEvents: Event[]): Event[] {
+		switch (baseEvent.type) {
 		case 'begincast':
 		case 'cast':
-			return [this.adaptCastEvent(event)]
+			return [this.adaptCastEvent(baseEvent)]
 
 		case 'calculateddamage':
 		case 'calculatedheal':
-			return this.adaptSnapshotEvent(event)
+			return this.adaptSnapshotEvent(baseEvent)
 
 		case 'damage':
-			return this.adaptDamageEvent(event)
+			return this.adaptDamageEvent(baseEvent)
 
 		case 'heal':
-			return this.adaptHealEvent(event)
+			return this.adaptHealEvent(baseEvent)
 
 		case 'applybuff':
 		case 'applydebuff':
 		case 'refreshbuff':
 		case 'refreshdebuff':
-			return [this.adaptStatusApplyEvent(event)]
+			return [this.adaptStatusApplyEvent(baseEvent)]
 
 		// TODO: Due to FFLogs™️ Quality™️, this effectively results in a double application
 		// of every stacked status. Probably should resolve that out.
@@ -84,17 +58,17 @@ class EventAdapter {
 		case 'applydebuffstack':
 		case 'removebuffstack':
 		case 'removedebuffstack':
-			return [this.adaptStatusApplyDataEvent(event)]
+			return [this.adaptStatusApplyDataEvent(baseEvent)]
 
 		case 'removebuff':
 		case 'removedebuff':
-			return [this.adaptStatusRemoveEvent(event)]
+			return [this.adaptStatusRemoveEvent(baseEvent)]
 
 		case 'death':
-			return [this.adaptDeathEvent(event)]
+			return [this.adaptDeathEvent(baseEvent)]
 
 		case 'targetabilityupdate':
-			return [this.adaptTargetableEvent(event)]
+			return [this.adaptTargetableEvent(baseEvent)]
 
 		/* eslint-disable no-fallthrough */
 		// Dispels are already modelled by other events, and aren't something we really care about
@@ -115,7 +89,7 @@ class EventAdapter {
 
 		default: {
 			// Anything that reaches this point is unknown. If we've already notified, just noop
-			const unknownEvent = event as {type: string}
+			const unknownEvent = baseEvent as {type: string}
 			if (this.unhandledTypes.has(unknownEvent.type)) {
 				break
 			}
@@ -124,7 +98,7 @@ class EventAdapter {
 			Sentry.withScope(scope => {
 				scope.setExtras({
 					report: this.report.meta.code,
-					event,
+					event: baseEvent,
 				})
 				Sentry.captureMessage(`adapter.fflogs.unhandled.${unknownEvent.type}`)
 			})

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -229,7 +229,7 @@ export class TranslateAdapterStep extends AdapterStep {
 			actor,
 			hp: {current: resources.hitPoints, maximum: resources.maxHitPoints},
 			mp: {current: resources.mp, maximum: resources.maxMP},
-			position: {x: resources.x, y: resources.y, heading: resources.facing},
+			position: {x: resources.x, y: resources.y, bearing: resources.facing},
 		}
 	}
 

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -229,7 +229,7 @@ export class TranslateAdapterStep extends AdapterStep {
 			actor,
 			hp: {current: resources.hitPoints, maximum: resources.maxHitPoints},
 			mp: {current: resources.mp, maximum: resources.maxMP},
-			position: {x: resources.x, y: resources.y},
+			position: {x: resources.x, y: resources.y, heading: resources.facing},
 		}
 	}
 


### PR DESCRIPTION
This PR modularises the event adaption pipeline slightly, making it easier to perform transformations on the events before they move into the parser.

This system is effectively the new event system's replacement for the old normalisation system.

In addition, it:
- Adds the new `bearing` position data to actor updates
- Merges duplicate `statusApply` events caused by fflog's apply -> applystack crap
- Omits redundant `actorUpdate` data