### PR TITLE
Corrected cases where Trick Attack windows could be improperly split.

### DIFF
--- a/src/parser/core/modules/BuffWindow.tsx
+++ b/src/parser/core/modules/BuffWindow.tsx
@@ -209,7 +209,9 @@ export abstract class BuffWindowModule extends Module {
 			return
 		}
 
-		this.startNewBuffWindow(event.timestamp, status)
+		if (this.activeBuffWindow === undefined) {
+			this.startNewBuffWindow(event.timestamp, status)
+		}
 	}
 
 	private startNewBuffWindow(startTime: number, status: Status) {

--- a/src/parser/jobs/nin/index.js
+++ b/src/parser/jobs/nin/index.js
@@ -20,6 +20,11 @@ export default new Meta({
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},
 	],
 	changelog: [{
+		date: new Date('2021-02-27'),
+		Changes: () => <>Corrected cases where Trick Attack windows could be improperly split in Shadowkeeper..</>,
+		contributors: [CONTRIBUTORS.KELOS],
+	},
+	{
 		date: new Date('2020-05-25'),
 		Changes: () => <>Included OGCD usage tracking in the checklist.</>,
 		contributors: [CONTRIBUTORS.TOASTDEIB],


### PR DESCRIPTION
Fixes the duplicated TA window ~4:30 in E10S.

I added a changelog entry since this is a bug that has been reported by users a few times, but I'm not attached to it if we want to silently fix instead.