### PR TITLE
Bugfix: BLM - Don't milli the milli

### DIFF
--- a/src/parser/jobs/blm/modules/RotationWatchdog.tsx
+++ b/src/parser/jobs/blm/modules/RotationWatchdog.tsx
@@ -40,7 +40,7 @@ const CYCLE_ENDPOINTS = [
 	ACTIONS.FREEZE.id,
 ]
 
-const FIRE_IV_CAST_MILLIS = ACTIONS.FIRE_IV.castTime * 1000
+const FIRE_IV_CAST_MILLIS = ACTIONS.FIRE_IV.castTime
 
 // This is feelycraft at the moment. Rotations shorter than this won't be processed for errors.
 const MIN_ROTATION_LENGTH = 3


### PR DESCRIPTION
PR #1130 added a new FIRE_IV_CAST_TIME_MILLIS const, but was done before the recent conversion to use millis for Action cast times, which got overlooked in review

Result was basically every Fire IV rotation that was missing F4s was subsequently tripping the 'you couldn't have gotten more F4s in' because it was looking at the ~45 minute mark to see if the boss was invulnerable instead of mere seconds after the cycle ended, thanks to the extra three orders of magnitude on that value