### PR TITLE
WHM: Thin air MP tracking module

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -939,5 +939,9 @@
   "whm.ogcds.title": "Anwendungen außerhalb der globalen Abklingzeit",
   "whm.overheal.assize.name": "Assise",
   "whm.overheal.hot.name": "",
-  "whm.swiftcast.missed.suggestion.content": "Wirke Zauber mit <0/> bevor es abläuft. Dadurch kannst du Angriffe mit Anwendungszeit sofort benutzen, wie beispielsweise <1/> für schnelle Wiederbelebungen oder <2/> zwischen Angriffen mit globaler Abklingzeit (zum weaven)."
+  "whm.swiftcast.missed.suggestion.content": "Wirke Zauber mit <0/> bevor es abläuft. Dadurch kannst du Angriffe mit Anwendungszeit sofort benutzen, wie beispielsweise <1/> für schnelle Wiederbelebungen oder <2/> zwischen Angriffen mit globaler Abklingzeit (zum weaven).",
+  "whm.thinair.messages.explanation": "",
+  "whm.thinair.messages.no-casts": "",
+  "whm.thinair.rotation.gcd": "",
+  "whm.thinair.title": ""
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -939,5 +939,9 @@
   "whm.ogcds.title": "Off Global Cooldowns",
   "whm.overheal.assize.name": "Assize",
   "whm.overheal.hot.name": "Healing Over Time",
-  "whm.swiftcast.missed.suggestion.content": "Cast a spell with <0/> before it expires. This allows you to instantly cast spells with a cast times, such as <1/> for a quick revive, or <2/> for weaving."
+  "whm.swiftcast.missed.suggestion.content": "Cast a spell with <0/> before it expires. This allows you to instantly cast spells with a cast times, such as <1/> for a quick revive, or <2/> for weaving.",
+  "whm.thinair.messages.explanation": "The main use of <0/> should be to save MP on high-MP cost phases of the fight. Don't be afraid to hold it and lose a use over the fight as long as it covers MP-heavy portions of the fight such as usages of <1/>, <2/> and <3/>",
+  "whm.thinair.messages.no-casts": "No casts recorded for <0/>",
+  "whm.thinair.rotation.gcd": "{numGcds, plural, one {# GCD} other {# GCDs}}",
+  "whm.thinair.title": "Thin Air"
 }

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -940,7 +940,7 @@
   "whm.overheal.assize.name": "Assize",
   "whm.overheal.hot.name": "Healing Over Time",
   "whm.swiftcast.missed.suggestion.content": "Cast a spell with <0/> before it expires. This allows you to instantly cast spells with a cast times, such as <1/> for a quick revive, or <2/> for weaving.",
-  "whm.thinair.messages.explanation": "The main use of <0/> should be to save MP on high-MP cost phases of the fight. Don't be afraid to hold it and lose a use over the fight as long as it covers MP-heavy portions of the fight such as usages of <1/>, <2/> and <3/>",
+  "whm.thinair.messages.explanation": "The main use of <0/> should be to save MP on high-MP cost phases of the fight. Don't be afraid to hold it and lose a use over the fight as long as it covers MP-heavy portions of the fight such as usages of <1/>, <2/>, and <3/>",
   "whm.thinair.messages.no-casts": "No casts recorded for <0/>",
   "whm.thinair.rotation.gcd": "{numGcds, plural, one {# GCD} other {# GCDs}}",
   "whm.thinair.title": "Thin Air"

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -939,5 +939,9 @@
   "whm.ogcds.title": "Temps de rechargement global",
   "whm.overheal.assize.name": "Assise",
   "whm.overheal.hot.name": "Soin sur la durée",
