### PR TITLE
Mark SMN patch 5.5 support.

### DIFF
--- a/src/parser/jobs/smn/index.js
+++ b/src/parser/jobs/smn/index.js
@@ -22,7 +22,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.1',
-		to: '5.4',
+		to: '5.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.ACKWELL, role: ROLES.MAINTAINER},


### PR DESCRIPTION
DoT nerf suspiciously missing from patch, but that wouldn't have affected analysis anyway.