### PR TITLE
[Bugfix] Synth executes for damage events prior to the FFLogs calculated damage update

### DIFF
--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -6,7 +6,7 @@ Array [
     "source": "11:2",
     "status": 1001917,
     "target": "4",
-    "timestamp": 7537469,
+    "timestamp": 1600007537469,
     "type": "statusApply",
   },
 ]
@@ -20,7 +20,7 @@ Array [
     "source": "7",
     "status": 1001238,
     "target": "7",
-    "timestamp": -3,
+    "timestamp": 1599999999997,
     "type": "action",
   },
   Object {
@@ -28,7 +28,7 @@ Array [
     "source": "7",
     "status": 1001238,
     "target": "7",
-    "timestamp": 7410286,
+    "timestamp": 1600007410286,
     "type": "statusApply",
   },
 ]
@@ -41,14 +41,14 @@ Array [
     "source": "6",
     "status": 1000638,
     "target": "11",
-    "timestamp": -3,
+    "timestamp": 1599999999997,
     "type": "action",
   },
   Object {
     "source": "6",
     "status": 1000638,
     "target": "11",
-    "timestamp": 190177,
+    "timestamp": 1600000190177,
     "type": "statusApply",
   },
 ]
@@ -61,7 +61,7 @@ Array [
     "source": "8",
     "status": 1000861,
     "target": "2",
-    "timestamp": 7425207,
+    "timestamp": 1600007425207,
     "type": "statusApply",
   },
 ]
@@ -73,7 +73,7 @@ Array [
     "action": 16541,
     "source": "9",
     "target": "2",
-    "timestamp": 7446878,
+    "timestamp": 1600007446878,
     "type": "prepare",
   },
 ]
@@ -85,7 +85,7 @@ Array [
     "action": 3554,
     "source": "1",
     "target": "3",
-    "timestamp": -1,
+    "timestamp": 1599999999999,
     "type": "action",
   },
   Object {
@@ -100,7 +100,7 @@ Array [
     "sourceModifier": 2,
     "target": "3",
     "targetModifier": 0,
-    "timestamp": 8011183,
+    "timestamp": 1600008011183,
     "type": "damage",
   },
   Object {
@@ -118,7 +118,7 @@ Array [
       "x": 9999,
       "y": 10081,
     },
-    "timestamp": 8011183,
+    "timestamp": 1600008011183,
     "type": "actorUpdate",
   },
   Object {
@@ -136,7 +136,7 @@ Array [
       "x": 9260,
       "y": 10463,
     },
-    "timestamp": 8011183,
+    "timestamp": 1600008011183,
     "type": "actorUpdate",
   },
 ]
@@ -155,7 +155,7 @@ Array [
     "source": "3",
     "sourceModifier": 2,
     "target": "3",
-    "timestamp": 7412071,
+    "timestamp": 1600007412071,
     "type": "heal",
   },
   Object {
@@ -173,7 +173,7 @@ Array [
       "x": 9887,
       "y": 10642,
     },
-    "timestamp": 7412071,
+    "timestamp": 1600007412071,
     "type": "actorUpdate",
   },
 ]
@@ -185,7 +185,7 @@ Array [
     "action": 16139,
     "source": "4",
     "target": "2",
-    "timestamp": 7537601,
+    "timestamp": 1600007537601,
     "type": "action",
   },
 ]
@@ -207,7 +207,7 @@ Array [
     "sourceModifier": 0,
     "target": "3",
     "targetModifier": 0,
-    "timestamp": 8012166,
+    "timestamp": 1600008012166,
     "type": "damage",
   },
   Object {
@@ -225,7 +225,7 @@ Array [
       "x": 9999,
       "y": 10081,
     },
-    "timestamp": 8012166,
+    "timestamp": 1600008012166,
     "type": "actorUpdate",
   },
 ]
@@ -238,7 +238,7 @@ Array [
     "sequence": 18762,
     "source": "2",
     "target": "3",
-    "timestamp": 107453814,
+    "timestamp": 1600107453814,
     "type": "execute",
   },
   Object {
@@ -256,7 +256,7 @@ Array [
       "x": 10000,
       "y": 9100,
     },
-    "timestamp": 107453814,
+    "timestamp": 1600107453814,
     "type": "actorUpdate",
   },
 ]
@@ -272,7 +272,7 @@ Array [
     "mp": Object {
       "current": 0,
     },
-    "timestamp": 502017,
+    "timestamp": 1600000502017,
     "type": "actorUpdate",
   },
 ]