-  "whm.swiftcast.missed.suggestion.content": "Lancer un sort avec <0/> avant qu'il expire. Cela vous permet d'utiliser directement un sort avec un temps de lancement, tel que <1/> pour une résurrection rapide , ou <2/> pour weave."
+  "whm.swiftcast.missed.suggestion.content": "Lancer un sort avec <0/> avant qu'il expire. Cela vous permet d'utiliser directement un sort avec un temps de lancement, tel que <1/> pour une résurrection rapide , ou <2/> pour weave.",
+  "whm.thinair.messages.explanation": "",
+  "whm.thinair.messages.no-casts": "",
+  "whm.thinair.rotation.gcd": "",
+  "whm.thinair.title": ""
 }

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -939,5 +939,9 @@
   "whm.ogcds.title": "GCD オフ",
   "whm.overheal.assize.name": "アサイズ",
   "whm.overheal.hot.name": "HoT",
-  "whm.swiftcast.missed.suggestion.content": ""
+  "whm.swiftcast.missed.suggestion.content": "",
+  "whm.thinair.messages.explanation": "",
+  "whm.thinair.messages.no-casts": "",
+  "whm.thinair.rotation.gcd": "",
+  "whm.thinair.title": ""
 }

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -939,5 +939,9 @@
   "whm.ogcds.title": "논글로벌 기술",
   "whm.overheal.assize.name": "심판",
   "whm.overheal.hot.name": "도트힐",
-  "whm.swiftcast.missed.suggestion.content": "<0/> 지속시간이 만료되기전에 사용하십시오. <1/>과 병행하여 빠른 부활 혹은 <2/>와 병행하여 논글쿨기를 끼워넣는 응용을 할 수 있습니다."
+  "whm.swiftcast.missed.suggestion.content": "<0/> 지속시간이 만료되기전에 사용하십시오. <1/>과 병행하여 빠른 부활 혹은 <2/>와 병행하여 논글쿨기를 끼워넣는 응용을 할 수 있습니다.",
+  "whm.thinair.messages.explanation": "",
+  "whm.thinair.messages.no-casts": "",
+  "whm.thinair.rotation.gcd": "",
+  "whm.thinair.title": ""
 }

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -939,5 +939,9 @@
   "whm.ogcds.title": "能力技",
   "whm.overheal.assize.name": "法令",
   "whm.overheal.hot.name": "HoT",
-  "whm.swiftcast.missed.suggestion.content": "在<0/>结束之前放一个法术。这样你就可以用<1/>秒拉人或者<2/>来插入能力技。"
+  "whm.swiftcast.missed.suggestion.content": "在<0/>结束之前放一个法术。这样你就可以用<1/>秒拉人或者<2/>来插入能力技。",
+  "whm.thinair.messages.explanation": "",
+  "whm.thinair.messages.no-casts": "",
+  "whm.thinair.rotation.gcd": "",
+  "whm.thinair.title": ""
 }

--- a/src/data/ACTIONS/root/WHM.ts
+++ b/src/data/ACTIONS/root/WHM.ts
@@ -184,7 +184,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2000,
-		mpCost: 700,
+		mpCost: 1000,
 	},
 
 	CURE_III: {

--- a/src/data/ACTIONS/root/WHM.ts
+++ b/src/data/ACTIONS/root/WHM.ts
@@ -41,6 +41,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		statusesApplied: ['DIA'],
+		mpCost: 400,
 	},
 
 	GLARE: {
@@ -50,6 +51,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2500,
+		mpCost: 400,
 	},
 
 	PLENARY_INDULGENCE: {
@@ -67,6 +69,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2500,
+		mpCost: 400,
 	},
 
 	TETRAGRAMMATON: {
@@ -105,6 +108,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 3000,
+		mpCost: 600,
 	},
 
 	PRESENCE_OF_MIND: {
@@ -122,6 +126,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2500,
+		mpCost: 400,
 	},
 
 	DIVINE_BENISON: {
@@ -147,6 +152,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2500,
+		mpCost: 400,
 	},
 
 	MEDICA_II: {
@@ -157,6 +163,7 @@ export const WHM = ensureActions({
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2500,
 		statusesApplied: ['MEDICA_II'],
+		mpCost: 1300,
 	},
 
 	// the following abilities are to be moved to CNJ.js
@@ -167,6 +174,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 8000,
+		mpCost: 2400,
 	},
 
 	CURE_II: {
@@ -176,6 +184,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2000,
+		mpCost: 700,
 	},
 
 	CURE_III: {
@@ -185,6 +194,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2000,
+		mpCost: 1500,
 	},
 
 	REGEN: {
@@ -194,6 +204,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		statusesApplied: ['REGEN'],
+		mpCost: 400,
 	},
 
 	FLUID_AURA: {
@@ -210,6 +221,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2500,
+		mpCost: 1000,
 	},
 
 	STONE: {
@@ -219,6 +231,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2500,
+		mpCost: 400,
 	},
 
 	AERO_II: {
@@ -227,6 +240,7 @@ export const WHM = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000402.png',
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
+		mpCost: 400,
 	},
 
 	AERO: {
@@ -235,6 +249,7 @@ export const WHM = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000401.png',
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
+		mpCost: 400,
 	},
 
 	REPOSE: {
@@ -243,6 +258,7 @@ export const WHM = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000414.png',
 		onGcd: true,
 		castTime: 2500,
+		mpCost: 600,
 	},
 
 	STONE_II: {
@@ -252,6 +268,7 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2500,
+		mpCost: 400,
 	},
 
 	CURE: {
@@ -261,5 +278,6 @@ export const WHM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 1500,
+		mpCost: 400,
 	},
 })

