### PR TITLE
Audit & remove look-ahead downtime checking

### DIFF
--- a/src/parser/core/modules/CooldownDowntime.tsx
+++ b/src/parser/core/modules/CooldownDowntime.tsx
@@ -188,7 +188,8 @@ export abstract class CooldownDowntime extends Module {
 		if (gRep.cooldown === undefined) {
 			return 0
 		}
-		const maxCharges = gRep.charges ?? 1
+		// 0 charges is nonsensical at this point, default up to 1.
+		const maxCharges = gRep.charges || 1
 
 		// Skill with charges get their allowed downtime from the charge build up time,
 		// so ignore the value on the group object

--- a/src/parser/core/modules/EntityStatuses.ts
+++ b/src/parser/core/modules/EntityStatuses.ts
@@ -162,12 +162,18 @@ export class EntityStatuses extends Module {
 		if (statusEvent.end == null) {
 			this.debug('Unfinished status event detected.  Applying ability duration after last refresh event.')
 			const statusInfo = this.data.getStatus(statusEvent.ability.guid)
+			let end: number
 			if (statusInfo?.duration) {
-				statusEvent.end = Math.min(this.parser.fight.end_time, statusEvent.lastRefreshed + statusInfo.duration * 1000)
-				this.debug(`Updating status event for status ${statusInfo.name}.  Adding ${statusInfo.duration} seconds, effective end time set to ${this.parser.formatTimestamp(statusEvent.end, 1)}`)
+				end = Math.min(this.parser.currentTimestamp, statusEvent.lastRefreshed + statusInfo.duration * 1000)
+				this.debug(`Updating status event for status ${statusInfo.name}.  Adding ${statusInfo.duration} seconds, effective end time set to ${this.parser.formatTimestamp(end, 1)}`)
 			} else {
 				this.debug(`No matching status duration information found for status ${statusEvent.ability.guid}, setting to end of fight so invuln detection can clip the end to when the target went untargetable`)
-				statusEvent.end = this.parser.pull.duration + this.parser.eventTimeOffset
+				end = this.parser.currentTimestamp
+			}
+
+			statusEvent = {
+				...statusEvent,
+				end,
 			}
 		}
 

--- a/src/parser/core/modules/GlobalCooldown.js
+++ b/src/parser/core/modules/GlobalCooldown.js
@@ -231,7 +231,7 @@ export default class GlobalCooldown extends Module {
 			const duration = this._getGcdLength(gcd)
 			const downtime = this.downtime.getDowntime(
 				gcd.timestamp,
-				gcd.timestamp + duration,
+				Math.min(gcd.timestamp + duration, this.parser.eventTimeOffset + this.parser.pull.duration),
 			)
 			return carry + duration - downtime
 		}, 0)

--- a/src/parser/core/modules/Invulnerability.tsx
+++ b/src/parser/core/modules/Invulnerability.tsx
@@ -234,7 +234,7 @@ export class Invulnerability extends Module {
 		const timeSince = event.timestamp - last
 
 		if (timeSince > MIN_INVULN_INACTIVITY) {
-			this.getInvulns(target).push({
+			this.getInvulnsInternal(target).push({
 				type,
 				start: last,
 				end: event.timestamp,
@@ -378,7 +378,7 @@ export class Invulnerability extends Module {
 	}
 
 	private startTypeWindow(type: InvulnType, target: InvulnTarget, start: number) {
-		const invulns = this.getInvulns(target)
+		const invulns = this.getInvulnsInternal(target)
 
 		// If there's an active invuln already, piggyback on it rather than starting a new one
 		const activeInvuln = invulns.find(invuln => invuln.active && invuln.type === type)
@@ -397,7 +397,7 @@ export class Invulnerability extends Module {
 	}
 
 	private endTypeWindow(type: InvulnType, target: InvulnTarget, end: number) {
-		const invulns = this.getInvulns(target)
+		const invulns = this.getInvulnsInternal(target)
 		let activeInvuln = invulns.find(invuln => invuln.active && invuln.type === type)
 
 		// == null means something became targetable, but never went untargetable
@@ -421,7 +421,7 @@ export class Invulnerability extends Module {
 
 		// Use the list of actor 'all's to compile ['all', 'all']
 		const allWindows = this.mergeInputWindows(actorWindowGroups)
-		this.getInvulns('all').push(...allWindows)
+		this.getInvulnsInternal('all').push(...allWindows)
 	}
 
 	private mergeInputWindows(inputWindowGroups: Iterable<Iterable<InvulnWindow>>): InvulnWindow[] {
@@ -549,7 +549,16 @@ export class Invulnerability extends Module {
 		end = this.parser.currentTimestamp,
 	) => this.getInvulnUptime(targetId, start, end, 'invulnerable')
 
-	getInvulns(
+	// Public interface for invuln windows that ensures consumers can't look ahead to the future
+	getInvulns = (...args: Parameters<typeof Invulnerability.prototype.getInvulnsInternal>) =>
+		this.getInvulnsInternal(...args)
+			.filter(window => window.start <= this.parser.currentTimestamp)
+			.map(window => ({
+				...window,
+				end: Math.min(window.end, this.parser.currentTimestamp),
+			}))
+
+	private getInvulnsInternal(
 		targetId: InvulnTarget = 'all',
 		start?: number,
 		end?: number,
@@ -589,7 +598,9 @@ export class Invulnerability extends Module {
 		end: number,
 		type: InvulnType,
 	) {
-		return this.getInvulns(targetId, start, end, type)
+		this.sanityCheckFuture(end)
+
+		return this.getInvulnsInternal(targetId, start, end, type)
 			.reduce((uptime, invuln) => uptime + Math.min(invuln.end, end) - Math.max(invuln.start, start), 0)
 	}
 
@@ -598,12 +609,20 @@ export class Invulnerability extends Module {
 		time: number,
 		type: InvulnType,
 	) {
-		const filtered = this.getInvulns(targetId).filter(invuln =>
+		this.sanityCheckFuture(time)
+
+		const filtered = this.getInvulnsInternal(targetId).filter(invuln =>
 			invuln.type === type &&
 			invuln.start <= time &&
 			invuln.end >= time,
 		)
 
 		return !!filtered.length
+	}
+
+	private sanityCheckFuture(time: number) {
+		if (time > this.parser.currentTimestamp) {
+			throw new Error('Invariant: Tried to retrieve invuln window beyond current analysis position.')
+		}
 	}
 }

--- a/src/parser/core/modules/UnableToAct/UnableToAct.tsx
+++ b/src/parser/core/modules/UnableToAct/UnableToAct.tsx
@@ -88,6 +88,9 @@ export default class UnableToAct extends Module {
 	}
 
 	getDowntimes(start = 0, end = this.parser.currentTimestamp) {
+		if (end > this.parser.currentTimestamp) {
+			throw new Error('Invariant: Tried to retrieve UTA window beyond current analysis position.')
+		}
 		return this.downtimes.filter(downtime => downtime.end > start && downtime.start < end)
 	}
 }

--- a/src/parser/jobs/ast/modules/SleeveDraw.js
+++ b/src/parser/jobs/ast/modules/SleeveDraw.js
@@ -45,7 +45,10 @@ export default class SleeveDraw extends Module {
 		const firstOpportunity = this._lastUse + ACTIONS.SLEEVE_DRAW.cooldown*1000
 		const _held = event.timestamp - firstOpportunity
 		if (_held > 0) {
-			const downtimes = this.unableToAct.getDowntimes(firstOpportunity, firstOpportunity + EXCUSED_HOLD_DEFAULT)
+			const downtimes = this.unableToAct.getDowntimes(
+				firstOpportunity,
+				Math.min(firstOpportunity + EXCUSED_HOLD_DEFAULT, event.timestamp),
+			)
 			const firstEnd = downtimes.length ? downtimes[0].end : firstOpportunity
 			this._totalHeld += _held
 			this._excusedHeld += EXCUSED_HOLD_DEFAULT + (firstEnd - firstOpportunity)

--- a/src/parser/jobs/blm/modules/Gauge.js
+++ b/src/parser/jobs/blm/modules/Gauge.js
@@ -257,7 +257,9 @@ export default class Gauge extends Module {
 
 	// Refund unable-to-act time if the downtime window was longer than the AF/UI timer
 	_countLostPolyglots(time) {
-		const unableToActTime = this.unableToAct.getDowntimes().filter(downtime => Math.max(0, downtime.end - downtime.start) >= ASTRAL_UMBRAL_DURATION).reduce((duration, downtime) => duration + Math.max(0, downtime.end - downtime.start), 0)
+		const unableToActTime = this.unableToAct.getDowntimes()
+			.filter(downtime => Math.max(0, downtime.end - downtime.start) >= ASTRAL_UMBRAL_DURATION)
+			.reduce((duration, downtime) => duration + Math.max(0, downtime.end - downtime.start), 0)
 		return Math.floor((time - unableToActTime)/ENOCHIAN_DURATION_REQUIRED)
 	}
 

--- a/src/parser/jobs/brd/modules/AlwaysBeCasting.ts
+++ b/src/parser/jobs/brd/modules/AlwaysBeCasting.ts
@@ -76,7 +76,10 @@ export default class AlwaysBeCasting extends CoreAlwaysBeCasting {
 
 		const uptime = this.gcd.gcds.reduce((acc, gcd) => {
 			const duration = this.gcd._getGcdLength(gcd)
-			const downtime = this.downtime.getDowntime(gcd.timestamp, gcd.timestamp + duration)
+			const downtime = this.downtime.getDowntime(
+				gcd.timestamp,
+				Math.min(gcd.timestamp + duration, this.parser.eventTimeOffset + this.parser.pull.duration)
+			)
 			// Ignore GCDs while muse / paeon were up
 			if (this.isArmyBuffActive(gcd.timestamp)) {
 				return acc

--- a/src/parser/jobs/brd/modules/PitchPerfect.js
+++ b/src/parser/jobs/brd/modules/PitchPerfect.js
@@ -422,7 +422,11 @@ export default class PitchPerfect extends Module {
 	}
 
 	_isAMissedPP(lastPPInWM, missedPPGracePeriod) {
-		return lastPPInWM.timeLeftOnSong > missedPPGracePeriod && !this.downtime.getDowntime(lastPPInWM.timestamp, lastPPInWM.timestamp + missedPPGracePeriod)
+		const downtime = this.downtime.getDowntime(
+			lastPPInWM.timestamp,
+			Math.min(lastPPInWM.timestamp + missedPPGracePeriod, this.parser.eventTimeOffset + this.parser.pull.duration)
+		)
+		return lastPPInWM.timeLeftOnSong > missedPPGracePeriod && !downtime
 	}
 
 	_cleanUpPPs() {
@@ -464,7 +468,11 @@ export default class PitchPerfect extends Module {
 				stacksUsedInCurrentWM = 0
 				castsInCurrentWM = []
 			}
-			if (this.downtime.isDowntime(pp.lastTickOnEnemy + DOT_TICK_FREQUENCY + ANIMATION_LOCK)) {
+			const nextPPTick = pp.lastTickOnEnemy + DOT_TICK_FREQUENCY + ANIMATION_LOCK
+			if (
+				nextPPTick > this.parser.eventTimeOffset + this.parser.pull.duration
+				|| this.downtime.isDowntime(nextPPTick)
+			) {
 				this._ppEvents.splice(this._ppEvents.indexOf(pp), 1)
 			}
 

--- a/src/parser/jobs/brd/modules/SongUptime.js
+++ b/src/parser/jobs/brd/modules/SongUptime.js
@@ -118,7 +118,10 @@ export default class SongUptime extends Module {
 		let tolerance = SETUP_TIME
 
 		this._songCastEvents.forEach(c => {
-			if (this.downtime.isDowntime(c.timestamp + SONG_DURATION)) {
+			if (this.downtime.isDowntime(Math.min(
+				c.timestamp + SONG_DURATION,
+				this.parser.eventTimeOffset + this.parser.pull.duration,
+			))) {
 				tolerance += SETUP_TIME
 			}
 		})

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -197,14 +197,10 @@ export default class DirtyDancing extends Module {
 		dance.end = finisher.timestamp
 
 		// Count dance as dirty if we didn't get the expected finisher, and the fight wouldn't have ended or been in an invuln window before we could have
-		if (finisher.ability.guid !== dance.expectedFinishId) {
-			if (dance.expectedEndTime <= this.parser.eventTimeOffset + this.parser.pull.duration) {
-				dance.dirty = true
-			} else {
-				this.addTimestampHook(dance.expectedEndTime, ({timestamp}) => {
-					dance.dirty = !this.invuln.isInvulnerable('all', timestamp)
-				})
-			}
+		if (finisher.ability.guid !== dance.expectedFinishId && dance.expectedEndTime <= this.parser.eventTimeOffset + this.parser.pull.duration) {
+			this.addTimestampHook(dance.expectedEndTime, ({timestamp}) => {
+				dance.dirty = !this.invuln.isInvulnerable('all', timestamp)
+			})
 		}
 
 		// If the finisher didn't hit anything, and something could've been, ding it.

--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.js
@@ -247,7 +247,10 @@ export default class BloodOfTheDragon extends Module {
 			lifeWindow.buffsInDelayWindow = {}
 
 			// downtime overlap
-			lifeWindow.dtOverlapTime = this._intersectsDowntime((lifeWindow.start + ACTIONS.HIGH_JUMP.cooldown * 1000))
+			lifeWindow.dtOverlapTime = this._intersectsDowntime(Math.min(
+				lifeWindow.start + ACTIONS.HIGH_JUMP.cooldown * 1000,
+				this.parser.eventTimeOffset + this.parser.pull.duration,
+			))
 
 			// flag for last life window
 			lifeWindow.isLast = lifeWindow.start + lifeWindow.duration > this.parser.fight.end_time

--- a/src/parser/jobs/drg/modules/Drift.tsx
+++ b/src/parser/jobs/drg/modules/Drift.tsx
@@ -68,7 +68,8 @@ export default class Drift extends Module {
 		const window = this.currentWindows[actionId]
 		window.end = event.timestamp
 
-		const plannedUseTime = window.start + cooldown
+		// Cap at this event's timestamp, as if we used before it came off CD, it's certainly driftless! (ms-range negative drift is common)
+		const plannedUseTime = Math.min(window.start + cooldown, event.timestamp)
 		this.debug(this.parser.formatTimestamp(plannedUseTime))
 
 		let expectedUseTime = 0

--- a/src/parser/jobs/pld/modules/FightOrFlight.tsx
+++ b/src/parser/jobs/pld/modules/FightOrFlight.tsx
@@ -5,7 +5,7 @@ import {RotationTable, RotationTableEntry} from 'components/ui/RotationTable'
 import {getDataBy} from 'data'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-import {CastEvent} from 'fflogs'
+import {BuffEvent, CastEvent} from 'fflogs'
 import _ from 'lodash'
 import Module, {dependency} from 'parser/core/Module'
 import {Invulnerability} from 'parser/core/modules/Invulnerability'
@@ -69,8 +69,6 @@ const EXCLUDED_GCD_IDS = [
 	ACTIONS.CONFITEOR.id,
 ]
 
-const FOF_DURATION_MILLIS = STATUSES.FIGHT_OR_FLIGHT.duration * 1000
-
 class FightOrFlightState {
 	start: number | null = null
 	lastGoringGcd: number | null = null
@@ -79,7 +77,7 @@ class FightOrFlightState {
 	circleOfScornCounter: number = 0
 	spiritsWithinCounter: number = 0
 	interveneCounter: number = 0
-	isRushed: boolean = false
+	goringTooCloseCounter: number = 0
 }
 
 class FightOrFlightErrorResult {
@@ -128,11 +126,6 @@ export default class FightOrFlight extends Module {
 
 		if (actionId === ACTIONS.FIGHT_OR_FLIGHT.id) {
 			this.fofState.start = event.timestamp
-
-			const endOfWindow = event.timestamp + FOF_DURATION_MILLIS
-			this.fofState.isRushed = endOfWindow >= this.parser.fight.end_time
-				|| this.invuln.isInvulnerable('all', endOfWindow)
-				|| this.invuln.isUntargetable('all', endOfWindow)
 		}
 
 		if (this.fofState.start) {
@@ -148,8 +141,8 @@ export default class FightOrFlight extends Module {
 				this.fofState.goringCounter++
 
 				if (this.fofState.lastGoringGcd !== null) {
-					if (this.fofState.gcdCounter - this.fofState.lastGoringGcd < CONSTANTS.GORING.MINIMUM_DISTANCE && !this.fofState.isRushed) {
-						this.fofErrorResult.goringTooCloseCounter++
+					if (this.fofState.gcdCounter - this.fofState.lastGoringGcd < CONSTANTS.GORING.MINIMUM_DISTANCE) {
+						this.fofState.goringTooCloseCounter++
 					}
 				}
 				this.fofState.lastGoringGcd = this.fofState.gcdCounter
@@ -173,13 +166,20 @@ export default class FightOrFlight extends Module {
 		}
 	}
 
-	private onRemoveFightOrFlight() {
-		if (!this.fofState.isRushed) {
+	private onRemoveFightOrFlight(event: BuffEvent) {
+		// If the enemy is untargetable at the end of FoF, the player was rushed - forgive missed hits.
+		// While technically this will never be called beyond the end of the fight, let's be really sure
+		const wasRushed = event.timestamp >= this.parser.eventTimeOffset + this.parser.pull.duration
+			|| this.invuln.isInvulnerable('all', event.timestamp)
+			|| this.invuln.isUntargetable('all', event.timestamp)
+
+		if (!wasRushed) {
 			this.fofErrorResult.missedGcds += Math.max(0, CONSTANTS.GCD.EXPECTED - this.fofState.gcdCounter)
 			this.fofErrorResult.missedGorings += Math.max(0, CONSTANTS.GORING.EXPECTED - this.fofState.goringCounter)
 			this.fofErrorResult.missedSpiritWithins += Math.max(0, CONSTANTS.SPIRITS_WITHIN.EXPECTED - this.fofState.spiritsWithinCounter)
 			this.fofErrorResult.missedCircleOfScorns += Math.max(0, CONSTANTS.CIRCLE_OF_SCORN.EXPECTED - this.fofState.circleOfScornCounter)
 			this.fofErrorResult.missedIntervenes += Math.max(0, CONSTANTS.INTERVENE.EXPECTED - this.fofState.interveneCounter)
+			this.fofErrorResult.goringTooCloseCounter += this.fofState.goringTooCloseCounter
 		}
 
 		this.fofState = new FightOrFlightState()

--- a/src/parser/jobs/pld/modules/Requiescat.tsx
+++ b/src/parser/jobs/pld/modules/Requiescat.tsx
@@ -104,11 +104,17 @@ export default class Requiescat extends Module {
 			const reqState = new RequiescatState(event.timestamp)
 			const reqEnd = event.timestamp + REQUIESCAT_DURATION_MILLIS
 
-			const isBossInvulnBeforeEnd = this.invuln.isUntargetable('all', reqEnd)
-				|| this.invuln.isInvulnerable('all', reqEnd)
+			if (reqEnd >= this.parser.fight.end_time) {
+				// If the requiescat overshoots the end of the fight, we know ahead of time it'll be a rush
+				reqState.isRushing = true
+			} else {
+				// Otherwise, wait for the expected end time and check invuln status
+				this.addTimestampHook(reqEnd, ({timestamp}) => {
+					reqState.isRushing = this.invuln.isUntargetable('all', timestamp)
+						|| this.invuln.isInvulnerable('all', timestamp)
+				})
+			}
 
-			reqState.isRushing = (reqEnd >= this.parser.fight.end_time)
-				|| isBossInvulnBeforeEnd
 			this.requiescats.push(reqState)
 		}
 

--- a/src/parser/jobs/smn/modules/Ruin2.js
+++ b/src/parser/jobs/smn/modules/Ruin2.js
@@ -18,7 +18,6 @@ export default class Ruin2 extends Module {
 	static handle = 'ruin2'
 	static dependencies = [
 		'combatants',
-		'gcd',
 		'invuln',
 		'pets',
 		'suggestions',
@@ -60,8 +59,8 @@ export default class Ruin2 extends Module {
 		// Calc the time in the GCD that the boss can't be targeted - R2ing before an invuln to prevent an R3 cancel is good
 		const invulnTime = this.invuln.getUntargetableUptime(
 			'all',
+			this._lastGcd.timestamp,
 			event.timestamp,
-			event.timestamp + this.gcd.getEstimate(),
 		)
 
 		if (


### PR DESCRIPTION
Title. Tin. Etc.

This PR audits every call to `downtime`, `unableToAct`, and `invuln` that I could find, fixing any logic that relied on their ability to "see the future" due to normalisation.

I've also put in some errors if anything else tries to do it, which'll hopefully be caught by sentry if I missed something.

I'm not going to pretend I know the intricacies of every job. I took care to avoid changing logic too much, but it's impossible to avoid in some cases. I may well have broken your job. Please check the code for your modules!

I'll be adding some comments below shortly.