### PR TITLE
Add striking dummy detection module

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -257,6 +257,8 @@
   "core.dblink.loading": "Wird geladen...",
   "core.deaths.content": "Sterbe nicht. Ob untätige Zeit, verlorene Job-Balken und Ressourcen oder Wiederbelebungsstatus, Tode sind absolut <0>vernichtend</0> zum Schadensausstoß.",
   "core.deaths.why": "{0, plural, =1 {# Tod} other {# Tode}}",
+  "core.dummy.broken-log": "",
+  "core.dummy.title": "",
   "core.error.generic": "Sieht aus, als ob etwas falsch gelaufen ist. Unser hoch motiviertes Team von Programmierern wurde benachrichtigt.",
   "core.find.refresh": "Aktualisieren",
   "core.gauge.title": "Balken",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -257,6 +257,8 @@
   "core.dblink.loading": "Loading...",
   "core.deaths.content": "Don't die. Between downtime, lost gauge resources, and resurrection debuffs, dying is absolutely <0>crippling</0> to damage output.",
   "core.deaths.why": "{0, plural, =1 {# death} other {# deaths}}",
+  "core.dummy.broken-log": "One or more actors in this pull appear to be striking dummies. The behaviour of dummy health pools breaks a number of assumptions made by xivanalysis, which can lead to subtly incorrect results.",
+  "core.dummy.title": "Striking Dummy",
   "core.error.generic": "Looks like something has gone wrong. The code monkies have been notified.",
   "core.find.refresh": "Refresh",
   "core.gauge.title": "Gauge",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -257,6 +257,8 @@
   "core.dblink.loading": "Chargement...",
   "core.deaths.content": "Ne mourez pas. Entre l'arrêt de votre DPS pendant votre mort, les pertes de PM/PT ou les ressources liées à votre jauge de job ainsi que le débuff d’affaiblissement : mourir est un <0>handicap</0> au DPS global.",
   "core.deaths.why": "{0, plural, =1 {# mort} other {# morts}}",
+  "core.dummy.broken-log": "",
+  "core.dummy.title": "",
   "core.error.generic": "On dirait que quelque tourne pas rond. Notre équipe de développeurs hautement qualifiée à été notifiée.",
   "core.find.refresh": "Actualiser",
   "core.gauge.title": "Jauge",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -257,6 +257,8 @@
   "core.dblink.loading": "読み込み中...",
   "core.deaths.content": "無駄死は避けてください。戦闘途中で死亡してしまうとトランスゲージのリセット・再構成によるロストタイムや蘇生による弱体化など様々な原因で火力の出力に<0>悪い</0>影響が出ます。",
   "core.deaths.why": "{0, plural, other {死亡回数: #}}",
+  "core.dummy.broken-log": "",
+  "core.dummy.title": "",
   "core.error.generic": "おや、何か大変なことになりましたね。すでに開発者にアラートを送りましたのでご安心ください。",
   "core.find.refresh": "更新",
   "core.gauge.title": "ゲージ",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -257,6 +257,8 @@
   "core.dblink.loading": "로딩중...",
   "core.deaths.content": "죽지마세요. 전투 도중 사망하면 게이지의 손실, 쇠약 디버프, 쿨타임 낭비로 인해 전체 데미지에 <0>좋지 않은</0> 영향을 줍니다.",
   "core.deaths.why": "{0, plural, other {사망 횟수: #}}",
+  "core.dummy.broken-log": "",
+  "core.dummy.title": "",
   "core.error.generic": "무언가 잘못되었습니다만 코드깎는 노인들이 이미 작업중입니다.",
   "core.find.refresh": "새로고침",
   "core.gauge.title": "게이지",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -257,6 +257,8 @@
   "core.dblink.loading": "加载中…",
   "core.deaths.content": "不要死。不仅会丢失输出时间，清空战斗资源，起来还会有虚弱debuff，死亡绝对会<0>严重降低</0>你的输出。",
   "core.deaths.why": "{0, plural, =1 {# 次死亡} other {# 次死亡}}",
+  "core.dummy.broken-log": "",
+  "core.dummy.title": "",
   "core.error.generic": "好像出了点问题。程序猿已经接到报警。",
   "core.find.refresh": "刷新",
   "core.gauge.title": "职业量谱",

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -702,6 +702,10 @@ class Parser {
 		return this.formatDuration(timestamp - this.fight.start_time, secondPrecision)
 	}
 
