### PR TITLE
Ignore precast events when counting weaves

### DIFF
--- a/src/parser/core/modules/Weaving.js
+++ b/src/parser/core/modules/Weaving.js
@@ -146,9 +146,9 @@ export default class Weaving extends Module {
 
 	// Basic weave check. For job-specific weave concerns, subclass Weaving and override this method. Make sure it's included under the same module key to override the base implementation.
 	isBadWeave(weave, maxWeaves) {
-		// Calc. the no. of weaves - we're ignoring any made while the boss is untargetable
+		// Calc. the no. of weaves - we're ignoring any made while the boss is untargetable, and events that happened before the pull
 		const weaveCount = weave.weaves.filter(
-			event => !this.invuln.isUntargetable('all', event.timestamp),
+			event => !this.invuln.isUntargetable('all', event.timestamp) && event.timestamp >= this.parser.fight.start_time,
 		).length
 
 		// Just using maxWeaves to allow potential subclasses to utilise standard functionality with custom max


### PR DESCRIPTION
Events synthed as precast shouldn't affect the weave count, since they happened before the first damage event. Kick out any events with a timestamp earlier than the beginning of the fight.