### PR TITLE
Refactor Debug logging to a module that can be shared with Analysers

### DIFF
--- a/src/parser/core/Analyser.ts
+++ b/src/parser/core/Analyser.ts
@@ -2,7 +2,6 @@ import {MessageDescriptor} from '@lingui/core'
 import {Event} from 'event'
 import _ from 'lodash'
 import {Compute} from 'utilities'
-import {seededColor} from 'utilities/color'
 import {EventFilterPredicate, EventHook, EventHookCallback, TimestampHook, TimestampHookCallback} from './Dispatcher'
 import {Injectable} from './Injectable'
 import Module, {DISPLAY_MODE as DisplayMode} from './Module'
@@ -39,13 +38,6 @@ type FilterUnion<U, F> =
 /** Builds a predicate function that will filter to events that match the provided partial. */
 const buildFilterPredicate = <T extends Event>(filter: Partial<Event>) =>
 	_.matches(filter) as EventFilterPredicate<T>
-
-// Helper types for debug
-type LogParameters = Parameters<typeof console.log>
-type DebugCallback = (opts: {
-	/** Log the provided arguments. */
-	log: (...data: LogParameters) => void,
-}) => void
 
 export type AnalyserOptions = ConstructorParameters<typeof Analyser>
 
@@ -197,37 +189,6 @@ export class Analyser extends Injectable {
 	 */
 	protected removeTimestampHook(hook: TimestampHook): boolean {
 		return this.parser.dispatcher.removeTimestampHook(hook)
-	}
-
-	// -----
-	// #endregion
-	// #region Debug
-	// -----
-
-	/** Execute the provided callback if the analyser is in debug mode. */
-	protected debug(callback: DebugCallback): void
-	/** Log the provided arguments if the analyser is in debug mode. */
-	protected debug(...data: LogParameters): void
-	protected debug(...args: [DebugCallback] | LogParameters) {
-		const constructor = this.constructor as typeof Analyser
-		if (!constructor.debug || process.env.NODE_ENV === 'production') {
-			return
-		}
-
-		typeof args[0] === 'function'
-			? args[0]({log: this.debugLog})
-			: this.debugLog(...args)
-	}
-
-	private debugLog = (...data: LogParameters) => {
-		const constructor = this.constructor as typeof Module
-		// eslint-disable-next-line no-console
-		console.log(
-			`[%c${constructor.handle}%c]`,
-			`color: ${seededColor(constructor.handle)}`,
-			'color: inherit',
-			...data,
-		)
 	}
 
 	// -----

--- a/src/parser/core/Debuggable.ts
+++ b/src/parser/core/Debuggable.ts
@@ -9,14 +9,14 @@ type DebugCallback = (opts: {
 
 export abstract class Debuggable {
 	/**
-	 * Set to `true` to enable debug mode for this loggable class, allowing the execution
+	 * Set to `true` to enable debug mode for this debuggable class, allowing the execution
 	 * of any calls to the debug method.
 	 */
 	static debug = false
 
-	/** Execute the provided callback if the loggable is in debug mode. */
+	/** Execute the provided callback if the debuggable is in debug mode. */
 	protected debug(callback: DebugCallback): void
-	/** Log the provided arguments if the loggable is in debug mode. */
+	/** Log the provided arguments if the debuggable is in debug mode. */
 	protected debug(...data: LogParameters): void
 	protected debug(...args: [DebugCallback] | LogParameters) {
 		const constructor = this.constructor as typeof Debuggable

--- a/src/parser/core/Debuggable.ts
+++ b/src/parser/core/Debuggable.ts
@@ -7,7 +7,7 @@ type DebugCallback = (opts: {
 	log: (...data: LogParameters) => void,
 }) => void
 
-export abstract class Loggable {
+export abstract class Debuggable {
 	/**
 	 * Set to `true` to enable debug mode for this loggable class, allowing the execution
 	 * of any calls to the debug method.
@@ -19,7 +19,7 @@ export abstract class Loggable {
 	/** Log the provided arguments if the loggable is in debug mode. */
 	protected debug(...data: LogParameters): void
 	protected debug(...args: [DebugCallback] | LogParameters) {
-		const constructor = this.constructor as typeof Loggable
+		const constructor = this.constructor as typeof Debuggable
 		if (!constructor.debug || process.env.NODE_ENV === 'production') {
 			return
 		}
@@ -30,7 +30,7 @@ export abstract class Loggable {
 	}
 
 	private debugLog = (...data: LogParameters) => {
-		const constructor = this.constructor as typeof Loggable
+		const constructor = this.constructor as typeof Debuggable
 		// eslint-disable-next-line no-console
 		console.log(
 			`[%c${constructor.name}%c]`,

--- a/src/parser/core/Injectable.ts
+++ b/src/parser/core/Injectable.ts
@@ -1,4 +1,4 @@
-import {Loggable} from 'parser/core/Loggable'
+import {Debuggable} from 'parser/core/Debuggable'
 
 /**
  * Mark the decorated property as a dependency. The dependency will be injected
@@ -62,7 +62,7 @@ export interface InjectableOptions {
  * Base dependency injection logic. Injectables can be injected into each other by
  * specifying dependencies within the class definition.
  */
-export class Injectable extends Loggable {
+export class Injectable extends Debuggable {
 	static dependencies: Array<string | MappedDependency> = []
 
 	private static _handle: string

--- a/src/parser/core/Injectable.ts
+++ b/src/parser/core/Injectable.ts
@@ -1,3 +1,5 @@
+import {Loggable} from 'parser/core/Loggable'
+
 /**
  * Mark the decorated property as a dependency. The dependency will be injected
  * during construction, and will be available for the lifetime of the instance.
@@ -60,7 +62,7 @@ export interface InjectableOptions {
  * Base dependency injection logic. Injectables can be injected into each other by
  * specifying dependencies within the class definition.
  */
-export class Injectable {
+export class Injectable extends Loggable {
 	static dependencies: Array<string | MappedDependency> = []
 
 	private static _handle: string
@@ -76,6 +78,8 @@ export class Injectable {
 	}
 
 	constructor({container}: InjectableOptions) {
+		super()
+
 		const injectable = this.constructor as typeof Injectable
 		for (const dependency of injectable.dependencies) {
 			// If the dependency is a plain string, normalise it to the mapped representation

--- a/src/parser/core/Loggable.ts
+++ b/src/parser/core/Loggable.ts
@@ -1,0 +1,42 @@
+import {seededColor} from 'utilities/color'
+
+// Helper types for debug
+type LogParameters = Parameters<typeof console.log>
+type DebugCallback = (opts: {
+	/** Log the provided arguments. */
+	log: (...data: LogParameters) => void,
+}) => void
+
+export abstract class Loggable {
+	/**
+	 * Set to `true` to enable debug mode for this loggable class, allowing the execution
+	 * of any calls to the debug method.
+	 */
+	static debug = false
+
+	/** Execute the provided callback if the loggable is in debug mode. */
+	protected debug(callback: DebugCallback): void
+	/** Log the provided arguments if the loggable is in debug mode. */
+	protected debug(...data: LogParameters): void
+	protected debug(...args: [DebugCallback] | LogParameters) {
+		const constructor = this.constructor as typeof Loggable
+		if (!constructor.debug || process.env.NODE_ENV === 'production') {
+			return
+		}
+
+		typeof args[0] === 'function'
+			? args[0]({log: this.debugLog})
+			: this.debugLog(...args)
+	}
+
+	private debugLog = (...data: LogParameters) => {
+		const constructor = this.constructor as typeof Loggable
+		// eslint-disable-next-line no-console
+		console.log(
+			`[%c${constructor.name}%c]`,
+			`color: ${seededColor(constructor.name)}`,
+			'color: inherit',
+			...data,
+		)
+	}
+}

--- a/src/parser/core/Module.ts
+++ b/src/parser/core/Module.ts
@@ -4,7 +4,6 @@ import {Event} from 'legacyEvent'
 import {cloneDeep} from 'lodash'
 import 'reflect-metadata'
 import {ensureArray} from 'utilities'
-import {seededColor} from 'utilities/color'
 import {Injectable, MappedDependency, dependency, executeBeforeDoNotUseOrYouWillBeFired} from './Injectable'
 import {EventHook, EventHookCallback, Filter, FilterPartial, TimestampHook, TimestampHookCallback} from './LegacyDispatcher'
 import Parser from './Parser'
@@ -31,12 +30,6 @@ type ModuleFilter<T extends Event> = Filter<T> & FilterPartial<{
 	to: 'player' | 'pet' | FflogsEvent['targetID'],
 	by: 'player' | 'pet' | FflogsEvent['sourceID'],
 }>
-
-type LogParams = Parameters<typeof console.log>
-interface DebugFnOpts {
-	log: (...messages: LogParams) => void
-}
-type DebugFn = (opts: DebugFnOpts) => void
 
 export default class Module extends Injectable {
 	static displayOrder: number = DISPLAY_ORDER.DEFAULT
@@ -215,35 +208,6 @@ export default class Module extends Injectable {
 	/** Remove a previously added timestamp hook */
 	protected removeTimestampHook(hook: TimestampHook) {
 		this.parser.legacyDispatcher.removeTimestampHook(hook)
-	}
-
-	/**
-	 * Log a debug console message. Will only be printed if built in a non-production
-	 * environment, with `static debug = true` in the module it's being executed in.
-	 */
-	protected debug(debugFn: DebugFn): void
-	protected debug(...messages: LogParams): void
-	protected debug(...messages: [DebugFn] | LogParams) {
-		const module = this.constructor as typeof Module
-
-		if (!module.debug || process.env.NODE_ENV === 'production') {
-			return
-		}
-
-		typeof messages[0] === 'function'
-			? messages[0]({log: this.debugLog})
-			: this.debugLog(...messages)
-	}
-
-	private debugLog = (...messages: LogParams) => {
-		const module = this.constructor as typeof Module
-		// eslint-disable-next-line no-console
-		console.log(
-			`[%c${module.handle}%c]`,
-			`color: ${seededColor(module.handle)}`,
-			'color: inherit',
-			...messages,
-		)
 	}
 
 	output(): React.ReactNode {

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -457,7 +457,7 @@ class Parser {
 			visited.add(handle)
 
 			const injectable = this.container[handle]
-			const constructor = injectable as typeof Injectable
+			const constructor = injectable.constructor as typeof Injectable
 
 			// TODO: Should Injectable also contain rudimentary error logic?
 			if (injectable instanceof Module) {

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -11,7 +11,7 @@ import {ReassignUnknownActorStep} from '../eventAdapter/reassignUnknownActor'
 // TODO: If we need to do this >1 times, work out a cleaner way of doing this.
 jest.mock('../eventAdapter/reassignUnknownActor')
 type ReassignUnknownActorStepParams = ConstructorParameters<typeof ReassignUnknownActorStep>
-const MockReassignUnknownActorStep = ReassignUnknownActorStep as jest.Mock<ReassignUnknownActorStep>
+const MockReassignUnknownActorStep = ReassignUnknownActorStep as unknown as jest.Mock<ReassignUnknownActorStep>
 MockReassignUnknownActorStep.mockImplementation((...args: ReassignUnknownActorStepParams) => {
 	const {ReassignUnknownActorStep} = jest.requireActual('../eventAdapter/reassignUnknownActor')
 	return new ReassignUnknownActorStep(...args)

--- a/src/reportSources/legacyFflogs/eventAdapter/base.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/base.ts
@@ -1,5 +1,6 @@
 import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
+import {Loggable} from 'parser/core/Loggable'
 import {Pull, Report} from 'report'
 
 export const PREPULL_OFFSETS = {
@@ -22,11 +23,12 @@ export interface MutationAdaptionResult {
 	adaptedEvents: Event[]
 }
 
-export abstract class AdapterStep {
+export abstract class AdapterStep extends Loggable {
 	protected report: Report
 	protected pull: Pull
 
 	constructor(opts: AdapterOptions) {
+		super()
 		this.report = opts.report
 		this.pull = opts.pull
 	}

--- a/src/reportSources/legacyFflogs/eventAdapter/base.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/base.ts
@@ -1,6 +1,6 @@
 import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
-import {Loggable} from 'parser/core/Loggable'
+import {Debuggable} from 'parser/core/Debuggable'
 import {Pull, Report} from 'report'
 
 export const PREPULL_OFFSETS = {
@@ -23,7 +23,7 @@ export interface MutationAdaptionResult {
 	adaptedEvents: Event[]
 }
 
-export abstract class AdapterStep extends Loggable {
+export abstract class AdapterStep extends Debuggable {
 	protected report: Report
 	protected pull: Pull
 


### PR DESCRIPTION
This was originally done in support of #1180, but I pulled it out for ~~ease of review~~ simplicity of troubleshooting the type errors I had.

I verified against https://xivanalysis.com/fflogs/F8ZfDGXrkbajxhYR/19/1258 that the broken log triggers were still generating the same output with the change to Parser._gatherErrorContext.