### PR TITLE
Modify getDataBy to return all matching entries

### DIFF
--- a/src/data/__tests__/getDataBy.ts
+++ b/src/data/__tests__/getDataBy.ts
@@ -1,10 +1,12 @@
-import {getDataBy} from '../getDataBy'
+import {getDataBy, getDataArrayBy} from '../getDataBy'
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
 const ExampleData = {
 	ONE: {value: 'one', arr: [0, 1, 2, 3, 4]},
 	TWO: {value: 'two', arr: [10, 11, 12, 13, 14]},
+	THREE: {value: 'same', arr: []},
+	FOUR: {value: 'same', arr: []},
 }
 
 describe('DATA', () => {
@@ -27,6 +29,13 @@ describe('DATA', () => {
 				getDataBy(ExampleData, 'invalid', 'one')
 			}
 			expect(erraneousCall).toThrowError('invalid')
+		})
+	}),
+	describe('getDataArrayBy', () => {
+		it('returns all matching data entries', () => {
+			expect(getDataArrayBy(ExampleData, 'value', 'same'))
+				.toContain(ExampleData.THREE)
+				.toContain(ExampleData.FOUR)
 		})
 	})
 })

--- a/src/data/getDataBy.ts
+++ b/src/data/getDataBy.ts
@@ -25,7 +25,7 @@ export function getDataArrayBy<
 	data: Data,
 	by: Key,
 	value: FlattenArray<Value[Key]>,
-):  Value[] | undefined {
+): Value[] | undefined {
 	// Sanity check in case someone is using this from JS and misspelled a key
 	const dataKeys = Object.keys(data)
 	const testEntry = data[dataKeys[0]]

--- a/src/data/getDataBy.ts
+++ b/src/data/getDataBy.ts
@@ -7,17 +7,17 @@ WeakMap<
 		Property being used for lookup,
 		Map<
 			Value for provided property,
-			DATA entry
+			DATA entries
 		>
 	>
 >
 */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const cache = new WeakMap<object, Map<any, Map<any, any>>>()
+const cache = new WeakMap<object, Map<any, Map<any, any[]>>>()
 
 type FlattenArray<T> = T extends Array<infer I> ? I : T
 
-export function getDataBy<
+export function getDataArrayBy<
 	Data extends Record<string, object>,
 	Value extends Data[keyof Data],
 	Key extends keyof Value,
@@ -25,7 +25,7 @@ export function getDataBy<
 	data: Data,
 	by: Key,
 	value: FlattenArray<Value[Key]>,
-): Value | undefined {
+):  Value[] | undefined {
 	// Sanity check in case someone is using this from JS and misspelled a key
 	const dataKeys = Object.keys(data)
 	const testEntry = data[dataKeys[0]]
@@ -51,13 +51,32 @@ export function getDataBy<
 
 			// Keys can be arrays (see STATUSES), handle it
 			const newKeys = ensureArray(val[by])
-			newKeys.forEach(key => map.set(key, val))
+			newKeys.forEach(key => {
+				if (map.has(key)) {
+					map.get(key)?.push(val)
+				} else {
+					map.set(key, [val])
+				}
+			})
 
 			return map
-		}, new Map<Value[Key], Value>())
+		}, new Map<Value[Key], Value[]>())
 
 		dataCache.set(by, lookup)
 	}
 
 	return lookup.get(value)
+}
+
+export function getDataBy<
+	Data extends Record<string, object>,
+	Value extends Data[keyof Data],
+	Key extends keyof Value,
+>(
+	data: Data,
+	by: Key,
+	value: FlattenArray<Value[Key]>,
+): Value | undefined {
+	const entries = getDataArrayBy(data, by, value)
+	return entries ? entries[0] : undefined
 }

--- a/src/data/getDataBy.ts
+++ b/src/data/getDataBy.ts
@@ -52,13 +52,13 @@ export function getDataArrayBy<
 			// Keys can be arrays (see STATUSES), handle it
 			const newKeys = ensureArray(val[by])
 			newKeys.forEach(key => {
-				if (map.has(key)) {
-					map.get(key)?.push(val)
-				} else {
-					map.set(key, [val])
+				let values = map.get(key)
+				if (values == null) {
+					values = []
+					map.set(key, values)
 				}
+				values.push(val)
 			})
-
 			return map
 		}, new Map<Value[Key], Value[]>())
 

--- a/src/parser/core/modules/PrecastStatus.js
+++ b/src/parser/core/modules/PrecastStatus.js
@@ -1,4 +1,4 @@
-import {getDataBy} from 'data'
+import {getDataArrayBy} from 'data'
 import _ from 'lodash'
 import {sortEvents} from 'parser/core/EventSorting'
 import Module from 'parser/core/Module'
@@ -102,11 +102,18 @@ export default class PrecastStatus extends Module {
 		this.debug(`Checking action associated with status ${statusInfo.name}`)
 		// Determine if this buff comes from a known action, fab a cast event
 		const statusKey = _.findKey(this.data.statuses, statusInfo)
-		const actionInfo = getDataBy(this.data.actions, 'statusesApplied', statusKey)
-		if (!actionInfo) {
-			this.debug('No action is applied by status, no action to synthesize')
+		const applyActions = getDataArrayBy(this.data.actions, 'statusesApplied', statusKey)
+		if (!applyActions) {
+			this.debug('No action applies this status, no action to synthesize')
 			return
 		}
+
+		if (applyActions.length > 1) {
+			this.debug('Multiple actions can apply this status, not enough info to synthesize')
+			return
+		}
+
+		const actionInfo = applyActions[0]
 
 		this.debug(`Checking if action ${actionInfo.name} has been observed`)
 		if (this._combatantActions.includes(actionInfo.id)) {


### PR DESCRIPTION
Adds a new function, `getDataArrayBy` with the same signature as gDB except it returns all matches instead of just the last one. Also includes a safeguard against a bug with `precastStatus` that occurs when there are multiple actions in data that apply the same status.