### PR TITLE
Port invulnerability to new event system, part 1

### DIFF
--- a/src/parser/bosses/e8/modules/Invulnerability2.ts
+++ b/src/parser/bosses/e8/modules/Invulnerability2.ts
@@ -1,0 +1,11 @@
+import {
+	ActorsConfig,
+	Invulnerability as CoreInvulnerability,
+} from 'parser/core/modules/Invulnerability2'
+
+export class Invulnerability extends CoreInvulnerability {
+	protected actorConfig: ActorsConfig = [
+		{kind: {legacyFflogs: '11633'}, exclude: true}, // Luminous aether (savage)
+		{kind: {legacyFflogs: '11765'}, exclude: true}, // Luminous aether (normal)
+	]
+}

--- a/src/parser/bosses/e8/modules/index.ts
+++ b/src/parser/bosses/e8/modules/index.ts
@@ -1,3 +1,4 @@
 import {Invulnerability} from './Invulnerability'
+import {Invulnerability as Invulnerability2} from './Invulnerability2'
 
-export default [Invulnerability]
+export default [Invulnerability, Invulnerability2]

--- a/src/parser/bosses/exVaris/modules/Invulnerability2.ts
+++ b/src/parser/bosses/exVaris/modules/Invulnerability2.ts
@@ -1,0 +1,20 @@
+import {
+	ActorsConfig,
+	Check,
+	Invulnerability as CoreInvulnerability,
+} from 'parser/core/modules/Invulnerability2'
+
+export class Invulnerability extends CoreInvulnerability {
+	protected actorConfig: ActorsConfig = [
+		// Bladesblood - Is overkilled but does not die.
+		{kind: {legacyFflogs: '11595'}, checks: [Check.TARGETABLE, Check.OVERKILL]},
+		// Magitek turret I - Dies, but never becomes targetable.
+		{kind: {legacyFflogs: '11596'}, checks: [Check.FIRST_TARGETED, Check.DEATH]},
+		// Magitek Turret II - actually not targetable, they cast the tether tank busters
+		{kind: {legacyFflogs: '11597'}, exclude: true},
+		// Confines of memory - die too quick to be meaningfully fixable
+		{kind: {legacyFflogs: '11598'}, exclude: true},
+		// Gunshield - No targetable updates nor death - use fallback checks on all fronts.
+		{kind: {legacyFflogs: '11692'}, checks: [Check.FIRST_TARGETED, Check.OVERKILL]},
+	]
+}

--- a/src/parser/bosses/exVaris/modules/Invulnerability2.ts
+++ b/src/parser/bosses/exVaris/modules/Invulnerability2.ts
@@ -8,8 +8,6 @@ export class Invulnerability extends CoreInvulnerability {
 	protected actorConfig: ActorsConfig = [
 		// Bladesblood - Is overkilled but does not die.
 		{kind: {legacyFflogs: '11595'}, checks: [Check.TARGETABLE, Check.OVERKILL]},
-		// Magitek turret I - Dies, but never becomes targetable.
-		{kind: {legacyFflogs: '11596'}, checks: [Check.FIRST_TARGETED, Check.DEATH]},
 		// Magitek Turret II - actually not targetable, they cast the tether tank busters
 		{kind: {legacyFflogs: '11597'}, exclude: true},
 		// Confines of memory - die too quick to be meaningfully fixable

--- a/src/parser/bosses/exVaris/modules/index.ts
+++ b/src/parser/bosses/exVaris/modules/index.ts
@@ -1,3 +1,4 @@
 import {Invulnerability} from './Invulnerability'
+import {Invulnerability as Invulnerability2} from './Invulnerability2'
 
-export default [Invulnerability]
+export default [Invulnerability, Invulnerability2]

--- a/src/parser/core/__tests__/filter.ts
+++ b/src/parser/core/__tests__/filter.ts
@@ -1,4 +1,4 @@
-import {filter, oneOf} from '../filter'
+import {exists, filter, oneOf} from '../filter'
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
@@ -54,5 +54,13 @@ describe('matchers', () => {
 		expect(matcher(1)).toBeTrue()
 		expect(matcher(2)).toBeTrue()
 		expect(matcher(3)).toBeFalse()
+	})
+
+	test('exists', () => {
+		expect(exists(1)).toBeTrue()
+		expect(exists('2')).toBeTrue()
+		expect(exists({a: 3})).toBeTrue()
+		expect(exists(undefined)).toBeFalse()
+		expect(exists(null)).toBeFalse()
 	})
 })

--- a/src/parser/core/filter.ts
+++ b/src/parser/core/filter.ts
@@ -39,8 +39,13 @@ export const filter = <Base>() => filterInternal<Base, {}>({})
 // -----
 
 // Extending primitive so TS narrows the type as far as it can
+/** Match successfully if value matches any of the provided values. */
 export const oneOf = <T extends TB.Misc.Primitive>(values: T[]): Matcher<T> =>
 	(objValue): objValue is T => values.includes(objValue)
+
+// This will technically always return true in a filter due to lodash semantics, but hey
+/** Match successfully if value is not nullish. */
+export const exists = <T>(value?: T | null): value is T => value != null
 
 // -----
 // #endregion

--- a/src/parser/core/filter.ts
+++ b/src/parser/core/filter.ts
@@ -39,9 +39,11 @@ export const filter = <Base>() => filterInternal<Base, {}>({})
 // -----
 
 // Extending primitive so TS narrows the type as far as it can
-/** Match successfully if value matches any of the provided values. */
-export const oneOf = <T extends TB.Misc.Primitive>(values: T[]): Matcher<T> =>
-	(objValue): objValue is T => values.includes(objValue)
+/** Match successfully if value matches any of the provided values by reference.  */
+export function oneOf<T extends TB.Misc.Primitive>(values: T[] | Set<T>): Matcher<T> {
+	const set = Array.isArray(values) ? new Set(values) : values
+	return (objValue): objValue is T => set.has(objValue)
+}
 
 // This will technically always return true in a filter due to lodash semantics, but hey
 /** Match successfully if value is not nullish. */

