### PR TITLE
Update SCH for 5.5 support

### DIFF
--- a/src/parser/jobs/sch/index.js
+++ b/src/parser/jobs/sch/index.js
@@ -18,7 +18,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.4',
+		to: '5.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.LIMA, role: ROLES.MAINTAINER},
@@ -27,6 +27,11 @@ export default new Meta({
 		{user: CONTRIBUTORS.NIV, role: ROLES.DEVELOPER},
 	],
 	changelog: [{
+		date: new Date('2020-4-13'),
+		Changes: () => <>Support for 5.5 added – 100 mp cost down on succor won't hurt us!.</>,
+		contributors: [CONTRIBUTORS.NONO],
+	},
+	{
 		date: new Date('2020-12-7'),
 		Changes: () => <>Support for 5.4 added – potency changes shouldn't affect analysis anyway.</>,
 		contributors: [CONTRIBUTORS.NONO],

--- a/src/parser/jobs/sch/index.js
+++ b/src/parser/jobs/sch/index.js
@@ -27,7 +27,7 @@ export default new Meta({
 		{user: CONTRIBUTORS.NIV, role: ROLES.DEVELOPER},
 	],
 	changelog: [{
-		date: new Date('2020-4-13'),
+		date: new Date('2021-04-13'),
 		Changes: () => <>Support for 5.5 added – 100 mp cost down on succor won't hurt us!.</>,
 		contributors: [CONTRIBUTORS.NONO],
 	},


### PR DESCRIPTION
I mean, it's 100 mp cost. We don't even do mp-based analysis on SCH.