### PR TITLE
Allow one Triplecast weave in JP opener & fix BLM description actionlink

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -79,7 +79,7 @@
   "ast.sleeve-draw.title": "Sleeve Draw",
   "ast.synastry.suggestion.content": "Try to use <0/> if you need to cast a single-target GCD heal. The GCD heal itself is already an efficiency loss, so it's better to make it as strong as possible if Synastry is not needed soon.",
   "ast.synastry.suggestion.why": "{0, plural, one {# single-target GCD heal was cast} other {# single-target GCD heals were cast}} without synastry even though it was available.",
-  "blm.about.description": "This analyser aims to identify how you're not actually casting [~action/FIRE_IV] as much as you think you are.",
+  "blm.about.description": "This analyser aims to identify how you're not actually casting <0/> as much as you think you are.",
   "blm.gauge.suggestions.dropped-enochian.content": "Dropping <0/> may lead to lost <1/> or <2/> casts, more clipping because of additional <3/> casts, unavailability of <4/> and <5/> or straight up missing out on the 15% damage bonus that <6/> provides.",
   "blm.gauge.suggestions.dropped-enochian.why": "{droppedEno} dropped Enochian {droppedEno, plural, one {buff} other {buffs}}.",
   "blm.gauge.suggestions.lost-polyglot.content": "You lost Polyglot due to dropped <0/>. <1/> and <2/> are your strongest GCDs, so always maximize their casts.",

--- a/src/parser/jobs/blm/index.js
+++ b/src/parser/jobs/blm/index.js
@@ -1,18 +1,16 @@
-import {t} from '@lingui/macro'
-import {StatusLink} from 'components/ui/DbLink'
-import TransMarkdown from 'components/ui/TransMarkdown'
+import {Trans} from '@lingui/react'
+import {ActionLink, StatusLink} from 'components/ui/DbLink'
+import ACTIONS from 'data/ACTIONS'
 import CONTRIBUTORS, {ROLES} from 'data/CONTRIBUTORS'
 import STATUSES from 'data/STATUSES'
 import {Meta} from 'parser/core/Meta'
 import React from 'react'
 
-const description = t('blm.about.description')`This analyser aims to identify how you're not actually casting [~action/FIRE_IV] as much as you think you are.`
-
 export default new Meta({
 	modules: () => import('./modules' /* webpackChunkName: "jobs-blm" */),
 
 	Description: () => <>
-		<TransMarkdown source={description}/>
+		<Trans id="blm.about.description">This analyser aims to identify how you're not actually casting <ActionLink {...ACTIONS.FIRE_IV} /> as much as you think you are.</Trans>
 	</>,
 	supportedPatches: {
 		from: '5.0',
@@ -67,5 +65,10 @@ export default new Meta({
 		date: new Date('2020-05-26'),
 		Changes: () => <>(Modified) Jp Opener is no longer falsely flagged.</>,
 		contributors: [CONTRIBUTORS.FURST],
+	},
+	{
+		date: new Date('2021-03-18'),
+		Changes: () => <>Forgive single-weave Triplecast in JP opener</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
 	}],
 })

--- a/src/parser/jobs/blm/modules/Weaving.js
+++ b/src/parser/jobs/blm/modules/Weaving.js
@@ -11,7 +11,11 @@ const OGCD_EXCEPTIONS = [
 	ACTIONS.TRANSPOSE.id,
 ]
 
-const OPENER_ENO_TIME_THRESHHOLD = 10000
+const OPENER_TIME_THRESHHOLD = 10000
+const OPENER_EXCEPTIONS = [
+	ACTIONS.ENOCHIAN.id,
+	ACTIONS.TRIPLECAST.id,
+]
 
 //max number of AFUI stacks
 const MAX_BUFF_STACKS = 3
@@ -76,10 +80,10 @@ export default class BlmWeaving extends Weaving {
 				return false
 			}
 
-			//allow first eno to be ignored because it's a neccessary weave. 10s for that to happen because of O5s Eno delay.
+			//allow certain actions to be ignored in openers because it can be a neccessary weave. 10s for that to happen because of O5s Eno delay.
 			if (weaveCount === 1) {
 				const ogcdTime = weave.weaves[0].timestamp - this.parser.fight.start_time
-				if (ogcdTime < OPENER_ENO_TIME_THRESHHOLD && weave.weaves[0].ability.guid === ACTIONS.ENOCHIAN.id) {
+				if (ogcdTime < OPENER_TIME_THRESHHOLD && OPENER_EXCEPTIONS.includes(weave.weaves[0].ability.guid)) {
 					return false
 				}
 			}


### PR DESCRIPTION
1. The JP opener (both versions) require a single clipped Triplecast weave after the first Fire IV. Converting the 'Opener Enochian' check to work for both of these skills, since they have the same opener considerations.
2. The About description for the BLM module had a busted action link in it. Switching from TransMarkdown to Trans to resolve that.