### PR TITLE
As-yet unused overheal addition to manually bucket heals

### DIFF
--- a/src/parser/jobs/war/modules/index.ts
+++ b/src/parser/jobs/war/modules/index.ts
@@ -3,6 +3,7 @@ import {Gauge} from './Gauge'
 import InnerRelease from './InnerRelease'
 import MultiHitSkills from './MultiHitSkills'
 import OGCDDowntime from './OGCDDowntime'
+import Overheal from './Overheal'
 import StormsEye from './StormsEye'
 
 export default [
@@ -10,6 +11,7 @@ export default [
 	InnerRelease,
 	MultiHitSkills,
 	OGCDDowntime,
+	Overheal,
 	StormsEye,
 	Cooldowns,
 ]


### PR DESCRIPTION
As always – open to suggestions.

This adds the ability to manually bucket heals by an arbitrary numerical id. I created a test with WAR to bucket nascent heals into equilibrium, direct (really just storm's path), glint (heals on someone else), and self heals, and results were promising:

![image](https://user-images.githubusercontent.com/971885/113498633-3a7a4000-94d4-11eb-9ccb-bcaa2eb97627.png)

As a very brief example:

```js
export default class Overheal extends CoreOverheal {
        // etc
    	trackedHealCategories = [
		{
			id: SELF_HEALS,
			name: <Trans id="war.overheal.self">Nascent heals (self)</Trans>,
			color: SuggestedColors[3],
			trackedHealIds: [],
		},
		{
			name: <Trans id="war.overheal.equilibirum">Nascent heals (other)</Trans>,
			color: SuggestedColors[1],
			trackedHealIds: [
				STATUSES.NASCENT_GLINT.id,
			],
		},
		{
			name: <Trans id="war.overheal.christianbale">That movie with Christian Bale</Trans>,
			color: SuggestedColors[2],
			trackedHealIds: [
				ACTIONS.EQUILIBRIUM.id,
			],
		},
	]

        // etc
        overrideHealCategory(event, petHeal) {
		if (this._flashOn && !IGNORED_HEALS.includes(event.ability.guid)) {
			return SELF_HEALS
		}
		return -1
	}
}
```