+	formatEpochTimestamp(timestamp: number, secondPrecision?: number) {
+		return this.formatDuration(timestamp - this.pull.timestamp, secondPrecision)
+	}
+
 	formatDuration(duration: number, secondPrecision?: number) {
 		return formatDuration(duration, {secondPrecision, hideMinutesIfZero: true, showNegative: true})
 	}

--- a/src/parser/core/modules/BrokenLog.tsx
+++ b/src/parser/core/modules/BrokenLog.tsx
@@ -34,14 +34,21 @@ export default class BrokenLog extends Analyser {
 	 * @param key Unique key that represents the BL trigger
 	 * @param source Module that is triggering BL
 	 * @param reason Short description of why BL was triggered
+	 * @param erroneous If this trigger should be reported as an error to logs.
 	 */
-	trigger(source: Module | Analyser, key: string, reason?: React.ReactNode) {
+	trigger(
+		source: Module | Analyser,
+		key: string,
+		reason?: React.ReactNode,
+		erroneous = true,
+	) {
 		const constructor = (source.constructor as SourceConstructor)
 		const {handle} = constructor
 		const triggerKey = `${handle}.${key}`
 
 		// If this is the first time this issue has been triggered, try and report it to Sentry
 		if (
+			erroneous &&
 			!this.triggers.has(triggerKey) &&
 			!getReportPatch(this.parser.newReport).branch
 		) {

--- a/src/parser/core/modules/Death.tsx
+++ b/src/parser/core/modules/Death.tsx
@@ -1,8 +1,10 @@
 import {Plural, Trans} from '@lingui/react'
-import {Event, Events, FieldsBase} from 'event'
+import {Event, Events, FieldsBase, Resource} from 'event'
 import React from 'react'
 import {Actor} from 'report'
 import {Analyser} from '../Analyser'
+import {EventHook} from '../Dispatcher'
+import {filter} from '../filter'
 import {dependency} from '../Injectable'
 import {Data} from './Data'
 import Suggestions, {SEVERITY, Suggestion} from './Suggestions'
@@ -43,6 +45,14 @@ declare module 'legacyEvent' {
 	}
 }
 
+interface ActorInfo {
+	timestampDeath?: Event['timestamp']
+	timestampTranscendent?: Event['timestamp']
+	count: number
+	duration: number
+	raiseHook?: EventHook<Events['actorUpdate']>
+}
+
 export class Death extends Analyser {
 	static handle = 'death'
 	static debug = true
@@ -53,23 +63,22 @@ export class Death extends Analyser {
 
 	/** Accumulated time the parsed actor has spent dead over the course of the fight. */
 	get deadTime() {
-		const timestamp = this.parser.currentEpochTimestamp
-		const currentDeadTime = timestamp - (this.currentDeathTimestamp ?? timestamp)
-		return this._deadTime + currentDeadTime
+		return this.getDuration(this.parser.actor.id)
 	}
 
-	private currentDeathTimestamp?: Event['timestamp']
-	private currentTranscendentTimestamp?: Event['timestamp']
-	private count = 0
-	private _deadTime = 0
+	private info = new Map<Actor['id'], ActorInfo>()
+
+	getDuration(actorId: Actor['id']) {
+		const actorInfo = this.getActorInfo(actorId)
+		const timestamp = this.parser.currentEpochTimestamp
+		const currentDeadTime = timestamp - (actorInfo.timestampDeath ?? timestamp)
+		return actorInfo.duration + currentDeadTime
+	}
 
 	initialise() {
-		// TODO: Look into generalising this to handle actors other than the parsed PC?
-
 		// An actor hitting 0 HP is a sign of a death.
 		this.addEventHook({
 			type: 'actorUpdate',
-			actor: this.parser.actor.id,
 			hp: {current: 0},
 		}, this.onDeath)
 
@@ -77,25 +86,34 @@ export class Death extends Analyser {
 		this.addEventHook({
 			type: 'statusApply',
 			status: this.data.statuses.TRANSCENDENT.id,
-			target: this.parser.actor.id,
 		}, this.onTranscendentApply)
 
 		// Any possible death events before transcendent falls off are flakes
 		this.addEventHook({
 			type: 'statusRemove',
 			status: this.data.statuses.TRANSCENDENT.id,
-			target: this.parser.actor.id,
 		}, this.onTranscendentRemove)
 
 		this.addEventHook('complete', this.onComplete)
 	}
 
+	private getActorInfo(actorId: Actor['id']): ActorInfo {
+		let actorInfo = this.info.get(actorId)
+		if (actorInfo == null) {
+			actorInfo = {count: 0, duration: 0}
+			this.info.set(actorId, actorInfo)
+		}
+		return actorInfo
+	}
+
 	private onDeath(event: Events['actorUpdate']) {
+		const actorInfo = this.getActorInfo(event.actor)
+
 		// If we already have a death being tracked, or the player is still
 		// transcendent, it's likely duplicate info, noop
 		if (
-			this.currentDeathTimestamp != null
-			|| this.currentTranscendentTimestamp != null
+			actorInfo.timestampDeath != null
+			|| actorInfo.timestampTranscendent != null
 		) { return }
 
 		const counted = this.shouldCountDeath(event)
@@ -111,8 +129,20 @@ export class Death extends Analyser {
 		// If we're not counting, can stop here
 		if (!counted) { return }
 
-		this.currentDeathTimestamp = event.timestamp
-		this.count++
+		actorInfo.timestampDeath = event.timestamp
+		actorInfo.count++
+
+		// Keep an eye out for the actor gaining health post-death - it signals that it has resurrected in some
+		// manner that bypassed the transcendent check. Transcendent itself is applied before any HP gain, so
+		// player actors will likely not trigger this hook.
+		actorInfo.raiseHook = this.addEventHook(
+			filter<Event>()
+				.type('actorUpdate')
+				.actor(event.actor)
+				.hp(filter<Resource>()
+					.current((value): value is number => value > 0)),
+			event => this.onRaise(event.actor, event.timestamp),
+		)
 	}
 
 	/**
@@ -126,50 +156,70 @@ export class Death extends Analyser {
 	}
 
 	private onTranscendentApply(event: Events['statusApply']) {
-		this.currentTranscendentTimestamp = event.timestamp
-		this.onRaise(event)
+		const actorInfo = this.getActorInfo(event.target)
+		actorInfo.timestampTranscendent = event.timestamp
+		this.onRaise(event.target, event.timestamp)
 	}
 
-	private onTranscendentRemove(_event: Events['statusRemove']) {
-		this.currentTranscendentTimestamp = undefined
+	private onTranscendentRemove(event: Events['statusRemove']) {
+		const actorInfo = this.getActorInfo(event.target)
+		actorInfo.timestampTranscendent = undefined
 	}
 
-	private onRaise(event: Event) {
+	private onRaise(actorId: Actor['id'], timestamp: Event['timestamp']) {
+		const actorInfo = this.getActorInfo(actorId)
+
 		// If there's no current death, likely duplicate info, noop
-		if (this.currentDeathTimestamp == null) { return }
+		if (actorInfo.timestampDeath == null) { return }
 
-		this.addDeathToTimeline(this.currentDeathTimestamp, event.timestamp)
+		// We only show the parsed player's deaths on the timeline itself
+		if (actorId === this.parser.actor.id) {
+			this.addDeathToTimeline(actorInfo.timestampDeath, timestamp)
+		}
+
+		actorInfo.duration += timestamp - actorInfo.timestampDeath
+		actorInfo.timestampDeath = undefined
+
+		if (actorInfo.raiseHook != null) {
+			this.removeEventHook(actorInfo.raiseHook)
+			actorInfo.raiseHook = undefined
+		}
 
 		// Queue the raise notification.
 		// Also fabricating a legacy event for backwards compatibility.
 		this.parser.queueEvent({
 			type: 'raise',
-			timestamp: event.timestamp,
-			actor: this.parser.actor.id,
-		})
-		this.parser.fabricateLegacyEvent({
-			type: 'raise',
-			timestamp: this.parser.currentTimestamp,
-			targetID: this.parser.player.id,
+			timestamp,
+			actor: actorId,
 		})
 
-		this.currentDeathTimestamp = undefined
+		// Legacy only fabricated raises for the player
+		if (actorId === this.parser.actor.id) {
+			this.parser.fabricateLegacyEvent({
+				type: 'raise',
+				timestamp: this.parser.currentTimestamp,
+				targetID: this.parser.player.id,
+			})
+		}
 	}
 
 	private onComplete(event: Events['complete']) {
-		// If the actor was dead on completion, and the pull was a wipe, refund the
-		// death. It's pretty meaningless to complain about the wipe itself.
-		if (
-			(this.parser.pull.progress ?? 0) < 100
-			&& this.currentDeathTimestamp != null
-		) {
-			this.count = Math.max(this.count - 1, 0)
+		for (const [actorId, actorInfo] of this.info) {
+			// If the actor was dead on completion, and the pull was a wipe, refund the
+			// death. It's pretty meaningless to complain about the wipe itself.
+			if (
+				(this.parser.pull.progress ?? 0) < 100
+				&& actorInfo.timestampDeath != null
+			) {
+				actorInfo.count = Math.max(actorInfo.count - 1, 0)
+			}
+
+			// Run raise cleanup in case the actor was dead on completion
+			this.onRaise(actorId, event.timestamp)
 		}
 
-		// Run raise cleanup in case the actor was dead on completion
-		this.onRaise(event)
-
-		if (this.count === 0) { return }
+		const playerInfo = this.getActorInfo(this.parser.actor.id)
+		if (playerInfo.count === 0) { return }
 
 		// Deaths are pretty morbid
 		this.suggestions.add(new Suggestion({
@@ -180,7 +230,7 @@ export class Death extends Analyser {
 			severity: SEVERITY.MORBID,
 			why: <Plural
 				id="core.deaths.why"
-				value={this.count}
+				value={playerInfo.count}
 				_1="# death"
 				other="# deaths"
 			/>,

--- a/src/parser/core/modules/Death.tsx
+++ b/src/parser/core/modules/Death.tsx
@@ -68,6 +68,10 @@ export class Death extends Analyser {
 
 	private info = new Map<Actor['id'], ActorInfo>()
 
+	getCount(actorId: Actor['id']) {
+		return this.getActorInfo(actorId).count
+	}
+
 	getDuration(actorId: Actor['id']) {
 		const actorInfo = this.getActorInfo(actorId)
 		const timestamp = this.parser.currentEpochTimestamp

--- a/src/parser/core/modules/Dummy.tsx
+++ b/src/parser/core/modules/Dummy.tsx
@@ -1,0 +1,48 @@
+import {t} from '@lingui/macro'
+import {Trans} from '@lingui/react'
+import {Event, Events} from 'event'
+import React from 'react'
+import {Team} from 'report'
+import {Analyser} from '../Analyser'
+import {EventHook} from '../Dispatcher'
+import {filter, oneOf} from '../filter'
+import {dependency} from '../Injectable'
+import BrokenLog from './BrokenLog'
+import {Death} from './Death'
+
+const LIKELY_DUMMY_THRESHOLD = 3
+
+export class Dummy extends Analyser {
+	static title = t('core.dummy.title')`Striking Dummy`
+	static handle = 'dummy'
+	static debug = false
+
+	@dependency private brokenLog!: BrokenLog
+	@dependency private death!: Death
+
+	private hook?: EventHook<Events['death']>
+
+	initialise() {
+		const foeIds = this.parser.pull.actors
+			.filter(actor => actor.team === Team.FOE)
+			.map(actor => actor.id)
+
+		this.hook = this.addEventHook(
+			filter<Event>()
+				.type('death')
+				.actor(oneOf(foeIds)),
+			this.onFoeDeath,
+		)
+	}
+
+	private onFoeDeath(event: Events['death']) {
+		const count = this.death.getCount(event.actor)
+		if (count < LIKELY_DUMMY_THRESHOLD) { return }
+		this.hook != null && this.removeEventHook(this.hook)
+		this.brokenLog.trigger(this, 'striking dummy', (
+			<Trans id="core.dummy.broken-log">
+				One or more actors in this pull appear to be striking dummies. The behaviour of dummy health pools breaks a number of assumptions made by xivanalysis, which can lead to subtly incorrect results.
+			</Trans>
+		), false)
+	}
+}

--- a/src/parser/core/modules/index.js
+++ b/src/parser/core/modules/index.js
@@ -12,6 +12,7 @@ import Cooldowns from './Cooldowns'
 import {Data} from './Data'
 import {Death} from './Death'
 import Downtime from './Downtime'
+import {Dummy} from './Dummy'
 import Enemies from './Enemies'
 import {EntityStatuses} from './EntityStatuses'
 import {EventsView} from './EventsView'
@@ -47,6 +48,7 @@ export default [
 	Data,
 	Death,
 	Downtime,
+	Dummy,
 	Enemies,
 	EntityStatuses,
 	EventsView,


### PR DESCRIPTION
Because dummies just... break things. A lot.

Also "just" updates `death` to handle non-active-player deaths which ended up as half a rewrite.