### PR TITLE
MNK - assume 100% uptime when fist is unknown

### DIFF
--- a/src/parser/jobs/mnk/modules/Fists.tsx
+++ b/src/parser/jobs/mnk/modules/Fists.tsx
@@ -185,7 +185,7 @@ export default class Fists extends Module {
 				columns: [
 					this.getFistName(id, unknownFist),
 					this.parser.formatDuration(value),
-					this.getFistUptimePercent(id) + '%',
+					this.getFistUptimePercent(id, unknownFist) + '%',
 				] as const,
 			}
 		}).filter(datum => datum.value > 0)
@@ -202,8 +202,13 @@ export default class Fists extends Module {
 			.reduce((total, current) => total + current.gcdCounter, 0)
 	}
 
-	getFistUptimePercent(fistId: number): string {
+	getFistUptimePercent(fistId: number, unknownFist: boolean): string {
 		const statusUptime = this.entityStatuses.getStatusUptime(fistId, this.combatants.getEntities())
+
+		if (unknownFist && statusUptime === 0) {
+			// No status events for this fist, assume 100% uptime
+			return '100'
+		}
 
 		return ((statusUptime / this.parser.currentDuration) * 100).toFixed(2)
 	}


### PR DESCRIPTION
Fixes this "bug"; since it's already assuming flame fisties for the full duration we might as well call it 100% uptime too.

![image](https://user-images.githubusercontent.com/65056303/114859347-9f794400-9db8-11eb-8d6a-be6739398d53.png)
