### PR TITLE
Also check init events when fudging

### DIFF
--- a/src/parser/jobs/dnc/modules/Gauge.tsx
+++ b/src/parser/jobs/dnc/modules/Gauge.tsx
@@ -349,7 +349,7 @@ export default class Gauge extends Analyser {
 
 	/** Dancer's gauges are both probabilistic, so we have to do some fudging to produce a realistic-looking graph */
 	private correctGaugeHistory(historyObject: DancerResourceDatum[], spenderCost: number, currentGauge: number) {
-		const lastGeneratorIndex = _.findLastIndex(historyObject, event => event.type === 'generate') // Get the last generation event we've recorded
+		const lastGeneratorIndex = _.findLastIndex(historyObject, event => event.type === 'generate' || event.type === 'init') // Get the last generation event we've recorded
 
 		// Add the amount we underran the simulation by to the last generation event, and all events through the current one
 		const underrunAmount = Math.abs(currentGauge - spenderCost)


### PR DESCRIPTION
This fixes the sentry logged with the new Feather/Esprit gauges from a 24 man that had carry-forward feathers spent before any generators.

https://xivanalysis.com/fflogs/9cr83VNbzAkGaDfq/10/18