@@ -297,7 +297,7 @@ Array [
     "source": "11",
     "sourceModifier": 0,
     "target": "8",
-    "timestamp": 8586700,
+    "timestamp": 1600008586700,
     "type": "heal",
   },
   Object {
@@ -315,7 +315,7 @@ Array [
       "x": 10601,
       "y": 9971,
     },
-    "timestamp": 8586700,
+    "timestamp": 1600008586700,
     "type": "actorUpdate",
   },
 ]
@@ -328,7 +328,7 @@ Array [
     "sequence": 18799,
     "source": "1",
     "target": "1",
-    "timestamp": 107457863,
+    "timestamp": 1600107457863,
     "type": "execute",
   },
   Object {
@@ -346,7 +346,7 @@ Array [
       "x": 9996,
       "y": 9999,
     },
-    "timestamp": 107457863,
+    "timestamp": 1600107457863,
     "type": "actorUpdate",
   },
 ]
@@ -360,7 +360,7 @@ Array [
     "source": "3",
     "status": 1001873,
     "target": "3",
-    "timestamp": 7416935,
+    "timestamp": 1600007416935,
     "type": "statusApply",
   },
 ]
@@ -372,7 +372,7 @@ Array [
     "source": "8",
     "status": 1000861,
     "target": "2",
-    "timestamp": 7423728,
+    "timestamp": 1600007423728,
     "type": "statusApply",
   },
 ]
@@ -385,21 +385,21 @@ Array [
     "source": "1",
     "status": 1001902,
     "target": "1",
-    "timestamp": -3,
+    "timestamp": 1599999999997,
     "type": "action",
   },
   Object {
     "source": "1",
     "status": 1001902,
     "target": "1",
-    "timestamp": -2,
+    "timestamp": 1599999999998,
     "type": "statusApply",
   },
   Object {
     "source": "1",
     "status": 1001902,
     "target": "1",
-    "timestamp": 7735462,
+    "timestamp": 1600007735462,
     "type": "statusRemove",
   },
 ]
@@ -413,7 +413,7 @@ Array [
     "source": "7",
     "status": 1001238,
     "target": "7",
-    "timestamp": -3,
+    "timestamp": 1599999999997,
     "type": "action",
   },
   Object {
@@ -421,7 +421,7 @@ Array [
     "source": "7",
     "status": 1001238,
     "target": "7",
-    "timestamp": 7410865,
+    "timestamp": 1600007410865,
     "type": "statusApply",
   },
 ]
@@ -434,21 +434,21 @@ Array [
     "source": "9",
     "status": 1001221,
     "target": "2",
-    "timestamp": -3,
+    "timestamp": 1599999999997,
     "type": "action",
   },
   Object {
     "source": "9",
     "status": 1001221,
     "target": "2",
-    "timestamp": -2,
+    "timestamp": 1599999999998,
     "type": "statusApply",
   },
   Object {
     "source": "9",
     "status": 1001221,
     "target": "2",
-    "timestamp": 7427662,
+    "timestamp": 1600007427662,
     "type": "statusRemove",
   },
 ]
@@ -461,7 +461,7 @@ Array [
     "source": "4917",
     "status": 1001964,
     "target": "4883:14",
-    "timestamp": 431742760,
+    "timestamp": 1600431742760,
     "type": "statusApply",
   },
 ]
@@ -472,7 +472,7 @@ Array [
   Object {
     "actor": "20:7",
     "targetable": true,
-    "timestamp": 7906700,
+    "timestamp": 1600007906700,
     "type": "actorUpdate",
   },
 ]

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -26,9 +26,12 @@ const actor: Actor = {
 	job: 'UNKNOWN',
 }
 
+// Semi-arbitrary time during 5.3. Needs to be post-5.08 for code path purposes.
+const timestamp = 1600000000000
+
 const pull: Pull = {
 	id: '1',
-	timestamp: 0,
+	timestamp,
 	duration: 1,
 	encounter: {
 		name: 'test encounter',
@@ -41,7 +44,7 @@ const pull: Pull = {
 }
 
 const report: Report = {
-	timestamp: 0,
+	timestamp,
 	edition: GameEdition.GLOBAL,
 	name: 'Event adapter test',
 	pulls: [pull],
@@ -769,24 +772,26 @@ describe('Event adapter', () => {
 			&& event.actor === '1'
 		)
 
+		/* eslint-disable @typescript-eslint/no-magic-numbers */
 		expect(updates).toEqual([{
-			timestamp: 100,
+			timestamp: timestamp + 100,
 			type: 'actorUpdate',
 			actor: '1',
 			hp: {current: 100, maximum: 1000},
 			mp: {current: 100, maximum: 10000},
 			position: {x: 100, y: 100, bearing: 0},
 		}, {
-			timestamp: 200,
+			timestamp: timestamp + 200,
 			type: 'actorUpdate',
 			actor: '1',
 			hp: {current: 200},
 		}, {
-			timestamp: 300,
+			timestamp: timestamp + 300,
 			type: 'actorUpdate',
 			actor: '1',
 			mp: {current: 300, maximum: 15000},
 			position: {x: 150, y: 50},
 		}])
+		/* eslint-enable @typescript-eslint/no-magic-numbers */
 	})
 })

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -617,6 +617,32 @@ describe('Event adapter', () => {
 		}))
 	})
 
