### PR TITLE
Bump PLD support to 5.5

### DIFF
--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -18,7 +18,7 @@ export default new Meta({
 	</>,
 	supportedPatches: {
 		from: '5.0',
-		to: '5.4',
+		to: '5.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.MIKEMATRIX, role: ROLES.MAINTAINER},


### PR DESCRIPTION
PLD is unchanged in 5.5, so no logic changes are needed.