### PR TITLE
Adapter step for precast actions

### DIFF
--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -69,6 +69,14 @@ Array [
     "sequence": 16647,
     "source": "1",
     "target": "3",
+    "timestamp": 0,
+    "type": "action",
+  },
+  Object {
+    "action": 3554,
+    "sequence": 16647,
+    "source": "1",
+    "target": "3",
     "timestamp": 8011183,
     "type": "snapshot",
   },
@@ -113,6 +121,14 @@ Array [
 
 exports[`Event adapter individual events adapts calculatedheal 1`] = `
 Array [
+  Object {
+    "action": 3571,
+    "sequence": 4570,
+    "source": "3",
+    "target": "3",
+    "timestamp": 0,
+    "type": "action",
+  },
   Object {
     "action": 3571,
     "sequence": 4570,

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -514,6 +514,12 @@ describe('Event adapter', () => {
 		}))
 	})
 
+	it('synthesizes prepull actions', () => {
+		const result = adaptEvents(report, pull, [fakeEvents.calculateddamage])
+		expect(result[0].type).toBe('action')
+		expect(result[1].type).toBe('snapshot')
+	})
+
 	it('merges duplicate status data', () => {
 		const statusData = 10
 

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -515,9 +515,19 @@ describe('Event adapter', () => {
 	})
 
 	it('synthesizes prepull actions', () => {
-		const result = adaptEvents(report, pull, [fakeEvents.calculateddamage])
-		expect(result[0].type).toBe('action')
-		expect(result[1].type).toBe('snapshot')
+		// simulating a begincast before the event that should trip the prepull, to ensure
+		// prepull is added before _all_ events, not just the start of the adapted base.
+		const result = adaptEvents(report, pull, [
+			fakeEvents.begincast,
+			fakeEvents.calculateddamage,
+		])
+		expect(result.map(event => event.type)).toEqual([
+			'action', // prepull synth
+			'prepare', // begincast
+			'snapshot', // calculateddamage
+			'actorUpdate',
+			'actorUpdate',
+		])
 	})
 
 	it('merges duplicate status data', () => {

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -1,14 +1,28 @@
 import {GameEdition} from 'data/PATCHES'
 import {Events} from 'event'
 import {FflogsEvent, HitType, ReportLanguage} from 'fflogs'
-import {Report} from 'report'
+import {Pull, Report} from 'report'
 import {adaptEvents} from '../eventAdapter'
+
+const pull: Pull = {
+	id: '1',
+	timestamp: 0,
+	duration: 1,
+	encounter: {
+		name: 'test encounter',
+		duty: {
+			id: 1,
+			name: 'test duty',
+		},
+	},
+	actors: [],
+}
 
 const report: Report = {
 	timestamp: 0,
 	edition: GameEdition.GLOBAL,
 	name: 'Event adapter test',
-	pulls: [],
+	pulls: [pull],
 	meta: {
 		source: 'legacyFflogs',
 		code: 'adapterTest',
@@ -496,14 +510,14 @@ describe('Event adapter', () => {
 	describe('individual events', () => {
 		Object.keys(fakeEvents).forEach(eventType => it(`adapts ${eventType}`, () => {
 			const event = fakeEvents[eventType as keyof typeof fakeEvents]
-			expect(adaptEvents(report, [event])).toMatchSnapshot()
+			expect(adaptEvents(report, pull, [event])).toMatchSnapshot()
 		}))
 	})
 
 	it('merges duplicate status data', () => {
 		const statusData = 10
 
-		const result = adaptEvents(report, [{
+		const result = adaptEvents(report, pull, [{
 			timestamp: 100,
 			type: 'applybuff',
 			sourceID: 1,
@@ -551,7 +565,7 @@ describe('Event adapter', () => {
 			facing: 0,
 		}
 
-		const result = adaptEvents(report, [{
+		const result = adaptEvents(report, pull, [{
 			...sharedFields,
 			timestamp: 100,
 			targetResources: sharedResources,

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -26,10 +26,15 @@ class EventAdapter {
 	}
 
 	adaptEvents(events: FflogsEvent[]): Event[] {
-		return events
+		const adaptedEvents = events
 			.map(baseEvent => this.adaptionSteps
 				.reduce((adaptedEvents, step) => step.adapt(baseEvent, adaptedEvents),
 				[] as Event[]))
 			.flat()
+
+		return this.adaptionSteps.reduce(
+			(processedEvents, step) => step.postprocess(processedEvents),
+			adaptedEvents,
+		)
 	}
 }

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -1,7 +1,7 @@
 import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
 import {Pull, Report} from 'report'
-import {AdapterStep} from './base'
+import {AdapterOptions, AdapterStep} from './base'
 import {DeduplicateActorUpdateStep} from './deduplicateActorUpdates'
 import {DeduplicateStatusApplicationStep} from './deduplicateStatus'
 import {PrepullActionAdapterStep} from './prepull/action'
@@ -11,11 +11,6 @@ import {TranslateAdapterStep} from './translate'
 export function adaptEvents(report: Report, pull: Pull, events: FflogsEvent[]): Event[] {
 	const adapter = new EventAdapter({report, pull})
 	return adapter.adaptEvents(events)
-}
-
-export interface AdapterOptions {
-	report: Report
-	pull: Pull
 }
 
 class EventAdapter {
@@ -31,9 +26,10 @@ class EventAdapter {
 	}
 
 	adaptEvents(events: FflogsEvent[]): Event[] {
-		return events.flatMap(baseEvent => this.adaptionSteps.reduce(
-			(adaptedEvents, step) => step.adapt(baseEvent, adaptedEvents),
-			[] as Event[],
-		))
+		return events
+			.map(baseEvent => this.adaptionSteps
+				.reduce((adaptedEvents, step) => step.adapt(baseEvent, adaptedEvents),
+				[] as Event[]))
+			.flat()
 	}
 }

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -26,11 +26,12 @@ class EventAdapter {
 	}
 
 	adaptEvents(events: FflogsEvent[]): Event[] {
-		const adaptedEvents = events
-			.map(baseEvent => this.adaptionSteps
-				.reduce((adaptedEvents, step) => step.adapt(baseEvent, adaptedEvents),
-				[] as Event[]))
-			.flat()
+		const adaptedEvents = events.flatMap(baseEvent =>
+			this.adaptionSteps.reduce(
+				(adaptedEvents, step) => step.adapt(baseEvent, adaptedEvents),
+				[] as Event[]
+			)
+		)
 
 		return this.adaptionSteps.reduce(
 			(processedEvents, step) => step.postprocess(processedEvents),

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -4,7 +4,7 @@ import {Pull, Report} from 'report'
 import {AdapterOptions, AdapterStep} from './base'
 import {DeduplicateActorUpdateStep} from './deduplicateActorUpdates'
 import {DeduplicateStatusApplicationStep} from './deduplicateStatus'
-import {PrepullActionAdapterStep} from './prepull/action'
+import {PrepullActionAdapterStep} from './prepullAction'
 import {TranslateAdapterStep} from './translate'
 
 /** Adapt an array of FFLogs APIv1 events to xiva representation. */

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -1,25 +1,32 @@
 import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
-import {Report} from 'report'
+import {Pull, Report} from 'report'
 import {AdapterStep} from './base'
 import {DeduplicateActorUpdateStep} from './deduplicateActorUpdates'
 import {DeduplicateStatusApplicationStep} from './deduplicateStatus'
+import {PrepullActionAdapterStep} from './prepull/action'
 import {TranslateAdapterStep} from './translate'
 
 /** Adapt an array of FFLogs APIv1 events to xiva representation. */
-export function adaptEvents(report: Report, events: FflogsEvent[]): Event[] {
-	const adapter = new EventAdapter({report})
+export function adaptEvents(report: Report, pull: Pull, events: FflogsEvent[]): Event[] {
+	const adapter = new EventAdapter({report, pull})
 	return adapter.adaptEvents(events)
+}
+
+export interface AdapterOptions {
+	report: Report
+	pull: Pull
 }
 
 class EventAdapter {
 	private adaptionSteps: AdapterStep[]
 
-	constructor({report}: {report: Report}) {
+	constructor(opts: AdapterOptions) {
 		this.adaptionSteps = [
-			new TranslateAdapterStep({report}),
-			new DeduplicateStatusApplicationStep({report}),
-			new DeduplicateActorUpdateStep({report}),
+			new TranslateAdapterStep(opts),
+			new DeduplicateStatusApplicationStep(opts),
+			new DeduplicateActorUpdateStep(opts),
+			new PrepullActionAdapterStep(opts),
 		]
 	}
 

--- a/src/reportSources/legacyFflogs/eventAdapter/base.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/base.ts
@@ -18,5 +18,20 @@ export abstract class AdapterStep {
 		this.pull = opts.pull
 	}
 
-	abstract adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[]
+	/**
+	 * Perform logic to adapt a report source event into zero or more xiva events.
+	 * This will be called once with each report source event, in the order provided
+	 * by the source.
+	 */
+	adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
+		return adaptedEvents
+	}
+
+	/**
+	 * Perform postprocessing on the final array of adapted events. This will be
+	 * called once after all report source events have been adapted.
+	 */
+	postprocess(adaptedEvents: Event[]): Event[] {
+		return adaptedEvents
+	}
 }

--- a/src/reportSources/legacyFflogs/eventAdapter/base.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/base.ts
@@ -1,9 +1,13 @@
 import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
 import {Pull, Report} from 'report'
-import {AdapterOptions} from './adapter'
 
 // This stuff will probably be moved to a shared location for other sources to use
+
+export interface AdapterOptions {
+	report: Report
+	pull: Pull
+}
 
 export abstract class AdapterStep {
 	protected report: Report

--- a/src/reportSources/legacyFflogs/eventAdapter/base.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/base.ts
@@ -1,13 +1,17 @@
 import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
-import {Report} from 'report'
+import {Pull, Report} from 'report'
+import {AdapterOptions} from './adapter'
 
 // This stuff will probably be moved to a shared location for other sources to use
 
 export abstract class AdapterStep {
 	protected report: Report
-	constructor(opts: {report: Report}) {
+	protected pull: Pull
+
+	constructor(opts: AdapterOptions) {
 		this.report = opts.report
+		this.pull = opts.pull
 	}
 
 	abstract adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[]

--- a/src/reportSources/legacyFflogs/eventAdapter/prepull/action.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepull/action.ts
@@ -1,27 +1,37 @@
 import {Event, Events} from 'event'
 import {FflogsEvent} from 'fflogs'
+import {action} from 'mobx'
+import {isDefined} from 'utilities'
 import {AdapterStep} from '../base'
 
 export class PrepullActionAdapterStep extends AdapterStep {
 	private finished = false
+	private initialEventLocation?: Event[]
 
 	adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
-		const synthesizedEvents: Event[] = []
-
 		if (this.finished) {
 			return adaptedEvents
 		}
 
+		if (!this.initialEventLocation) {
+			this.initialEventLocation = adaptedEvents
+		}
+
+		const synthesizedEvents: Event[] = []
 		for (const event of adaptedEvents) {
-			if (event.type === 'action') {
+			if (event.type === 'snapshot') {
+				// Create a new action event and push it to the front of the adapted events
+				const actionEvent = this.synthesizeActionEvent(event)
+				synthesizedEvents.push(actionEvent)
+			} else if (event.type === 'action') {
 				// Stop once we hit the first real action event post-pull
 				this.finished = true
-			} else if (event.type === 'snapshot') {
-				synthesizedEvents.push(this.synthesizeActionEvent(event))
 			}
 		}
 
-		return [...synthesizedEvents, ...adaptedEvents]
+		this.initialEventLocation.unshift(...synthesizedEvents)
+
+		return adaptedEvents
 	}
 
 	private synthesizeActionEvent(event: Events['snapshot']): Events['action'] {

--- a/src/reportSources/legacyFflogs/eventAdapter/prepull/action.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepull/action.ts
@@ -1,0 +1,34 @@
+import {Event, Events} from 'event'
+import {FflogsEvent} from 'fflogs'
+import {AdapterStep} from '../base'
+
+export class PrepullActionAdapterStep extends AdapterStep {
+	private finished = false
+
+	adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
+		const synthesizedEvents: Event[] = []
+
+		if (this.finished) {
+			return adaptedEvents
+		}
+
+		for (const event of adaptedEvents) {
+			if (event.type === 'action') {
+				// Stop once we hit the first real action event post-pull
+				this.finished = true
+			} else if (event.type === 'snapshot') {
+				synthesizedEvents.push(this.synthesizeActionEvent(event))
+			}
+		}
+
+		return [...synthesizedEvents, ...adaptedEvents]
+	}
+
+	private synthesizeActionEvent(event: Events['snapshot']): Events['action'] {
+		return {
+			...event,
+			type: 'action',
+			timestamp: this.pull.timestamp,
+		}
+	}
+}

--- a/src/reportSources/legacyFflogs/eventAdapter/prepull/action.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepull/action.ts
@@ -1,36 +1,23 @@
 import {Event, Events} from 'event'
-import {FflogsEvent} from 'fflogs'
-import {isDefined} from 'utilities'
 import {AdapterStep} from '../base'
 
 export class PrepullActionAdapterStep extends AdapterStep {
-	private finished = false
-	private initialEventLocation?: Event[]
+	postprocess(adaptedEvents: Event[]): Event[] {
+		const precastEvents: Event[] = []
 
-	adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
-		if (this.finished) {
-			return adaptedEvents
-		}
-
-		if (!isDefined(this.initialEventLocation)) {
-			this.initialEventLocation = adaptedEvents
-		}
-
-		const synthesizedEvents: Event[] = []
 		for (const event of adaptedEvents) {
 			if (event.type === 'snapshot') {
 				// Create a new action event and push it to the front of the adapted events
-				const actionEvent = this.synthesizeActionEvent(event)
-				synthesizedEvents.push(actionEvent)
+				precastEvents.push(this.synthesizeActionEvent(event))
 			} else if (event.type === 'action') {
 				// Stop once we hit the first real action event post-pull
-				this.finished = true
+				break
 			}
 		}
 
-		this.initialEventLocation.unshift(...synthesizedEvents)
-
-		return adaptedEvents
+		return precastEvents.length > 0
+			? [...precastEvents, ...adaptedEvents]
+			: adaptedEvents
 	}
 
 	private synthesizeActionEvent(event: Events['snapshot']): Events['action'] {

--- a/src/reportSources/legacyFflogs/eventAdapter/prepull/action.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepull/action.ts
@@ -1,6 +1,5 @@
 import {Event, Events} from 'event'
 import {FflogsEvent} from 'fflogs'
-import {action} from 'mobx'
 import {isDefined} from 'utilities'
 import {AdapterStep} from '../base'
 
@@ -13,7 +12,7 @@ export class PrepullActionAdapterStep extends AdapterStep {
 			return adaptedEvents
 		}
 
-		if (!this.initialEventLocation) {
+		if (!isDefined(this.initialEventLocation)) {
 			this.initialEventLocation = adaptedEvents
 		}
 

--- a/src/reportSources/legacyFflogs/eventAdapter/prepullAction.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepullAction.ts
@@ -1,5 +1,5 @@
 import {Event, Events} from 'event'
-import {AdapterStep} from '../base'
+import {AdapterStep} from './base'
 
 export class PrepullActionAdapterStep extends AdapterStep {
 	postprocess(adaptedEvents: Event[]): Event[] {

--- a/src/reportSources/legacyFflogs/store.ts
+++ b/src/reportSources/legacyFflogs/store.ts
@@ -51,7 +51,8 @@ export class LegacyFflogsReportStore extends ReportStore {
 		// Dig into the fflogs report data to build the request
 		const legacyReport = report.meta
 		const legacyFight = legacyReport.fights.find(fight => fight.id.toString() === pullId)
-		if (legacyFight == null) {
+		const pull = report.pulls.find(pull => pull.id === pullId)
+		if (legacyFight == null || pull == null) {
 			throw new Error('no fight')
 		}
 
@@ -62,7 +63,7 @@ export class LegacyFflogsReportStore extends ReportStore {
 			{/* actorid: parseInt(actorId, 10) */},
 			true,
 		)
-		return adaptEvents(report, legacyEvents)
+		return adaptEvents(report, pull, legacyEvents)
 	}
 
 	getReportLink(pullId?: Pull['id'], actorId?: Actor['id']) {


### PR DESCRIPTION
Adds a new fflogs adapter step that synthesizes 'action' events for actions used pre-pull. The old version (PCA) needs to stay for now since it's still depended on by legacy modules.

![image](https://user-images.githubusercontent.com/65056303/111560922-eea46880-8769-11eb-9f74-2e157b593c36.png)