--- a/src/parser/jobs/whm/modules/Thinair.tsx
+++ b/src/parser/jobs/whm/modules/Thinair.tsx
@@ -1,0 +1,143 @@
+import {t} from '@lingui/macro'
+import {Plural, Trans} from '@lingui/react'
+import {ActionLink} from 'components/ui/DbLink'
+import Rotation from 'components/ui/Rotation'
+import {getDataBy} from 'data'
+import ACTIONS from 'data/ACTIONS'
+import STATUSES from 'data/STATUSES'
+import {BuffEvent, CastEvent} from 'fflogs'
+import Module, {dependency} from 'parser/core/Module'
+import {Data} from 'parser/core/modules/Data'
+import {CompleteEvent} from 'parser/core/Parser'
+import React, {Fragment, ReactNode} from 'react'
+import {Accordion} from 'semantic-ui-react'
+
+type ThinAirRecord = {
+	start: number,
+	end: number,
+	casts: CastEvent[],
+	mpsaved: number,
+}
+
+export default class Thinair extends Module {
+	static override handle = 'thinair'
+	static override title = t('whm.thinair.title')`Thin Air`
+
+	@dependency private data!: Data
+
+	private active = false
+	private history: ThinAirRecord[] = []
+	private currentRecord: ThinAirRecord = {start: -1, end: -1, casts: [], mpsaved: 0}
+
+	protected override init() {
+		this.addEventHook('applybuff', {abilityId: STATUSES.THIN_AIR.id, by: 'player'}, this.onThinAirCast)
+		this.addEventHook('removebuff', {abilityId: STATUSES.THIN_AIR.id, by: 'player'}, this.onThinAirRemove)
+		this.addEventHook('cast', {by: 'player'}, this.onCast)
+		this.addEventHook('complete', this.onComplete)
+	}
+
+	private onThinAirCast(ev: BuffEvent) {
+		this.startThinAir(ev.timestamp)
+	}
+
+	private onThinAirRemove(ev: BuffEvent) {
+		this.stopAndSave(ev.timestamp)
+	}
+
+	private onCast(ev: CastEvent) {
+		const actionid = ev.ability.guid
+
+		if (actionid === ACTIONS.THIN_AIR.id) {
+			this.startThinAir(ev.timestamp)
+		}
+
+		// Don't track autos
+		const action = getDataBy(ACTIONS, 'id', actionid)
+		if (!this.active || !action || action.autoAttack) {
+			return
+		}
+
+		if (action.onGcd) {
+			const mpcost = action.mpCost === undefined ? 0 : action.mpCost
+			this.currentRecord.mpsaved += mpcost
+		}
+
+		// Save the event
+		this.currentRecord.casts.push(ev)
+	}
+
+	private startThinAir(timestamp: number) {
+		// Ignore if we are already active
+		if (this.active) {
+			return
+		}
+
+		this.active = true
+		this.currentRecord = {
+			start: timestamp,
+			end: -1,
+			casts: [],
+			mpsaved: 0,
+		}
+	}
+
+	private stopAndSave(timestamp: number) {
+		if (!this.active) {
+			return
+		}
+
+		this.active = false
+		this.currentRecord.end = timestamp
+		this.history.push(this.currentRecord)
+	}
+
+	private onComplete(ev: CompleteEvent) {
+		if (this.active) {
+			this.stopAndSave(ev.timestamp)
+		}
+	}
+
+	override output(): ReactNode {
+		const casts = this.history.length
+		if (casts === 0) {
+			return <Fragment>
+				<p><span><Trans id="whm.thinair.messages.no-casts">No casts recorded for <ActionLink {...ACTIONS.THIN_AIR}/></Trans></span></p>
+			</Fragment>
+		}
+
+		const panels = this.history.map(record => {
+			const gcds = record.casts
+				.map(cast => getDataBy(ACTIONS, 'id', cast.ability.guid))
+				.filter(action => action && action.onGcd)
+			const numGcds = gcds.length
+
+			return {
+				key: record.start,
+				title: {
+					content: <Fragment>
+						{this.parser.formatTimestamp(record.start)}
+						<span> - </span>
+						<Trans id="whm.thinair.rotation.gcd"><Plural value={numGcds} one="# GCD" other="# GCDs" /></Trans>, {record.mpsaved} MP saved
+					</Fragment>,
+				},
+				content: {
+					content: <Rotation events={record.casts}/>,
+				},
+			}
+		})
+
+		const thinairDisplay = <Accordion
+			exclusive={false}
+			panels={panels}
+			styled
+			fluid
+		></Accordion>
+
+		return <Fragment>
+			<p><Trans id="whm.thinair.messages.explanation">
+				The main use of <ActionLink {...ACTIONS.THIN_AIR} /> should be to save MP on high-MP cost phases of the fight. Don't be afraid to hold it and lose a use over the fight as long as it covers MP-heavy portions of the fight such as usages of <ActionLink {...ACTIONS.MEDICA_II}/>, <ActionLink {...ACTIONS.CURE_III}/> and <ActionLink {...ACTIONS.RAISE} />
+			</Trans></p>
+			{thinairDisplay}
+		</Fragment>
+	}
+}

