### PR TITLE
BLM - Don't flag rotations with all expected fires as having 'extra T3's

### DIFF
--- a/src/parser/jobs/blm/modules/RotationWatchdog.tsx
+++ b/src/parser/jobs/blm/modules/RotationWatchdog.tsx
@@ -150,7 +150,12 @@ class Cycle {
 	public get hardT3Count(): number {
 		return this.casts.filter(cast => cast.ability.guid === ACTIONS.THUNDER_III.id && !cast.isProc).length
 	}
+	// TODO: Need to find a way to distinguish which AF/UI element the thunders were cast in, and filter out the hardcasts that happened in Ice phase...
+	// Also probably want to better calculate how many T3 hardcasts could happen without sacrificing a fire (ie, one before and after manafont, with enough starting MP) and refund that many instead of a flat one (in case of multitarget bosses)
 	public get extraT3s(): number {
+		if (!(this.missingFire4s || this.missingDespairs)) { // By definition, if you didn't miss any expected casts, you couldn't have hardcast an extra T3
+			return 0
+		}
 		if (this.firePhaseStartMP < MIN_MP_FOR_FULL_ROTATION) {
 			return this.hardT3Count
 		}


### PR DESCRIPTION
Depending on the exact ordering of the MP status updates vs the rotation starting, opener MP can come in as 8000, which is below our 'Max MP for full rotation' threshold. That doesn't mean you'll actually be missing fires however...

Similarly, thunder spam under ice shouldn't _really_ flag as 'extra hardcast t3s' since that metric is about losing Fires because of it, which isn't the case for ice phase thunders.

There's probably some better calculation work we can put into the 'did you hardcast more T3s than you should have?' logic, but for right now, just including a backstop of checking if you got all your fires should resolve the bug.