### PR TITLE
Add new interrupt event to core structure

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -69,9 +69,7 @@ interface EventPrepare extends FieldsTargeted {
 }
 
 /** An actor's cast has been interrupted in some manner. */
-interface EventInterrupt extends FieldsBase {
-	/** ID of the actor whose cast was interrupted. */
-	actor: Actor['id']
+interface EventInterrupt extends FieldsTargeted {
 	/** XIV Action ID */
 	action: number
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -68,6 +68,14 @@ interface EventPrepare extends FieldsTargeted {
 	action: number
 }
 
+/** An actor's cast has been interrupted in some manner. */
+interface EventInterrupt extends FieldsBase {
+	/** ID of the actor whose cast was interrupted. */
+	actor: Actor['id']
+	/** XIV Action ID */
+	action: number
+}
+
 /** An actor has executed an action. */
 interface EventAction extends FieldsTargeted {
 	/** XIV Action ID */
@@ -185,6 +193,7 @@ interface EventActorUpdate extends FieldsBase {
 // eslint-disable-next-line import/export
 export interface EventTypeRepository {
 	prepare: EventPrepare
+	interrupt: EventInterrupt
 	action: EventAction
 	statusApply: EventStatusApply
 	statusRemove: EventStatusRemove

--- a/src/parser/core/modules/EventsView/eventFormatter.tsx
+++ b/src/parser/core/modules/EventsView/eventFormatter.tsx
@@ -72,9 +72,9 @@ registerEventFormatter('prepare', ({event, pull}) => <>
 </>)
 
 registerEventFormatter('interrupt', ({event, pull}) => <>
-	{getActorName(event.actor, pull.actors)}'s
+	{getActorName(event.source, pull.actors)}
+	&nbsp;interrupts {getActorName(event.target, pull.actors)}'s
 	&nbsp;<ActionLink id={event.action}/>
-	&nbsp;is interrupted
 </>)
 
 registerEventFormatter('action', ({event, pull}) => <>

--- a/src/parser/core/modules/EventsView/eventFormatter.tsx
+++ b/src/parser/core/modules/EventsView/eventFormatter.tsx
@@ -71,6 +71,12 @@ registerEventFormatter('prepare', ({event, pull}) => <>
 	&nbsp;on {getActorName(event.target, pull.actors)}
 </>)
 
+registerEventFormatter('interrupt', ({event, pull}) => <>
+	{getActorName(event.actor, pull.actors)}'s
+	&nbsp;<ActionLink id={event.action}/>
+	&nbsp;is interrupted
+</>)
+
 registerEventFormatter('action', ({event, pull}) => <>
 	{getActorName(event.source, pull.actors)}
 	&nbsp;uses <ActionLink id={event.action}/>

--- a/src/parser/jobs/blm/modules/Procs.tsx
+++ b/src/parser/jobs/blm/modules/Procs.tsx
@@ -12,6 +12,7 @@ import React from 'react'
 
 declare module 'event' {
 	interface FieldsTargeted {
+		/** BLM specific logic. Do not use. Please remove ASAP. */
 		overrideAction?: number
 	}
 }

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -1,6 +1,6 @@
 import {GameEdition} from 'data/EDITIONS'
 import {Events} from 'event'
-import {FflogsEvent, HitType, ReportLanguage} from 'fflogs'
+import {CastEvent, FflogsEvent, HitType, ReportLanguage} from 'fflogs'
 import {Actor, Pull, Report, Team} from 'report'
 import {adaptEvents} from '../eventAdapter'
 import {AdapterStep} from '../eventAdapter/base'
@@ -657,6 +657,36 @@ describe('Event adapter', () => {
 			'action',
 			'statusApply',
 		])
+	})
+
+	it('fabricates interrupts', () => {
+		const interruptedAbility = (fakeEvents.begincast[0] as CastEvent).ability
+		const interruptingAbility = {...interruptedAbility, guid: interruptedAbility.guid + 1}
+		const interruptionTimestamp = 4
+
+		const result = adaptEvents(report, pull, [
+			{...fakeEvents.begincast[0], ability: interruptedAbility, sourceID: 1, timestamp: 1} as CastEvent,
+			{...fakeEvents.begincast[0], ability: interruptedAbility, sourceID: 2, timestamp: 1} as CastEvent,
+			{...fakeEvents.cast[0], ability: interruptedAbility, sourceID: 1, timestamp: 2} as CastEvent,
+
+			{...fakeEvents.begincast[0], ability: interruptedAbility, sourceID: 1, timestamp: 3} as CastEvent,
+			{...fakeEvents.begincast[0], ability: interruptingAbility, sourceID: 1, timestamp: interruptionTimestamp} as CastEvent,
+		])
+
+		expect(result.map(event => event.type)).toEqual([
+			'prepare', // regular cast sequence from actor 1
+			'prepare', // prep from actor 2, should not effect actor 1
+			'action',
+			'prepare', // interrupted cast from actor 1
+			'interrupt',
+			'prepare',
+		])
+		expect(result[4] as Events['interrupt']).toEqual({
+			type: 'interrupt',
+			timestamp: timestamp + interruptionTimestamp,
+			actor: '1',
+			action: interruptedAbility.guid,
+		})
 	})
 
 	it('synthesizes prepull actions', () => {

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -684,7 +684,8 @@ describe('Event adapter', () => {
 		expect(result[4] as Events['interrupt']).toEqual({
 			type: 'interrupt',
 			timestamp: timestamp + interruptionTimestamp,
-			actor: '1',
+			source: '1',
+			target: '1',
 			action: interruptedAbility.guid,
 		})
 	})

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -5,6 +5,7 @@ import {Pull, Report} from 'report'
 import {AdapterOptions, AdapterStep} from './base'
 import {DeduplicateActorUpdateStep} from './deduplicateActorUpdates'
 import {DeduplicateStatusApplicationStep} from './deduplicateStatus'
+import {InterruptsAdapterStep} from './interrupts'
 import {OneHpLockAdapterStep} from './oneHpLock'
 import {PrepullActionAdapterStep} from './prepullAction'
 import {PrepullStatusAdapterStep} from './prepullStatus'
@@ -32,6 +33,7 @@ class EventAdapter {
 		this.adaptionSteps = [
 			new ReassignUnknownActorStep(opts),
 			new TranslateAdapterStep(opts),
+			new InterruptsAdapterStep(opts),
 			new DeduplicateStatusApplicationStep(opts),
 			new DeduplicateActorUpdateStep(opts),
 			new PrepullActionAdapterStep(opts),

--- a/src/reportSources/legacyFflogs/eventAdapter/interrupts.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/interrupts.ts
@@ -1,0 +1,55 @@
+import {Event, Events} from 'event'
+import {FflogsEvent} from 'fflogs'
+import {Actor} from 'report'
+import {AdapterStep} from './base'
+
+export class InterruptsAdapterStep extends AdapterStep {
+	private casts = new Map<Actor['id'], number>()
+
+	adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
+		const interrupts: Array<Events['interrupt']> = []
+
+		for (const event of adaptedEvents) {
+			if (event.type === 'prepare') {
+				// If there's an existing cast, this prepare likely signals an interrupt
+				const action = this.casts.get(event.source)
+				if (action != null) {
+					interrupts.push(this.fromEvent(event, action))
+				}
+
+				// Mark the prepared action as being cast
+				this.casts.set(event.source, event.action)
+
+			} else if (event.type === 'action') {
+				// If the action doesn't match the cast, it's likely an instant cast
+				// following an interrupted hard cast
+				const action = this.casts.get(event.source)
+				if (action != null && action !== event.action) {
+					interrupts.push(this.fromEvent(event, action))
+				}
+
+				// Clear any further cast state
+				this.casts.delete(event.source)
+			}
+		}
+
+		// NOTE: This assumes that no single set of adapted events will contain start-
+		//       to-end an interruption sequence. Given fflogs, this is a safe assumption.
+		//       Double check before moving to any other report source.
+		return interrupts.length > 0
+			? [...interrupts, ...adaptedEvents]
+			: adaptedEvents
+	}
+
+	private fromEvent(
+		event: Events['prepare'] | Events['action'],
+		action: number
+	): Events['interrupt'] {
+		return {
+			type: 'interrupt',
+			timestamp: event.timestamp,
+			actor: event.source,
+			action,
+		}
+	}
+}

--- a/src/reportSources/legacyFflogs/eventAdapter/interrupts.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/interrupts.ts
@@ -48,7 +48,10 @@ export class InterruptsAdapterStep extends AdapterStep {
 		return {
 			type: 'interrupt',
 			timestamp: event.timestamp,
-			actor: event.source,
+			// TODO: Work out if it's possible to find the true source of the interruption.
+			//       Using source for now, as it's a reasonably safe bet for players.
+			source: event.source,
+			target: event.source,
 			action,
 		}
 	}


### PR DESCRIPTION
Title. Cast interruption/cancellation is a discrete concept in the game (pretty sure it's an ActorControl packet or similar), and is even logged by ACT. Unfortunately it isn't exposed by fflogs, so here we are, fabricating it. Great.

I'm opting to keep both a source and target field on this event, as realistically, interruptions _are_ targeted. Movement and explicit cancellation is self -> self, but players can interrupt some boss abilities, and (at least in the past?) bosses can interrupt us with damage.