--- a/src/parser/jobs/whm/modules/Thinair.tsx
+++ b/src/parser/jobs/whm/modules/Thinair.tsx
@@ -48,18 +48,6 @@ export class Thinair extends Analyser {
 	private onCast(ev: Events['action']) {
 		const actionid = ev.action
 
-		if (actionid === ACTIONS.THIN_AIR.id) {
-			// Include the action of casting thin air itself in the window just
-			// as a cosmetic preference to see it included in the gui
-			// We don't explicitly start the thinair window here since it only
-			// shapshots on status application, which is covered with the
-			// status filter. In theory this doesn't matter due to 600ms
-			// animation lock which should be plenty for status to apply, but
-			// who knows what horrors lurk beneath SE's code
-			this.currentRecord.casts.push(ev.action)
-			return
-		}
-
 		// Don't track autos
 		const action = getDataBy(ACTIONS, 'id', actionid)
 		if (!this.active || !action || action.autoAttack) {
@@ -87,6 +75,10 @@ export class Thinair extends Analyser {
 			casts: [],
 			mpsaved: 0,
 		}
+
+		// Add thin air action as the 1st element for cosmetic reasons
+		// and keeping in style with astro's lightspeed module
+		this.currentRecord.casts.push(ACTIONS.THIN_AIR.id)
 	}
 
 	private stopAndSave(timestamp: number) {
@@ -142,7 +134,7 @@ export class Thinair extends Analyser {
 
 		return <Fragment>
 			<p><Trans id="whm.thinair.messages.explanation">
-				The main use of <ActionLink {...ACTIONS.THIN_AIR} /> should be to save MP on high-MP cost phases of the fight. Don't be afraid to hold it and lose a use over the fight as long as it covers MP-heavy portions of the fight such as usages of <ActionLink {...ACTIONS.MEDICA_II}/>, <ActionLink {...ACTIONS.CURE_III}/> and <ActionLink {...ACTIONS.RAISE} />
+				The main use of <ActionLink {...ACTIONS.THIN_AIR} /> should be to save MP on high-MP cost phases of the fight. Don't be afraid to hold it and lose a use over the fight as long as it covers MP-heavy portions of the fight such as usages of <ActionLink {...ACTIONS.MEDICA_II}/>, <ActionLink {...ACTIONS.CURE_III}/>, and <ActionLink {...ACTIONS.RAISE} />
 			</Trans></p>
 			{thinairDisplay}
 		</Fragment>

--- a/src/parser/jobs/whm/modules/Thinair.tsx
+++ b/src/parser/jobs/whm/modules/Thinair.tsx
@@ -11,14 +11,14 @@ import {filter} from 'parser/core/filter'
 import React, {Fragment, ReactNode} from 'react'
 import {Accordion} from 'semantic-ui-react'
 
-type ThinAirRecord = {
+interface ThinAirRecord {
 	start: number,
 	end: number,
 	casts: number[],
 	mpsaved: number,
 }
 
-export default class Thinair extends Analyser {
+export class Thinair extends Analyser {
 	static override handle = 'thinair'
 	static override title = t('whm.thinair.title')`Thin Air`
 
@@ -49,7 +49,15 @@ export default class Thinair extends Analyser {
 		const actionid = ev.action
 
 		if (actionid === ACTIONS.THIN_AIR.id) {
-			this.startThinAir(ev.timestamp)
+			// Include the action of casting thin air itself in the window just
+			// as a cosmetic preference to see it included in the gui
+			// We don't explicitly start the thinair window here since it only
+			// shapshots on status application, which is covered with the
+			// status filter. In theory this doesn't matter due to 600ms
+			// animation lock which should be plenty for status to apply, but
+			// who knows what horrors lurk beneath SE's code
+			this.currentRecord.casts.push(ev.action)
+			return
 		}
 
 		// Don't track autos
@@ -58,9 +66,8 @@ export default class Thinair extends Analyser {
 			return
 		}
 
-		if (action.onGcd) {
-			const mpcost = action.mpCost === undefined ? 0 : action.mpCost
-			this.currentRecord.mpsaved += mpcost
+		if (action.mpCost) {
+			this.currentRecord.mpsaved += action.mpCost
 		}
 
 		// Save the event

--- a/src/parser/jobs/whm/modules/index.js
+++ b/src/parser/jobs/whm/modules/index.js
@@ -5,6 +5,7 @@ import oGCDs from './oGCDs'
 import Overheal from './Overheal'
 import Speedmod from './Speedmod'
 import Swiftcast from './Swiftcast'
+import Thinair from './Thinair'
 
 export default [
 	DoTs,
@@ -14,4 +15,5 @@ export default [
 	Overheal,
 	Speedmod,
 	Swiftcast,
+	Thinair,
 ]

--- a/src/parser/jobs/whm/modules/index.js
+++ b/src/parser/jobs/whm/modules/index.js
@@ -5,7 +5,7 @@ import oGCDs from './oGCDs'
 import Overheal from './Overheal'
 import Speedmod from './Speedmod'
 import Swiftcast from './Swiftcast'
-import Thinair from './Thinair'
+import {Thinair} from './Thinair'
 
 export default [
 	DoTs,


### PR DESCRIPTION
Add module to track Thin Air mana usage. Kinda what is suggested in #600, but scanning for a specific spot of time to use thin air doesn't feel quite right as rotations are different per fight and giving specific 'use thin air here' advice doesn't sit quite well with me. 

For now this just tracks each usage of thin air and how much MP they save each. Maybe add something about total MP saved and missed usages?

Edit: also please help test that the MP calculation is correct. In theory this only counts casts completed while thin air is active but that may be buggy because I don't know how the codebase actually works :/

![image](https://user-images.githubusercontent.com/30614624/121618741-57337680-ca35-11eb-829b-f624f8378be7.png)