+	it('preserves event semantics for old logs', () => {
+		const result = adaptEvents(
+			{...report, timestamp: 0},
+			{...pull, timestamp: 0},
+			[
+				fakeEvents.calculateddamage[0],
+				fakeEvents.calculatedheal[0],
+				fakeEvents.damage[0],
+				fakeEvents.heal[0],
+			],
+		)
+
+		expect(result.map(event => event.type)).toEqual([
+			// calculated events should be nooped
+			'damage', // from damage event
+			'execute', // fabricated immediate execution
+			'actorUpdate',
+			'heal',
+			'execute',
+			'actorUpdate',
+		])
+		// Ensure the sequence is matched up
+		expect((result[0] as Events['damage']).sequence).toEqual((result[1] as Events['execute']).sequence)
+		expect((result[3] as Events['heal']).sequence).toEqual((result[4] as Events['execute']).sequence)
+	})
+
 	it('sorts events with identical timestamps', () => {
 		const result = adaptEvents(report, pull, [
 			{...fakeEvents.applybuff[0], timestamp: 1},

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -186,7 +186,7 @@ export class TranslateAdapterStep extends AdapterStep {
 		// We don't get explicit execution, fabricate an execute to preserve event stream semantics
 		const sequence = this.falseSequence++
 		(adaptedEvents[primaryEventIndex] as Events['damage' | 'heal']).sequence = sequence
-		adaptedEvents.splice(primaryEventIndex, 0, {
+		adaptedEvents.splice(primaryEventIndex+1, 0, {
 			...this.adaptTargetedFields(event),
 			type: 'execute',
 			action: event.ability.guid,

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -45,25 +45,37 @@ const FAILED_HITS = new Set([
 ])
 /* eslint-enable @typescript-eslint/no-magic-numbers */
 
+// Calculated damage/heal events were not added to FF Logs until during 5.05 ish.
+// To ensure the xiva event model remains sane, we patch up events to match them together.
 const CALCULATED_DAMAGE_UPDATE: PatchNumber = '5.08'
-
-// 1564483826807
-
-// private adaptEffectEvent(event: DamageEvent | HealEvent): Array<Events['execute' | 'damage' | 'heal' | 'actorUpdate']> {
 
 /** Translate an FFLogs APIv1 event to the xiva representation, if any exists. */
 export class TranslateAdapterStep extends AdapterStep {
 	private unhandledTypes = new Set<string>()
 
-	private adaptFuck: (event: DamageEvent | HealEvent) => Event[]
+	private falseSequence = 0
+	private adaptEffectEvent: (event: DamageEvent | HealEvent) => Event[]
+	private adaptDamageEvent: (event: DamageEvent) => Event[]
+	private adaptHealEvent: (event: HealEvent) => Event[]
 
 	constructor(opts: AdapterOptions) {
 		super(opts)
 
+		// TODO: Remove this logic in 6.0.
 		const patch = new Patch(this.report.edition, this.report.timestamp/1000)
-		this.adaptFuck = patch.before(CALCULATED_DAMAGE_UPDATE)
-			? this.adaptFuckingOldTHing
-			: this.adaptEffectEvent
+		const beforeCalculateDamageUpdate = patch.before(CALCULATED_DAMAGE_UPDATE)
+		this.adaptEffectEvent = beforeCalculateDamageUpdate
+			? this.adaptPreCalculatedEffectEvent
+			: this.adaptPostCalculatedEffectEvent
+
+		// While the above should be enough, we noop the calculated* events just in
+		// case they slip through, to preserve event stream sanity.
+		this.adaptDamageEvent = beforeCalculateDamageUpdate
+			? this.adaptNothing
+			: this.adaptPostCalculatedDamageEvent
+		this.adaptHealEvent = beforeCalculateDamageUpdate
+			? this.adaptNothing
+			: this.adaptPostCalculatedHealEvent
 	}
 
 	adapt(baseEvent: FflogsEvent, _adaptedEvents: Event[]): Event[] {
@@ -79,7 +91,7 @@ export class TranslateAdapterStep extends AdapterStep {
 
 		case 'damage':
 		case 'heal':
-			return this.adaptFuck(baseEvent)
+			return this.adaptEffectEvent(baseEvent)
 
 		case 'applybuff':
 		case 'applydebuff':
@@ -149,6 +161,8 @@ export class TranslateAdapterStep extends AdapterStep {
 		return []
 	}
 
+	private adaptNothing(_event: FflogsEvent): Event[] { return [] }
+
 	private adaptCastEvent(event: CastEvent): Events['prepare' | 'action'] {
 		return {
 			...this.adaptTargetedFields(event),
@@ -157,12 +171,32 @@ export class TranslateAdapterStep extends AdapterStep {
 		}
 	}
 
-	private adaptFuckingOldTHing(event: DamageEvent | HealEvent): Event[] {
-		console.log('fuck')
-		return []
+	private adaptPreCalculatedEffectEvent(event: DamageEvent | HealEvent): Event[] {
+		// Adapt the event into the primary effect event
+		let adaptedEvents: Event[] | undefined
+		if (event.type === 'damage') { adaptedEvents = this.adaptPostCalculatedDamageEvent(event) }
+		if (event.type === 'heal') { adaptedEvents = this.adaptPostCalculatedHealEvent(event) }
+		if (adaptedEvents == null) {
+			throw new Error(`Unexpected event type "${event.type}" when adapting old effect event.`)
+		}
+
+		const primaryEventIndex = adaptedEvents
+			.findIndex(adaptedEvent => adaptedEvent.type === 'damage' || adaptedEvent.type === 'heal')
+
+		// We don't get explicit execution, fabricate an execute to preserve event stream semantics
+		const sequence = this.falseSequence++
+		(adaptedEvents[primaryEventIndex] as Events['damage' | 'heal']).sequence = sequence
+		adaptedEvents.splice(primaryEventIndex, 0, {
+			...this.adaptTargetedFields(event),
+			type: 'execute',
+			action: event.ability.guid,
+			sequence,
+		})
+
+		return adaptedEvents
 	}
 
-	private adaptEffectEvent(event: DamageEvent | HealEvent): Array<Events['execute' | 'damage' | 'heal' | 'actorUpdate']> {
+	private adaptPostCalculatedEffectEvent(event: DamageEvent | HealEvent): Array<Events['execute' | 'damage' | 'heal' | 'actorUpdate']> {
 		// Calc events should all have a packet ID for sequence purposes. Let sentry catch outliers.
 		const sequence = event.packetID
 		if (sequence == null) {
@@ -174,10 +208,9 @@ export class TranslateAdapterStep extends AdapterStep {
 				|| EFFECT_ONLY_ACTIONS.has(event.ability.guid)
 				|| FAILED_HITS.has(event.hitType)
 			) {
-				if (event.type === 'damage') { return this.adaptDamageEvent(event) }
-				if (event.type === 'heal') { return this.adaptHealEvent(event) }
+				if (event.type === 'damage') { return this.adaptPostCalculatedDamageEvent(event) }
+				if (event.type === 'heal') { return this.adaptPostCalculatedHealEvent(event) }
 			}
-			debugger
 			throw new Error('FFLogs Effect event encountered with no packet ID, did not match to over time status effect (DoT/HoT)')
 		}
 
@@ -192,7 +225,7 @@ export class TranslateAdapterStep extends AdapterStep {
 		return [newEvent, ...this.buildActorUpdateResourceEvents(event)]
 	}
 
-	private adaptDamageEvent(event: DamageEvent): Array<Events['damage' | 'actorUpdate']> {
+	private adaptPostCalculatedDamageEvent(event: DamageEvent): Array<Events['damage' | 'actorUpdate']> {
 		// Calculate source modifier
 		let sourceModifier = sourceHitType[event.hitType] ?? SourceModifier.NORMAL
 		if (event.multistrike) {
@@ -218,7 +251,7 @@ export class TranslateAdapterStep extends AdapterStep {
 		return [newEvent, ...this.buildActorUpdateResourceEvents(event)]
 	}
 
-	private adaptHealEvent(event: HealEvent): Array<Events['heal' | 'actorUpdate']> {
+	private adaptPostCalculatedHealEvent(event: HealEvent): Array<Events['heal' | 'actorUpdate']> {
 		const overheal = event.overheal ?? 0
 		const newEvent: Events['heal'] = {
 			...this.adaptTargetedFields(event),


### PR DESCRIPTION
What the title says.

This acts under the assumption that _everything_ prior to 5.08 has no `calculatedX` events, and noops them to be doubly sure.
It then treats all `damage` and `heal` events (as opposed to `calculateddamage` and `calculatedheal`) as the primary effect, and fabricates an immediate execute event.

This should effectively maintain the semantics of xiva's event model with... _reasonable_ back compat with old stuff. Reasonable enough to not crash and provide semi-sane output, at least.