### PR TITLE
BuffWindow - status counting bugfix

### DIFF
--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -50,8 +50,10 @@ export class BuffWindowState {
 				.filter(e => this.data.getAction(e.ability.guid)?.onGcd)
 				.map(e => e.timestamp)
 
+			// Check to make sure at least one GCD happened before the status expired
 			return this.expiredStatuses
-				.filter(e => e.ability.guid === action.status?.id && gcdTimestamps.includes(e.timestamp))
+				.filter(e => e.ability.guid === action.status?.id &&
+					gcdTimestamps.some(t => t <= e.timestamp))
 				.length
 		}
 


### PR DESCRIPTION
For whatever reason, logs are not behaving like they used to and statuses that apply to GCDs aren't always fading at the same time as the GCD was cast. This PR adjusts the logic for counting expired statuses by checking for a GCD use that was within the buffwindow with a timestamp less than or equal to the status fade timestamp.