### PR TITLE
Patch 5.5 support for MNK

### DIFF
--- a/src/data/STATUSES/layers/patch5.5.ts
+++ b/src/data/STATUSES/layers/patch5.5.ts
@@ -3,5 +3,8 @@ import {StatusRoot} from '../root'
 
 export const patch550: Layer<StatusRoot> = {
 	patch: '5.5',
-	data: {},
+	data: {
+		// MNK 5.5 status updates
+		RIDDLE_OF_EARTH: {duration: 10, stacksApplied: 3},
+	},
 }

--- a/src/parser/jobs/mnk/index.tsx
+++ b/src/parser/jobs/mnk/index.tsx
@@ -18,7 +18,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.4',
-		to: '5.4',
+		to: '5.5',
 	},
 
 	contributors: [
@@ -26,6 +26,13 @@ export default new Meta({
 		{user: CONTRIBUTORS.LHEA, role: ROLES.DEVELOPER},
 	],
 	changelog: [
+		{
+			date: new Date('2021-04-13'),
+			Changes: () => <>
+				Update MNK support for patch 5.5, fix Twin clipping bug, and allow ST in opener outside of RoF.
+			</>,
+			contributors: [CONTRIBUTORS.ACCHAN],
+		},
 		{
 			date: new Date('2020-12-08'),
 			Changes: () => <>

--- a/src/parser/jobs/mnk/modules/RiddleOfFire.tsx
+++ b/src/parser/jobs/mnk/modules/RiddleOfFire.tsx
@@ -192,7 +192,7 @@ export default class RiddleOfFire extends Module {
 				unless you need to hold a charge for strategic purposes.
 			</Trans>,
 			tiers: {
-				1: SEVERITY.MINOR,	// Always a minor suggestion
+				2: SEVERITY.MINOR,	// Always a minor suggestion, however we start from 2 to forgive ST on pull
 			},
 			value: riddlesWithOneTackle,
 			why: <Trans id="mnk.rof.suggestions.tackle.why">


### PR DESCRIPTION
Plus bug fixes raised in fb-monk on Discord. ST pre-RoF in opener is largely unavoidable so bumping the trigger to 2 bad ST's over the fight. Twin is a bit more complex, a user finished a combo, hit 6SS, then LB, which forced their next combo to refresh Twin. The timing was correct but the GCD count wasn't, so I've converted the module to ding on any refresh above 6s remaining on the status.