### PR TITLE
Remove SwiftCast from tracked CDs

### DIFF
--- a/src/parser/jobs/rdm/index.js
+++ b/src/parser/jobs/rdm/index.js
@@ -31,6 +31,11 @@ export default new Meta({
 
 	changelog: [
 		{
+			date: new Date('2021-04-14'),
+			Changes: () => <>Removed Swift Cast from General CD Usage as it's no longer suggested to use on CD</>,
+			contributors: [CONTRIBUTORS.LEYLIA],
+		},
+		{
 			date: new Date('2021-02-11'),
 			Changes: () => <>Severity for all broken melee combos is now Major</>,
 			contributors: [CONTRIBUTORS.LEYLIA],

--- a/src/parser/jobs/rdm/modules/GeneralCDDowntime.ts
+++ b/src/parser/jobs/rdm/modules/GeneralCDDowntime.ts
@@ -15,10 +15,6 @@ export default class GeneralCDDowntime extends CooldownDowntime {
 			allowedAverageDowntime: 4000,
 		},
 		{
-			cooldowns: [ACTIONS.SWIFTCAST],
-			firstUseOffset: 31000,
-		},
-		{
 			cooldowns: [ACTIONS.MANAFICATION],
 			firstUseOffset: 17500,
 		},


### PR DESCRIPTION
It's no longer suggested to use SwiftCast on CD for a RDM so removing it from the General CD tracking list.