### PR TITLE
Port UnableToAct to Analyser

### DIFF
--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -653,6 +653,24 @@ class Parser {
 		return pet && pet.petOwner === playerId
 	}
 
+	/**
+	 * Convert an fflogs event timestamp for the current pull to an epoch timestamp
+	 * compatible with logic running in the new analysis system. Do ***not*** use this
+	 * outside the above scenario.
+	 * @deprecated
+	 */
+	fflogsToEpoch = (timestamp: number) =>
+		timestamp - this.eventTimeOffset + this.pull.timestamp
+
+	/**
+	 * Convert a unix epoch timestamp to a report-relative timestamp compatible
+	 * with logic running in the old analysis system.. Do ***not*** use this
+	 * outside the above scenario.
+	 * @deprecated
+	 */
+	epochToFflogs = (timestamp: number) =>
+		timestamp - this.pull.timestamp + this.eventTimeOffset
+
 	formatTimestamp(timestamp: number, secondPrecision?: number) {
 		return this.formatDuration(timestamp - this.fight.start_time, secondPrecision)
 	}

--- a/src/parser/core/modules/Downtime.tsx
+++ b/src/parser/core/modules/Downtime.tsx
@@ -2,7 +2,7 @@ import Module, {dependency} from 'parser/core/Module'
 import React from 'react'
 import {Invulnerability} from './Invulnerability'
 import {Timeline, SimpleItem} from './Timeline'