--- a/src/parser/core/modules/Actors/Actor.ts
+++ b/src/parser/core/modules/Actors/Actor.ts
@@ -94,6 +94,7 @@ interface ActorOptions {
 export class Actor extends ActorResources implements ReportActor {
 	// we re-export the actor shape so people don't need to dig into `Pull` to get it.
 	readonly id: string
+	readonly kind: string
 	readonly name: string
 	readonly team: Team
 	readonly playerControlled: boolean
@@ -106,6 +107,7 @@ export class Actor extends ActorResources implements ReportActor {
 	constructor({actor}: ActorOptions) {
 		super({})
 		this.id = actor.id
+		this.kind = actor.kind
 		this.name = actor.name
 		this.team = actor.team
 		this.playerControlled = actor.playerControlled

--- a/src/parser/core/modules/Death.tsx
+++ b/src/parser/core/modules/Death.tsx
@@ -64,6 +64,8 @@ export class Death extends Analyser {
 	private _deadTime = 0
 
 	initialise() {
+		// TODO: Look into generalising this to handle actors other than the parsed PC?
+
 		// An actor hitting 0 HP is a sign of a death.
 		this.addEventHook({
 			type: 'actorUpdate',

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -106,9 +106,14 @@ export class Invulnerability extends Analyser {
 		actorId: Actor['id'],
 		timestamp: number,
 	) {
-		// TODO: Should I exclude friendlies?
-		// Get the actor data and the config for its kind
 		const actor = this.actors.get(actorId)
+
+		// Ignore PCs
+		// TODO: This is primarily for consistency with old systems. Consider if it's feasible to track PCs.
+		if (actor.playerControlled) {
+			return
+		}
+
 		const config = this.flatConfig.get(actor.kind)
 
 		// If the actor is explicitly excluded, we can noop

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -64,28 +64,38 @@ export class Invulnerability extends Analyser {
 	/** @todo docs */
 	protected actorConfig: ActorConfig[] = []
 
-	private flatConfig = new Map<Actor['kind'], ActorConfig>()
+	private skipMirroring = new Set<Actor['id']>()
 	private windows = new Map<Actor['id'], Window[]>()
 
 	initialise() {
-		// If there's any subclass actor config, flatten it to a map by the current
-		// report sources' kind keys, for faster lookups later.
-		if (this.actorConfig.length > 0) {
-			const reportSource = this.parser.newReport.meta.source
-			this.flatConfig = new Map(this.actorConfig.map(config => [
-				config.kind[reportSource],
-				config,
-			]))
-		}
+		const reportSource = this.parser.newReport.meta.source
+
+		// Flatten any subclass actor config to a map by the current report sources'
+		// kind keys, for faster lookups later.
+		const flatConfig = new Map(this.actorConfig.map(config => [
+			config.kind[reportSource],
+			config,
+		]))
 
 		// Group actors by the checks that should be performed on them.
 		const actorChecks = new Map<Check, Array<Actor['id']>>()
 		for (const actor of this.parser.pull.actors) {
-			const config = this.flatConfig.get(actor.kind)
+			// Skip player-controlled actors
+			// TODO: This is primarily for consistency with old systems. Consider if it's feasible to track PCs.
+			if (actor.playerControlled) {
+				continue
+			}
+
+			const config = flatConfig.get(actor.kind)
 
 			// If the actor has been explicitly excluded, skip it entirely
 			if (config != null && config.exclude) {
 				continue
+			}
+
+			// Check if this actor should not be mirrored
+			if (config?.mirrorToInvuln === false) {
+				this.skipMirroring.add(actor.id)
 			}
 
 			// Add the actor to each of the check keys it is configured for
@@ -150,6 +160,7 @@ export class Invulnerability extends Analyser {
 	private endWindow = (actorId: Actor['id'], timestamp: number) =>
 		this.manageConfigWindows(this.endTypeWindow, actorId, timestamp)
 
+	// TODO: is this needed?
 	private manageConfigWindows(
 		fn: (type: Type, actor: Actor, timestamp: number) => void,
 		actorId: Actor['id'],
@@ -157,22 +168,9 @@ export class Invulnerability extends Analyser {
 	) {
 		const actor = this.actors.get(actorId)
 
-		// Ignore PCs
-		// TODO: This is primarily for consistency with old systems. Consider if it's feasible to track PCs.
-		if (actor.playerControlled) {
-			return
-		}
-
-		const config = this.flatConfig.get(actor.kind)
-
-		// If the actor is explicitly excluded, we can noop
-		if (config != null && config.exclude) {
-			return
-		}
-
 		// Start the untargetable window, mirroring to invuln if configured to do so
 		fn('untargetable', actor, timestamp)
-		if (config?.mirrorToInvuln ?? true) {
+		if (!this.skipMirroring.has(actorId)) {
 			fn('invulnerable', actor, timestamp)
 		}
 	}

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -24,6 +24,8 @@ export enum Check {
 	 * Use for actors that do not die in a typical manner.
 	 */
 	OVERKILL,
+	/** Mark an actor as targetable when it is first targeted by an event. */
+	FIRST_TARGETED,
 }
 
 interface IncludedActorConfig {
@@ -120,6 +122,7 @@ export class Invulnerability extends Analyser {
 			[Check.TARGETABLE]: this.addTargetableHooks,
 			[Check.DEATH]: this.addDeathHooks,
 			[Check.OVERKILL]: this.addOverkillHooks,
+			[Check.FIRST_TARGETED]: this.addFirstTargetedHooks,
 		}
 		for (const [check, ids] of actorChecks) {
 			addHooksFns[check](ids)
@@ -176,6 +179,20 @@ export class Invulnerability extends Analyser {
 				.hp(filter<Resource>().current(1)),
 			event => this.startWindow(event.actor, event.timestamp),
 		)
+	}
+
+	private addFirstTargetedHooks = (actorIds: Array<Actor['id']>) => {
+		// Adding multiple temporary hooks rather than one generalised one so we
+		// can selectively remove them as they are targeted
+		for (const id of actorIds) {
+			const hook = this.addEventHook(
+				{target: id},
+				event => {
+					this.removeEventHook(hook)
+					this.endWindow(event.target, event.timestamp)
+				},
+			)
+		}
 	}
 
 	private startWindow = (actorId: Actor['id'], timestamp: number) =>
@@ -265,7 +282,7 @@ export class Invulnerability extends Analyser {
 			const actor = this.actors.get(actorId)
 
 			const actorRow = parentRow.addRow(new SimpleRow({
-				label: `${actor.name} (${actor.kind})`,
+				label: `${actor.name} (id ${actor.id} kind ${actor.kind})`,
 			}))
 
 			// TODO: invuln/untarget

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -1,20 +1,16 @@
 import {Event, Resource} from 'event'
 import _ from 'lodash'
 import React from 'react'
-import {ReportMetaKey} from 'report'
+import {Actor, ReportMetaKey} from 'report'
 import {Analyser} from '../Analyser'
 import {exists, filter, oneOf} from '../filter'
 import {dependency} from '../Injectable'
-import {Actors, Actor} from './Actors'
+import {Actors} from './Actors'
 import {SimpleItem, SimpleRow, Timeline} from './Timeline'
 
-// i'm tempted to say that the invuln config should be basically removed
-// under what scenario is firsttab not a start?
-// under what scenario is overkill not an end?
-// If we assume we don't need config, then most of the old logic can become an adaption step, and this module can be pared down to effectively just tracking the invuln windows, and providing the capability for exclusion and mirroring?
-// not sure it's really an adapter step tbh
-
 export enum Check {
+	/** Mark an actor as targetable when it is first targeted by an event. */
+	FIRST_TARGETED,
 	/** Check actor updates for changes to actor targetability. */
 	TARGETABLE,
 	/** Consider an actor as untargetable on death. */
@@ -24,14 +20,18 @@ export enum Check {
 	 * Use for actors that do not die in a typical manner.
 	 */
 	OVERKILL,
-	/** Mark an actor as targetable when it is first targeted by an event. */
-	FIRST_TARGETED,
 }
+
+const DEFAULT_CHECKS = [
+	Check.FIRST_TARGETED,
+	Check.TARGETABLE,
+	Check.DEATH,
+]
 
 interface IncludedActorConfig {
 	/**
 	 * Checks to perform to determine targetability.
-	 * Defaults to [TARGETABLE, DEATH].
+	 * Defaults to [FIRST_TARGETED, TARGETABLE, DEATH].
 	 */
 	checks?: Check[]
 
@@ -87,9 +87,9 @@ export class Invulnerability extends Analyser {
 		// Group actors by the checks that should be performed on them.
 		const actorChecks = new Map<Check, Array<Actor['id']>>()
 		for (const actor of this.parser.pull.actors) {
-			// Skip player-controlled actors
+			// Skip player-controlled actors and their pets
 			// TODO: This is primarily for consistency with old systems. Consider if it's feasible to track PCs.
-			if (actor.playerControlled) {
+			if (this.isPlayerDerived(actor)) {
 				continue
 			}
 
@@ -106,7 +106,7 @@ export class Invulnerability extends Analyser {
 			}
 
 			// Add the actor to each of the check keys it is configured for
-			const checks = config?.checks ?? [Check.TARGETABLE, Check.DEATH]
+			const checks = config?.checks ?? DEFAULT_CHECKS
 			for (const check of checks) {
 				let foo = actorChecks.get(check)
 				if (foo == null) {
@@ -133,6 +133,10 @@ export class Invulnerability extends Analyser {
 
 		this.debug(() => this.addEventHook('complete', this.renderDebugTimelineData))
 	}
+
+	private isPlayerDerived = (actor: Actor): boolean => false
+		|| actor.playerControlled
+		|| (actor.owner != null && this.isPlayerDerived(actor.owner))
 
 	private addTargetableHooks = (actorIds: Array<Actor['id']>) => {
 		this.addEventHook(
@@ -182,12 +186,27 @@ export class Invulnerability extends Analyser {
 	}
 
 	private addFirstTargetedHooks = (actorIds: Array<Actor['id']>) => {
-		// Adding multiple temporary hooks rather than one generalised one so we
-		// can selectively remove them as they are targeted
 		for (const id of actorIds) {
+			// Preemptively start the first window at the beginning of the fight
+			this.startWindow(id, this.parser.pull.timestamp)
+
+			// Adding temporary hooks rather than one generalised one so we
+			// can selectively remove them as they are targeted
+			// TODO: that's >100 actors sometimes. worth it? probably not tbqh.
+
 			const hook = this.addEventHook(
 				{target: id},
 				event => {
+					// skip self target (filter?)
+					if (event.target === event.source) {
+						return
+					}
+
+					// type filter - probs should whitelist? duno, would be nice to type a not
+					if (event.type === 'statusApply' || event.type === 'statusRemove') {
+						return
+					}
+
 					this.removeEventHook(hook)
 					this.endWindow(event.target, event.timestamp)
 				},
@@ -253,11 +272,12 @@ export class Invulnerability extends Analyser {
 		// == null means something became targetable, but never went untargetable
 		// we can presume it has been untargetable since the start of the fight
 		if (activeWindow == null) {
+			// TODO: With the preemptive fill changes, this should probably be an error?
 			activeWindow = this.startTypeWindow(type, actor, this.parser.pull.timestamp)
 		}
 
 		activeWindow.active = false
-		activeWindow.end = timestamp
+		activeWindow.end = Math.max(timestamp, activeWindow.start)
 	}
 
 	// TODO: Expose with options, ooor?

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -255,7 +255,7 @@ export class Invulnerability extends Analyser {
 			window => window.active && window.type === type,
 		)
 		if (activeWindow != null) {
-			return activeWindow
+			return
 		}
 
 		// Build & save the new window
@@ -266,25 +266,20 @@ export class Invulnerability extends Analyser {
 			end: this.parser.pull.timestamp + this.parser.pull.duration,
 		}
 		windows.push(window)
-		return window
 	}
 
 	private endTypeWindow = (type: Type, actor: Actor, timestamp: number) => {
 		const windows = this.getActorWindows(actor)
 
-		let activeWindow = _.findLast(
+		const activeWindow = _.findLast(
 			windows,
 			window => window.active && window.type === type
 		)
 
-		// TODO: The below was traditionally safe as we were precomputing, but this is effectively timewarping backwards. If i keep this as-is, i _must_ ensure that any lookups for an "all" value (if kept as a capability) only check for _known_ actors by this module, which will keep the below in sync (as it will technically only occur for newly-known actors).
-		// i may be well-served by swapping logic here to only performing the backfill if no windows exist at all, rather than no active windows - might be safer.
-
-		// == null means something became targetable, but never went untargetable
-		// we can presume it has been untargetable since the start of the fight
+		// If there's nothing open that we can close, throw. We can't sanely backfill in many cases,
+		// as it may technically change historical information that other modules have already read.
 		if (activeWindow == null) {
-			// TODO: With the preemptive fill changes, this should probably be an error?
-			activeWindow = this.startTypeWindow(type, actor, this.parser.pull.timestamp)
+			throw new Error(`Actor ${actor.id} has no active ${type} window to end.`)
 		}
 
 		activeWindow.active = false

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -74,7 +74,11 @@ export class Invulnerability extends Analyser {
 	@dependency private actors!: Actors
 	@dependency private timeline!: Timeline
 
-	/** @todo docs */
+	/**
+	 * Array of configuration overrides. The default configuration should be fine
+	 * for most actors - add an override if the derived invulnerability windows
+	 * look wrong.
+	 */
 	protected actorConfig: ActorConfig[] = []
 
 	private skipMirroring = new Set<Actor['id']>()
@@ -168,8 +172,6 @@ export class Invulnerability extends Analyser {
 	}
 
 	private addDeathHooks = (actorIds: Array<Actor['id']>) => {
-		// this.addEventHook('death', this.onDeath)
-		// TODO: Look into generalising death for non-pc actors?
 		this.addEventHook(
 			filter<Event>()
 				.type('actorUpdate')
@@ -251,7 +253,6 @@ export class Invulnerability extends Analyser {
 	private endWindow = (actorId: Actor['id'], timestamp: number) =>
 		this.manageConfigWindows(this.endTypeWindow, actorId, timestamp)
 
-	// TODO: is this needed?
 	private manageConfigWindows(
 		fn: (type: Type, actor: Actor, timestamp: number) => void,
 		actorId: Actor['id'],

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -144,6 +144,12 @@ export class Invulnerability extends Analyser {
 		|| (actor.owner != null && this.isPlayerDerived(actor.owner))
 
 	private addTargetableHooks = (actorIds: Array<Actor['id']>) => {
+		// Preemptively start the first window at the beginning of the fight in case
+		// the actor has been configured without first targeted
+		for (const id of actorIds) {
+			this.startWindow(id, this.parser.pull.timestamp)
+		}
+
 		this.addEventHook(
 			filter<Event>()
 				.type('actorUpdate')

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -95,30 +95,35 @@ export class Invulnerability extends Analyser {
 		this.startWindow(event.actor, event.timestamp)
 	}
 
-	// TODO: can we dedupe start/end window? maybe pass the fn to call?
-	private startWindow(actorId: Actor['id'], timestamp: number) {
-		// TODO: Do we want to only track friendlies?
-		// TODO: get config
+	private startWindow = (actorId: Actor['id'], timestamp: number) =>
+		this.manageConfigWindows(this.startTypeWindow, actorId, timestamp)
+
+	private endWindow = (actorId: Actor['id'], timestamp: number) =>
+		this.manageConfigWindows(this.endTypeWindow, actorId, timestamp)
+
+	private manageConfigWindows(
+		fn: (type: Type, actor: Actor, timestamp: number) => void,
+		actorId: Actor['id'],
+		timestamp: number,
+	) {
+		// TODO: Should I exclude friendlies?
+		// Get the actor data and the config for its kind
 		const actor = this.actors.get(actorId)
 		const config = this.flatConfig.get(actor.kind)
 
-		if (config?.exclude) {
+		// If the actor is explicitly excluded, we can noop
+		if (config != null && config.exclude) {
 			return
 		}
-		// TODO: mirror
-		this.startTypeWindow('untargetable', actor, timestamp)
-	}
 
-	private endWindow(actorId: Actor['id'], timestamp: number) {
-		const actor = this.actors.get(actorId)
-		const config = this.flatConfig.get(actor.kind)
-		if (config?.exclude) {
-			return
+		// Start the untargetable window, mirroring to invuln if configured to do so
+		fn('untargetable', actor, timestamp)
+		if (config?.mirrorToInvuln ?? true) {
+			fn('invulnerable', actor, timestamp)
 		}
-		this.endTypeWindow('untargetable', actor, timestamp)
 	}
 
-	private startTypeWindow(type: Type, actor: Actor, timestamp: number) {
+	private startTypeWindow = (type: Type, actor: Actor, timestamp: number) => {
 		const windows = this.getActorWindows(actor)
 
 		// If there's already an active window, piggyback on it
@@ -141,7 +146,7 @@ export class Invulnerability extends Analyser {
 		return window
 	}
 
-	private endTypeWindow(type: Type, actor: Actor, timestamp: number) {
+	private endTypeWindow = (type: Type, actor: Actor, timestamp: number) => {
 		const windows = this.getActorWindows(actor)
 
 		let activeWindow = _.findLast(

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -1,0 +1,190 @@
+import {Event, Events} from 'event'
+import _ from 'lodash'
+import React from 'react'
+import {ReportMetaKey} from 'report'
+import {Analyser, AnalyserOptions} from '../Analyser'
+import {exists, filter} from '../filter'
+import {dependency} from '../Injectable'
+import {Actors, Actor} from './Actors'
+import {SimpleItem, SimpleRow, Timeline} from './Timeline'
+
+// i'm tempted to say that the invuln config should be basically removed
+// under what scenario is firsttab not a start?
+// under what scenario is overkill not an end?
+// If we assume we don't need config, then most of the old logic can become an adaption step, and this module can be pared down to effectively just tracking the invuln windows, and providing the capability for exclusion and mirroring?
+// not sure it's really an adapter step tbh
+
+interface IncludedActorConfig {
+	/**
+	 * Mirror 'untargetable' invuln windows into 'invulnerable' windows.
+	 * Default `true`. Disable for actors that take damage while untargetable -
+	 * you will need to add custom logic to add the invulnerable windows yourself.
+	 */
+	mirrorToInvuln?: boolean
+}
+
+type ActorConfig =
+	& {kind: Record<ReportMetaKey, Actor['kind']>}
+	& (
+		| {exclude: true}
+		| ({exclude: false} & IncludedActorConfig)
+	)
+
+type Type = 'invulnerable' | 'untargetable'
+
+interface Window {
+	type: Type
+	active: boolean
+	start: number
+	end: number
+}
+
+export class Invulnerability extends Analyser {
+	static handle = 'invulnerability'
+	static debug = true
+
+	@dependency private actors!: Actors
+	@dependency private timeline!: Timeline
+
+	/** @todo docs */
+	protected actorConfig: ActorConfig[] = []
+
+	private flatConfig: Map<Actor['kind'], ActorConfig>
+	private windows = new Map<Actor['id'], Window[]>()
+
+	constructor(...args: AnalyserOptions) {
+		super(...args)
+
+		const reportSource = this.parser.newReport.meta.source
+		this.flatConfig = new Map(this.actorConfig.map(config => [
+			config.kind[reportSource],
+			config,
+		]))
+	}
+
+	initialise() {
+		// TODO: LEGACY?
+		// probably should just allow narrowing support ranges and drop legacy range
+
+		this.addEventHook(
+			filter<Event>().type('actorUpdate').targetable(exists),
+			this.onTargetableChange,
+		)
+		// this.addEventHook('death', this.onDeath)
+		// TODO: Look into generalising death for non-pc actors?
+		this.addEventHook(
+			{type: 'actorUpdate', hp: {current: 0}},
+			this.onDeath,
+		)
+
+		this.debug(() => this.addEventHook('complete', this.renderDebugTimelineData))
+	}
+
+	private onTargetableChange(event: Events['actorUpdate']) {
+		// This should never be hit, but sanity check anyway
+		if (event.targetable == null) { return }
+
+		event.targetable
+			? this.endWindow(event.actor, event.timestamp)
+			: this.startWindow(event.actor, event.timestamp)
+	}
+
+	private onDeath(event: Events['actorUpdate']) {
+		this.startWindow(event.actor, event.timestamp)
+	}
+
+	private startWindow(actorId: Actor['id'], timestamp: number) {
+		// TODO: Do we want to only track friendlies?
+		// TODO: get config
+		const actor = this.actors.get(actorId)
+		// TODO: mirror
+		// TODO: can we dedupe start/end window? maybe pass the fn to call?
+		this.startTypeWindow('untargetable', actor, timestamp)
+	}
+
+	private endWindow(actorId: Actor['id'], timestamp: number) {
+		const actor = this.actors.get(actorId)
+		this.endTypeWindow('untargetable', actor, timestamp)
+	}
+
+	private startTypeWindow(type: Type, actor: Actor, timestamp: number) {
+		const windows = this.getActorWindows(actor)
+
+		// If there's already an active window, piggyback on it
+		const activeWindow = _.findLast(
+			windows,
+			window => window.active && window.type === type,
+		)
+		if (activeWindow != null) {
+			return activeWindow
+		}
+
+		// Build & save the new window
+		const window: Window = {
+			active: true,
+			type,
+			start: timestamp,
+			end: this.parser.pull.timestamp + this.parser.pull.duration,
+		}
+		windows.push(window)
+		return window
+	}
+
+	private endTypeWindow(type: Type, actor: Actor, timestamp: number) {
+		const windows = this.getActorWindows(actor)
+
+		let activeWindow = _.findLast(
+			windows,
+			window => window.active && window.type === type
+		)
+
+		// TODO: The below was traditionally safe as we were precomputing, but this is effectively timewarping backwards. If i keep this as-is, i _must_ ensure that any lookups for an "all" value (if kept as a capability) only check for _known_ actors by this module, which will keep the below in sync (as it will technically only occur for newly-known actors).
+		// i may be well-served by swapping logic here to only performing the backfill if no windows exist at all, rather than no active windows - might be safer.
+
+		// == null means something became targetable, but never went untargetable
+		// we can presume it has been untargetable since the start of the fight
+		if (activeWindow == null) {
+			activeWindow = this.startTypeWindow(type, actor, this.parser.pull.timestamp)
+		}
+
+		activeWindow.active = false
+		activeWindow.end = timestamp
+	}
+
+	// TODO: Expose with options, ooor?
+	private getActorWindows(actor: Actor) {
+		let windows = this.windows.get(actor.id)
+		if (windows == null) {
+			windows = []
+			this.windows.set(actor.id, windows)
+		}
+		return windows
+	}
+
+	private renderDebugTimelineData() {
+		const startTime = this.parser.pull.timestamp
+
+		const parentRow = this.timeline.addRow(new SimpleRow({
+			label: 'Invuln2 Debug',
+			order: -Infinity,
+		}))
+
+		for (const [actorId, windows] of this.windows) {
+			const actor = this.actors.get(actorId)
+
+			const actorRow = parentRow.addRow(new SimpleRow({
+				label: `${actor.name} (${actor.kind})`,
+			}))
+
+			// TODO: invuln/untarget
+
+			for (const window of windows) {
+				actorRow.addItem(new SimpleItem({
+					start: window.start - startTime,
+					end: window.end - startTime,
+					content: <div style={{width: '100%', height: '100%', backgroundColor: '#faa'}}/>,
+				}))
+			}
+		}
+	}
+}

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -2,7 +2,7 @@ import {Event, Events} from 'event'
 import _ from 'lodash'
 import React from 'react'
 import {ReportMetaKey} from 'report'
-import {Analyser, AnalyserOptions} from '../Analyser'
+import {Analyser} from '../Analyser'
 import {exists, filter} from '../filter'
 import {dependency} from '../Injectable'
 import {Actors, Actor} from './Actors'
@@ -30,6 +30,8 @@ type ActorConfig =
 		| ({exclude: false} & IncludedActorConfig)
 	)
 
+export type ActorsConfig = ActorConfig[]
+
 type Type = 'invulnerable' | 'untargetable'
 
 interface Window {
@@ -49,20 +51,20 @@ export class Invulnerability extends Analyser {
 	/** @todo docs */
 	protected actorConfig: ActorConfig[] = []
 
-	private flatConfig: Map<Actor['kind'], ActorConfig>
+	private flatConfig = new Map<Actor['kind'], ActorConfig>()
 	private windows = new Map<Actor['id'], Window[]>()
 
-	constructor(...args: AnalyserOptions) {
-		super(...args)
-
-		const reportSource = this.parser.newReport.meta.source
-		this.flatConfig = new Map(this.actorConfig.map(config => [
-			config.kind[reportSource],
-			config,
-		]))
-	}
-
 	initialise() {
+		// If there's any subclass actor config, flatten it to a map by the current
+		// report sources' kind keys, for faster lookups later.
+		if (this.actorConfig.length > 0) {
+			const reportSource = this.parser.newReport.meta.source
+			this.flatConfig = new Map(this.actorConfig.map(config => [
+				config.kind[reportSource],
+				config,
+			]))
+		}
+
 		// TODO: LEGACY?
 		// probably should just allow narrowing support ranges and drop legacy range
 
@@ -93,17 +95,26 @@ export class Invulnerability extends Analyser {
 		this.startWindow(event.actor, event.timestamp)
 	}
 
+	// TODO: can we dedupe start/end window? maybe pass the fn to call?
 	private startWindow(actorId: Actor['id'], timestamp: number) {
 		// TODO: Do we want to only track friendlies?
 		// TODO: get config
 		const actor = this.actors.get(actorId)
+		const config = this.flatConfig.get(actor.kind)
+
+		if (config?.exclude) {
+			return
+		}
 		// TODO: mirror
-		// TODO: can we dedupe start/end window? maybe pass the fn to call?
 		this.startTypeWindow('untargetable', actor, timestamp)
 	}
 
 	private endWindow(actorId: Actor['id'], timestamp: number) {
 		const actor = this.actors.get(actorId)
+		const config = this.flatConfig.get(actor.kind)
+		if (config?.exclude) {
+			return
+		}
 		this.endTypeWindow('untargetable', actor, timestamp)
 	}
 

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -1,9 +1,9 @@
-import {Event, Events} from 'event'
+import {Event, Resource} from 'event'
 import _ from 'lodash'
 import React from 'react'
 import {ReportMetaKey} from 'report'
 import {Analyser} from '../Analyser'
-import {exists, filter} from '../filter'
+import {exists, filter, oneOf} from '../filter'
 import {dependency} from '../Injectable'
 import {Actors, Actor} from './Actors'
 import {SimpleItem, SimpleRow, Timeline} from './Timeline'
@@ -14,7 +14,20 @@ import {SimpleItem, SimpleRow, Timeline} from './Timeline'
 // If we assume we don't need config, then most of the old logic can become an adaption step, and this module can be pared down to effectively just tracking the invuln windows, and providing the capability for exclusion and mirroring?
 // not sure it's really an adapter step tbh
 
+export enum Check {
+	/** Check actor updates for changes to actor targetability. */
+	TARGETABLE,
+	/** Consider an actor as untargetable on death. */
+	DEATH,
+}
+
 interface IncludedActorConfig {
+	/**
+	 * Checks to perform to determine targetability.
+	 * Defaults to [TARGETABLE, DEATH].
+	 */
+	checks?: Check[]
+
 	/**
 	 * Mirror 'untargetable' invuln windows into 'invulnerable' windows.
 	 * Default `true`. Disable for actors that take damage while untargetable -
@@ -27,7 +40,7 @@ type ActorConfig =
 	& {kind: Record<ReportMetaKey, Actor['kind']>}
 	& (
 		| {exclude: true}
-		| ({exclude: false} & IncludedActorConfig)
+		| ({exclude?: false} & IncludedActorConfig)
 	)
 
 export type ActorsConfig = ActorConfig[]
@@ -65,34 +78,70 @@ export class Invulnerability extends Analyser {
 			]))
 		}
 
+		// Group actors by the checks that should be performed on them.
+		const actorChecks = new Map<Check, Array<Actor['id']>>()
+		for (const actor of this.parser.pull.actors) {
+			const config = this.flatConfig.get(actor.kind)
+
+			// If the actor has been explicitly excluded, skip it entirely
+			if (config != null && config.exclude) {
+				continue
+			}
+
+			// Add the actor to each of the check keys it is configured for
+			const checks = config?.checks ?? [Check.TARGETABLE, Check.DEATH]
+			for (const check of checks) {
+				let foo = actorChecks.get(check)
+				if (foo == null) {
+					foo = []
+					actorChecks.set(check, foo)
+				}
+				foo.push(actor.id)
+			}
+		}
+
+		// Set up hooks for each check
+		const addHooksFns: Record<Check, (actorIds: Array<Actor['id']>) => void> = {
+			[Check.TARGETABLE]: this.addTargetableHooks,
+			[Check.DEATH]: this.addDeathHooks,
+		}
+		for (const [check, ids] of actorChecks) {
+			addHooksFns[check](ids)
+		}
+
 		// TODO: LEGACY?
 		// probably should just allow narrowing support ranges and drop legacy range
-
-		this.addEventHook(
-			filter<Event>().type('actorUpdate').targetable(exists),
-			this.onTargetableChange,
-		)
-		// this.addEventHook('death', this.onDeath)
-		// TODO: Look into generalising death for non-pc actors?
-		this.addEventHook(
-			{type: 'actorUpdate', hp: {current: 0}},
-			this.onDeath,
-		)
 
 		this.debug(() => this.addEventHook('complete', this.renderDebugTimelineData))
 	}
 
-	private onTargetableChange(event: Events['actorUpdate']) {
-		// This should never be hit, but sanity check anyway
-		if (event.targetable == null) { return }
+	private addTargetableHooks = (actorIds: Array<Actor['id']>) => {
+		this.addEventHook(
+			filter<Event>()
+				.type('actorUpdate')
+				.actor(oneOf(actorIds))
+				.targetable(exists),
+			event => {
+				// This should never be hit, but sanity check anyway
+				if (event.targetable == null) { return }
 
-		event.targetable
-			? this.endWindow(event.actor, event.timestamp)
-			: this.startWindow(event.actor, event.timestamp)
+				event.targetable
+					? this.endWindow(event.actor, event.timestamp)
+					: this.startWindow(event.actor, event.timestamp)
+			}
+		)
 	}
 
-	private onDeath(event: Events['actorUpdate']) {
-		this.startWindow(event.actor, event.timestamp)
+	private addDeathHooks = (actorIds: Array<Actor['id']>) => {
+		// this.addEventHook('death', this.onDeath)
+		// TODO: Look into generalising death for non-pc actors?
+		this.addEventHook(
+			filter<Event>()
+				.type('actorUpdate')
+				.actor(oneOf(actorIds))
+				.hp(filter<Resource>().current(0)),
+			event => this.startWindow(event.actor, event.timestamp),
+		)
 	}
 
 	private startWindow = (actorId: Actor['id'], timestamp: number) =>

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -19,6 +19,11 @@ export enum Check {
 	TARGETABLE,
 	/** Consider an actor as untargetable on death. */
 	DEATH,
+	/**
+	 * Consider an actor as untargetable on hitting 1HP or being overkilled.
+	 * Use for actors that do not die in a typical manner.
+	 */
+	OVERKILL,
 }
 
 interface IncludedActorConfig {
@@ -114,6 +119,7 @@ export class Invulnerability extends Analyser {
 		const addHooksFns: Record<Check, (actorIds: Array<Actor['id']>) => void> = {
 			[Check.TARGETABLE]: this.addTargetableHooks,
 			[Check.DEATH]: this.addDeathHooks,
+			[Check.OVERKILL]: this.addOverkillHooks,
 		}
 		for (const [check, ids] of actorChecks) {
 			addHooksFns[check](ids)
@@ -150,6 +156,24 @@ export class Invulnerability extends Analyser {
 				.type('actorUpdate')
 				.actor(oneOf(actorIds))
 				.hp(filter<Resource>().current(0)),
+			event => this.startWindow(event.actor, event.timestamp),
+		)
+	}
+
+	private addOverkillHooks = (actorIds: Array<Actor['id']>) => {
+		// Hook both overkill and an update to 1HP to ensure all cases are caught
+		this.addEventHook(
+			filter<Event>()
+				.type('damage')
+				.target(oneOf(actorIds))
+				.overkill((v): v is number => v > 0),
+			event => this.startWindow(event.target, event.timestamp),
+		)
+		this.addEventHook(
+			filter<Event>()
+				.type('actorUpdate')
+				.actor(oneOf(actorIds))
+				.hp(filter<Resource>().current(1)),
 			event => this.startWindow(event.actor, event.timestamp),
 		)
 	}

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -52,6 +52,11 @@ type ActorConfig =
 
 export type ActorsConfig = ActorConfig[]
 
+const sharedActorConfig: ActorsConfig = [
+	// Exclude unknown actors
+	{kind: {legacyFflogs: 'unknown'}, exclude: true},
+]
+
 type Type = 'invulnerable' | 'untargetable'
 
 interface Window {
@@ -79,7 +84,7 @@ export class Invulnerability extends Analyser {
 
 		// Flatten any subclass actor config to a map by the current report sources'
 		// kind keys, for faster lookups later.
-		const flatConfig = new Map(this.actorConfig.map(config => [
+		const flatConfig = new Map([...sharedActorConfig, ...this.actorConfig].map(config => [
 			config.kind[reportSource],
 			config,
 		]))

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -2,6 +2,7 @@ import {Event, Resource} from 'event'
 import _ from 'lodash'
 import React from 'react'
 import {Actor, ReportMetaKey} from 'report'
+import * as TB from 'ts-toolbelt'
 import {Analyser} from '../Analyser'
 import {exists, filter, oneOf} from '../filter'
 import {dependency} from '../Injectable'
@@ -197,32 +198,51 @@ export class Invulnerability extends Analyser {
 	}
 
 	private addFirstTargetedHooks = (actorIds: Array<Actor['id']>) => {
+		// Preemptively start the first window at the beginning of the fight
 		for (const id of actorIds) {
-			// Preemptively start the first window at the beginning of the fight
 			this.startWindow(id, this.parser.pull.timestamp)
-
-			// Adding temporary hooks rather than one generalised one so we
-			// can selectively remove them as they are targeted
-			// TODO: that's >100 actors sometimes. worth it? probably not tbqh.
-
-			const hook = this.addEventHook(
-				{target: id},
-				event => {
-					// skip self target (filter?)
-					if (event.target === event.source) {
-						return
-					}
-
-					// type filter - probs should whitelist? duno, would be nice to type a not
-					if (event.type === 'statusApply' || event.type === 'statusRemove') {
-						return
-					}
-
-					this.removeEventHook(hook)
-					this.endWindow(event.target, event.timestamp)
-				},
-			)
 		}
+
+		// Exclude status updates, it's relatively common for player statuses to be mirrored to
+		// untargetable actors, and we don't want that to crop up and cause issues.
+		const ensureEventTypes = <T extends Event['type']>(types: T[]) => types
+		const ignoredTypes = ensureEventTypes(['statusApply', 'statusRemove'])
+
+		// This is basically an inverse oneOf
+		// TODO: Look into genericising this. Will require some type hackery in filter, hence not doing right now.
+		type PermittedTypes = TB.Union.Filter<
+			Event['type'],
+			(typeof ignoredTypes) extends Array<infer T> ? T : never
+		>
+		const ignoredTypesSet = new Set<Event['type']>(ignoredTypes)
+		const matchType = (value: Event['type']): value is PermittedTypes => !ignoredTypesSet.has(value)
+
+		// Track actors that have been seen so they may be skipped. If you're thinking
+		// of copying this pattern, probably don't - preference adding temporary hooks
+		// that you remove once they've done their job. This is only implemented with
+		// a single hook here due to the majority of the 100+ mechanic actors common in
+		// complex fights never removing their hook, and just chew unnessecary time.
+		const seenActors = new Set<Actor['id']>()
+
+		this.addEventHook(
+			filter<Event>()
+				.type(matchType)
+				.target(oneOf(actorIds)),
+			event => {
+				// If the event is self-targeted, doesn't mean much - skip it
+				// TODO: Look into moving this to the filter? Doing so will require access to event data in filter matchers, check lodash docs.
+				// Also skip anything from targets we've already tracked a window for, we're only interested in the first event.
+				if (
+					seenActors.has(event.target)
+					|| event.target === event.source
+				) {
+					return
+				}
+
+				seenActors.add(event.target)
+				this.endWindow(event.target, event.timestamp)
+			}
+		)
 	}
 
 	private startWindow = (actorId: Actor['id'], timestamp: number) =>

--- a/src/parser/core/modules/Invulnerability2.tsx
+++ b/src/parser/core/modules/Invulnerability2.tsx
@@ -319,26 +319,51 @@ export class Invulnerability extends Analyser {
 
 	private renderDebugTimelineData() {
 		const startTime = this.parser.pull.timestamp
+		const endTime = startTime + this.parser.pull.duration
 
 		const parentRow = this.timeline.addRow(new SimpleRow({
 			label: 'Invuln2 Debug',
 			order: -Infinity,
 		}))
 
+		const kindRows = new Map<Actor['kind'], SimpleRow>()
+
 		for (const [actorId, windows] of this.windows) {
 			const actor = this.actors.get(actorId)
 
-			const actorRow = parentRow.addRow(new SimpleRow({
-				label: `${actor.name} (id ${actor.id} kind ${actor.kind})`,
+			let kindRow = kindRows.get(actor.kind)
+			if (kindRow == null) {
+				kindRow = parentRow.addRow(new SimpleRow({
+					label: actor.kind,
+				}))
+				kindRows.set(actor.kind, kindRow)
+			}
+
+			const actorRow = kindRow.addRow(new SimpleRow({
+				label: `${actor.name} (${actor.id})`,
+				collapse: true,
 			}))
 
-			// TODO: invuln/untarget
+			const invulnerableRow = actorRow.addRow(new SimpleRow({
+				label: 'invulnerable',
+			}))
+			const untargetableRow = actorRow.addRow(new SimpleRow({
+				label: 'untargetable',
+			}))
 
 			for (const window of windows) {
-				actorRow.addItem(new SimpleItem({
+				// Windows that run the full length of the fight are meaningless to display
+				if (window.start <= startTime && window.end >= endTime) {
+					continue
+				}
+
+				const row = window.type === 'invulnerable'
+					? invulnerableRow
+					: untargetableRow
+				row.addItem(new SimpleItem({
 					start: window.start - startTime,
 					end: window.end - startTime,
-					content: <div style={{width: '100%', height: '100%', backgroundColor: '#faa'}}/>,
+					content: <div style={{width: '100%', height: '100%', backgroundColor: '#faa8'}}/>,
 				}))
 			}
 		}

--- a/src/parser/core/modules/index.js
+++ b/src/parser/core/modules/index.js
@@ -18,6 +18,7 @@ import {EventsView} from './EventsView'
 import GlobalCooldown from './GlobalCooldown'
 import HitType from './HitType'
 import {Invulnerability} from './Invulnerability'
+import {Invulnerability as Invulnerability2} from './Invulnerability2'
 import {NormalisedEvents} from './NormalisedEvents'
 import PrecastAction from './PrecastAction'
 import PrecastStatus from './PrecastStatus'
@@ -53,6 +54,7 @@ export default [
 	GlobalCooldown,
 	HitType,
 	Invulnerability,
+	Invulnerability2,
 	NormalisedEvents,
 	PrecastAction,
 	PrecastStatus,

--- a/src/report.ts
+++ b/src/report.ts
@@ -115,6 +115,13 @@ export interface Actor {
 	 * Treat as a black box outside report sources.
 	 */
 	id: string
+	/**
+	 * Unique identifier of the kind of enemy this actor is. Unlike IDs, an actor's
+	 * kind will be stable both between multiple copies of the same enemy, and multiple
+	 * pulls across multiple reports.
+	 * The value of this field should be treated as a black box outside report sources.
+	 */
+	kind: string
 	/** Name of the actor. */
 	name: string
 	/** Team the actor belongs to, in relation to the logging user. */

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -19,6 +19,7 @@ MockReassignUnknownActorStep.mockImplementation((...args: ReassignUnknownActorSt
 
 const actor: Actor = {
 	id: '1',
+	kind: '1',
 	name: 'Test Actor',
 	team: Team.FRIEND,
 	playerControlled: true,

--- a/src/reportSources/legacyFflogs/reportAdapter.ts
+++ b/src/reportSources/legacyFflogs/reportAdapter.ts
@@ -101,12 +101,14 @@ function buildActorsByFight(report: LegacyReport) {
 const convertActor = (actor: FflogsActor, overrides?: Partial<Actor>): Actor => ({
 	...UNKNOWN_ACTOR,
 	id: actor.id.toString(),
+	kind: actor.guid.toString(),
 	name: actor.name,
 	...overrides,
 })
 
 const UNKNOWN_ACTOR: Actor = {
 	id: 'unknown',
+	kind: 'unknown',
 	name: 'Unknown',
 	team: Team.UNKNOWN,
 	playerControlled: false,


### PR DESCRIPTION
This PR:
- Implements the core logic of tracking invulnerability windows at runtime using the new event system
- Adds the concept of an actor "kind"
- makes the deduplication adapter more typesafe
- adds the `exists` filter (lmao)

It does _not_ implement a public API for the new invulnerability module, nor does it actually replace the old with the new. That will be done in a follow-up.

This new module, due to the constraints imposed by pulling the logic into the primary parser runtime, now throws an error at a point where the old module could sanely backfill data.

I've added logic to pre-emptively fill the data that would previously be backfilled, and it seems to function correctly, but I want to leave this running in the background for a short while to make sure I've caught all the edge cases.