### PR TITLE
SMN - more summons, more problems

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -875,7 +875,7 @@
   "smn.pets.suggestions.garuda-st.why": "Garuda-Egi was attacking a single target {0}% of the time it was active.",
   "smn.pets.suggestions.ifrit-aoe.content": "Ifrit-Egi should only be used for single target.  Use Garuda-Egi instead when multiple targets are available, as it will deal more damage.",
   "smn.pets.suggestions.ifrit-aoe.why": "Ifrit-Egi hit multiple targets with {0, plural, one {# use} other {# uses}} of <0/> or <1/>.",
-  "smn.pets.suggestions.no-pet.content": "Pets provide a <0>lot</0> of SMN's passive damage, and are essential for <1/> procs and <2/>. Make sure you have a pet summoned at all times, and keep them out of boss AoEs.",
+  "smn.pets.suggestions.no-pet.content": "Pets provide a <0>lot</0> of SMN's passive damage, and are essential for <1/> procs and <2/>. Make sure you have a pet summoned at all times.",
   "smn.pets.suggestions.no-pet.why": "No pet summoned for {noPetUptimePercent}% of the fight (<1% is recommended).",
   "smn.pets.suggestions.slipstream-ticks.content": "Ensure you use <0/> such that it can deal damage for its entire duration. Summoning another pet or recasting Slipstream will prevent any remaining ticks of a cast.",
   "smn.pets.suggestions.slipstream-ticks.why": "{missedTicks, plural, one {# missed tick} other {# missed ticks}} of Slipstream.",

--- a/src/parser/jobs/smn/modules/Pets.js
+++ b/src/parser/jobs/smn/modules/Pets.js
@@ -115,9 +115,11 @@ export default class Pets extends Module {
 
 			// I mean this shouldn't happen but people are stupid.
 			// If there's a summon cast before any pet action, they didn't start with a pet.
-			if (action.id && Object.keys(SUMMON_ACTIONS).includes(action.id.toString())) {
-				break
-			}
+			if (
+				action.id &&
+				event.sourceID === this.parser.player.id &&
+				Object.keys(SUMMON_ACTIONS).includes(action.id.toString())
+			) { break }
 
 			const pet = petCache[event.sourceID]
 				|| this.parser.report.friendlyPets.find(pet => pet.id === event.sourceID)
@@ -319,7 +321,7 @@ export default class Pets extends Module {
 			tiers: NO_PET_SEVERITY,
 			value: noPetUptimePercent,
 			content: <Trans id="smn.pets.suggestions.no-pet.content">
-				Pets provide a <em>lot</em> of SMN's passive damage, and are essential for <StatusLink {...STATUSES.FURTHER_RUIN}/> procs and <ActionLink {...ACTIONS.ENKINDLE}/>. Make sure you have a pet summoned at all times, and keep them out of boss AoEs.
+				Pets provide a <em>lot</em> of SMN's passive damage, and are essential for <StatusLink {...STATUSES.FURTHER_RUIN}/> procs and <ActionLink {...ACTIONS.ENKINDLE}/>. Make sure you have a pet summoned at all times.
 			</Trans>,
 			why: <Trans id="smn.pets.suggestions.no-pet.why">
 				No pet summoned for {noPetUptimePercent}% of the fight (&lt;1% is recommended).


### PR DESCRIPTION
Prevents the pet summon normaliser from `break`ing prematurely when a summon event is detected from a summoner other than the selected player. Also removes an outdated reference to "keeping your pet out of boss AoEs", since pets can't die anymore.