-import UnableToAct from './UnableToAct'
+import {UnableToAct} from './UnableToAct'
 
 interface DowntimeWindow {
 	start: number,
@@ -22,8 +22,14 @@ export default class Downtime extends Module {
 
 	private internalDowntime(start = 0, end = this.parser.currentTimestamp) {
 		// Get all the downtime from both unableToAct and invuln, and sort it
-		const downtimePeriods = [
-			...this.unableToAct.getDowntimes(start, end),
+		const downtimePeriods: DowntimeWindow[] = [
+			...this.unableToAct.getWindows({
+				start: this.parser.fflogsToEpoch(start),
+				end: this.parser.fflogsToEpoch(end),
+			}).map(window => ({
+				start: this.parser.epochToFflogs(window.start),
+				end: this.parser.epochToFflogs(window.end),
+			})),
 			...this.invuln.getInvulns('all', start, end, 'untargetable'),
 		].sort((a, b) => a.start - b.start)
 

--- a/src/parser/core/modules/UnableToAct/UnableToAct.tsx
+++ b/src/parser/core/modules/UnableToAct/UnableToAct.tsx
@@ -1,96 +1,181 @@
-import {AbilityEvent} from 'fflogs'
-import Module, {dependency} from 'parser/core/Module'
-import {CompleteEvent} from 'parser/core/Parser'
+import {Event, Events} from 'event'
+import {Analyser} from 'parser/core/Analyser'
+import {filter, oneOf} from 'parser/core/filter'
+import {dependency} from 'parser/core/Injectable'
 import React from 'react'
-import {SimpleRow, Timeline, SimpleItem} from '../Timeline'
+import {Actor} from 'report'
+import {SimpleItem, SimpleRow, Timeline} from '../Timeline'
 import {STATUS_IDS} from './statusIds'
 
-interface UTADowntime {
+export interface Window {
+	/** Number of events currently causing inability to act. */
 	depth: number
+	/** The start time of this window. */
 	start: number
+	/** The end time of this window. If `depth > 0`, will be `Infinity`. */
 	end: number
-	applyEvents: AbilityEvent[]
-	removeEvents: Array<AbilityEvent | CompleteEvent>
+	/** Events causing inability to act. */
+	applyEvents: Array<Events['statusApply']>
+	/** Events counteracting inability to act. */
+	removeEvents: Array<Events['statusRemove'] | Events['complete']>
 }
 
-export default class UnableToAct extends Module {
+export interface WindowFilter {
+	/** Actor ID to retrieve windows for. */
+	actorId?: Actor['id']
+	/** Omit windows closed prior to this timestamp. */
+	start?: number
+	/** Omit windows opened after this timestamp. */
+	end?: number
+}
+
+export class UnableToAct extends Analyser {
 	static handle = 'unableToAct'
 	static debug = false
 
-	@dependency private readonly timeline!: Timeline
+	@dependency private timeline!: Timeline
 
-	private downtimes: UTADowntime[] = []
-	private current?: UTADowntime
+	private actorWindows = new Map<Actor['id'], Window[]>()
 
-	protected init() {
-		const filter = {abilityId: STATUS_IDS, to: 'player'} as const
-		this.addEventHook('applybuff', filter, this.onApply)
-		this.addEventHook('applydebuff', filter, this.onApply)
-		this.addEventHook('removebuff', filter, this.onRemove)
-		this.addEventHook('removedebuff', filter, this.onRemove)
+	/**
+	 * Get unable to act windows for the specified actor that intersect with the
+	 * provided range. Defaults to all windows for the currently parsed actor.
+	 */
+	getWindows({
+		actorId = this.parser.actor.id,
+		start = this.parser.pull.timestamp,
+		end = this.parser.currentEpochTimestamp,
+	}: WindowFilter = {}) {
+		return this.getActorWindows(actorId)
+			.filter(window => window.end > start && window.start < end)
+	}
+
+	/**
+	 * Get the duration that specified actor was unable to act within the provided
+	 * range. Defaults to total time unable to act for the currently parsed actor.
+	 */
+	getDuration({
+		actorId = this.parser.actor.id,
+		start = this.parser.pull.timestamp,
+		end = this.parser.currentEpochTimestamp,
+	}: WindowFilter = {}) {
+		return this.getWindows({actorId, start, end})
+			.reduce((duration, window) => duration + Math.min(window.end, end) - Math.max(window.start, start), 0)
+	}
+
+	/**
+	 * Check if the specified actor was unable to act at the provided timestamp.
+	 * Defaults to checking the parsed actor at the current timestamp.
+	 */
+	isUnableToAct({
+		actorId = this.parser.actor.id,
+		timestamp = this.parser.currentEpochTimestamp,
+	}: {
+		actorId?: Actor['id']
+		timestamp?: number
+	} = {}) {
+		return this.getWindows({
+			actorId,
+			start: timestamp,
+			end: timestamp,
+		}).length > 0
+	}
+
+	initialise() {
+		const statusFilter = filter<Event>().status(oneOf(...STATUS_IDS))
+		this.addEventHook(statusFilter.type('statusApply'), this.onApply)
+		this.addEventHook(statusFilter.type('statusRemove'), this.onRemove)
 
 		this.addEventHook('complete', this.onComplete)
 	}
 
-	private onApply(event: AbilityEvent) {
-		const downtime: UTADowntime = this.current || {
-			depth: 0,
-			start: event.timestamp,
-			end: Infinity,
-			applyEvents: [],
-			removeEvents: [],
+	private onApply(event: Events['statusApply']) {
+		const windows = this.getActorWindows(event.target)
+
+		// Get the latest window, building a new one if there is none, or the previous is complete
+		let window: Window | undefined = windows[windows.length - 1]
+		if (window == null || window.depth <= 0) {
+			window = {
+				depth: 0,
+				start: event.timestamp,
+				end: Infinity,
+				applyEvents: [],
+				removeEvents: [],
+			}
+			windows.push(window)
 		}
 
-		downtime.depth++
-		downtime.applyEvents.push(event)
-		this.current = downtime
+		window.depth++
+		window.applyEvents.push(event)
 	}
 
-	private onRemove(event: AbilityEvent | CompleteEvent) {
-		const downtime = this.current
-		if (!downtime) { return }
+	private onRemove(event: Events['statusRemove']) {
+		const windows = this.getActorWindows(event.target)
 
-		downtime.depth--
-		downtime.removeEvents.push(event)
-
-		if (downtime.depth <= 0) {
-			downtime.end = event.timestamp
-			this.downtimes.push(downtime)
-			this.current = undefined
+		// Make sure nothing's gone wrong
+		const window: Window | undefined = windows[windows.length - 1]
+		if (window == null || window.depth <= 0) {
+			throw new Error('No valid UTA window to close.')
 		}
+
+		this.decrementWindow(window, event)
 	}
 
-	private onComplete(event: CompleteEvent) {
-		// If there's a current downtime, just force clear it
-		if (this.current) {
-			for (let i = this.current.depth; i > 0; i--) {
-				this.onRemove(event)
+	private onComplete(event: Events['complete']) {
+		// Clear out any open windows
+		for (const windows of this.actorWindows.values()) {
+			if (windows.length === 0) { continue }
+			const window = windows[windows.length - 1]
+			while (window.depth > 0) {
+				this.decrementWindow(window, event)
 			}
 		}
 
 		this.debug(() => this.renderDebugTimelineData())
 	}
 
+	private getActorWindows(actorId: Actor['id']) {
+		let windows = this.actorWindows.get(actorId)
+		if (windows == null) {
+			windows = []
+			this.actorWindows.set(actorId, windows)
+		}
+		return windows
+	}
+
+	private decrementWindow(
+		window: Window,
+		event: Events['statusRemove'] | Events['complete'],
+	) {
+		window.depth--
+		window.removeEvents.push(event)
+		if (window.depth <= 0) {
+			window.end = event.timestamp
+		}
+	}
+
 	private renderDebugTimelineData() {
-		const startTime = this.parser.eventTimeOffset
-		const row = this.timeline.addRow(new SimpleRow({
-			label: 'UTA Debug',
+		const startTime = this.parser.pull.timestamp
+		const parentRow = this.timeline.addRow(new SimpleRow({
+			label: 'UTA2 Debug',
 			order: -Infinity,
 		}))
 
-		this.downtimes.forEach(downtime => {
-			row.addItem(new SimpleItem({
-				start: downtime.start - startTime,
-				end: downtime.end - startTime,
-				content: <div style={{width: '100%', height: '100%', backgroundColor: '#aaf'}}/>,
+		for (const [actorId, windows] of this.actorWindows.entries()) {
+			const actor = this.parser.pull.actors.find(actor => actor.id === actorId)
+			const row = parentRow.addRow(new SimpleRow({
+				label: actor != null
+					? `${actor.name} (${actorId})`
+					: actorId,
 			}))
-		})
-	}
 
-	getDowntimes(start = 0, end = this.parser.currentTimestamp) {
-		if (end > this.parser.currentTimestamp) {
-			throw new Error('Invariant: Tried to retrieve UTA window beyond current analysis position.')
+			for (const window of windows) {
+				row.addItem(new SimpleItem({
+					start: window.start - startTime,
+					end: window.end - startTime,
+					content: <div style={{width: '100%', height: '100%', backgroundColor: '#aaf'}}/>,
+				}))
+			}
 		}
-		return this.downtimes.filter(downtime => downtime.end > start && downtime.start < end)
 	}
 }

--- a/src/parser/core/modules/UnableToAct/index.ts
+++ b/src/parser/core/modules/UnableToAct/index.ts
@@ -1,2 +1,2 @@
-import UnableToAct from './UnableToAct'
-export default UnableToAct
+export {UnableToAct} from './UnableToAct'
+export type {Window, WindowFilter} from './UnableToAct'

--- a/src/parser/core/modules/index.js
+++ b/src/parser/core/modules/index.js
@@ -28,7 +28,7 @@ import {Statistics} from './Statistics'
 import Statuses from './Statuses'
 import Suggestions from './Suggestions'
 import {Timeline} from './Timeline'
-import UnableToAct from './UnableToAct'
+import {UnableToAct} from './UnableToAct'
 import Weaving from './Weaving'
 
 export default [

--- a/src/parser/jobs/ast/modules/SleeveDraw.js
+++ b/src/parser/jobs/ast/modules/SleeveDraw.js
@@ -45,11 +45,15 @@ export default class SleeveDraw extends Module {
 		const firstOpportunity = this._lastUse + ACTIONS.SLEEVE_DRAW.cooldown*1000
 		const _held = event.timestamp - firstOpportunity
 		if (_held > 0) {
-			const downtimes = this.unableToAct.getDowntimes(
-				firstOpportunity,
-				Math.min(firstOpportunity + EXCUSED_HOLD_DEFAULT, event.timestamp),
-			)
-			const firstEnd = downtimes.length ? downtimes[0].end : firstOpportunity
+			const downtimes = this.unableToAct.getWindows({
+				start: this.parser.fflogsToEpoch(firstOpportunity),
+				end: this.parser.fflogsToEpoch(
+					Math.min(firstOpportunity + EXCUSED_HOLD_DEFAULT, event.timestamp)
+				),
+			})
+			const firstEnd = downtimes.length
+				? this.parser.epochToFflogs(downtimes[0].end)
+				: firstOpportunity
 			this._totalHeld += _held
 			this._excusedHeld += EXCUSED_HOLD_DEFAULT + (firstEnd - firstOpportunity)
 		}

--- a/src/parser/jobs/blm/modules/NotCasting.js
+++ b/src/parser/jobs/blm/modules/NotCasting.js
@@ -99,13 +99,18 @@ export default class NotCasting extends Module {
 		const gcdLength = this.gcd.getEstimate(true)
 		//finish up
 		this._stopAndSave(event.timestamp)
+		// TODO: The following two filters can probably be replaced with one filter with the downtime module.
 		//filter out invuln periods
 		this._noCastWindows.history = this._noCastWindows.history.filter(windows => {
 			return this.invuln.getInvulns('all', windows.start, windows.stop).length === 0
 		})
 		// Filter out periods where you got stunned, etc
 		this._noCastWindows.history = this._noCastWindows.history.filter(windows => {
-			return this.unableToAct.getDowntimes(windows.start, windows.stop).length === 0
+			const duration = this.unableToAct.getDuration({
+				start: this.parser.fflogsToEpoch(windows.start),
+				end: this.parser.fflogsToEpoch(windows.stop),
+			})
+			return duration === 0
 		})
 		//filter out negative durations
 		this._noCastWindows.history = this._noCastWindows.history.filter(windows => windows.stop - windows.start > gcdLength + GCD_ERROR_OFFSET)


### PR DESCRIPTION
That diff is... gnarly. git pls. It's basically a total rewrite, probably better looking at it without the diff.

This PR:
- "Ports" `UnableToAct` to the new analysis system
- Adds a few nice-to-have APIs to it for direct access w/o going through downtime
- Adds some deprecated-out-of-the-gate functions to the parser to assist with converting timestamps between the two systems.