### PR TITLE
Add patch 5.5

### DIFF
--- a/src/data/ACTIONS/layers/index.ts
+++ b/src/data/ACTIONS/layers/index.ts
@@ -4,6 +4,7 @@ import {patch501} from './patch5.01'
 import {patch510} from './patch5.1'
 import {patch530} from './patch5.3'
 import {patch540} from './patch5.4'
+import {patch550} from './patch5.5'
 
 export const layers: Array<Layer<ActionRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -14,4 +15,5 @@ export const layers: Array<Layer<ActionRoot>> = [
 	patch510,
 	patch530,
 	patch540,
+	patch550,
 ]

--- a/src/data/ACTIONS/layers/patch5.5.ts
+++ b/src/data/ACTIONS/layers/patch5.5.ts
@@ -1,0 +1,9 @@
+import {Layer} from 'data/layer'
+import {ActionRoot} from '../root'
+
+// tslint:disable:no-magic-numbers
+
+export const patch550: Layer<ActionRoot> = {
+	patch: '5.5',
+	data: {},
+}

--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -85,6 +85,11 @@ const patchData = {
 			[GameEdition.GLOBAL]: 1607418000, // 08/12/20 09:00:00 GMT
 		},
 	},
+	'5.5': {
+		date: {
+			[GameEdition.GLOBAL]: 1618304400, // 13/04/21 09:00:00 GMT
+		},
+	},
 }
 
 export type PatchNumber = keyof typeof patchData

--- a/src/data/STATUSES/layers/index.ts
+++ b/src/data/STATUSES/layers/index.ts
@@ -4,6 +4,7 @@ import {patch505} from './patch5.05'
 import {patch510} from './patch5.1'
 import {patch530} from './patch5.3'
 import {patch540} from './patch5.4'
+import {patch550} from './patch5.5'
 
 export const layers: Array<Layer<StatusRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -13,4 +14,5 @@ export const layers: Array<Layer<StatusRoot>> = [
 	patch510,
 	patch530,
 	patch540,
+	patch550,
 ]

--- a/src/data/STATUSES/layers/patch5.5.ts
+++ b/src/data/STATUSES/layers/patch5.5.ts
@@ -1,0 +1,7 @@
+import {Layer} from 'data/layer'
+import {StatusRoot} from '../root'
+
+export const patch550: Layer<StatusRoot> = {
+	patch: '5.5',
+	data: {},
+}


### PR DESCRIPTION
Layers are empty however DRG and WAR need the actions layer, and MNK needs the statuses one. SCH doesn't appear to use the mpCost so that won't need a layer update I guess.