### PR TITLE
Cooldowns2 part 1 amendment 1: It's groups all the way down.

### DIFF
--- a/src/parser/core/modules/Cooldowns2.tsx
+++ b/src/parser/core/modules/Cooldowns2.tsx
@@ -88,13 +88,14 @@ export class Cooldowns extends Analyser {
 	}
 
 	private onPrepare(event: Events['prepare']) {
+		this.currentCast = event.action
+
 		const action = this.data.getAction(event.action)
 		if (action == null) { return }
 
 		// This is, for the sake of simplicity, assuming that charges are consumed
 		// on prepare. As it stands, no 2+ charge action actually has a cast time,
 		// so this is a pretty-safe assumption. Revisit if this ever changes.
-		this.currentCast = event.action
 		this.useAction(action)
 	}
 

--- a/src/parser/core/modules/Cooldowns2.tsx
+++ b/src/parser/core/modules/Cooldowns2.tsx
@@ -10,33 +10,49 @@ import {SpeedAdjustments} from './SpeedAdjustments'
 import {SimpleItem, SimpleRow, Timeline} from './Timeline'
 
 const DEFAULT_CHARGES = 1
+const GCD_CHARGES = 1
 const GCD_COOLDOWN_GROUP = 58
 
-interface ChargeState {
-	current: number
-	maximum: number
+/** Representative key of a cooldown group. */
+type CooldownGroup = Exclude<Action['cooldownGroup'], undefined>
+
+/** Configuration for a single cooldown group on an action. */
+interface CooldownGroupConfig {
+	action: Action
+	group: CooldownGroup
+	duration: number
+	maximumCharges: number
 }
 
-enum CooldownEndReason {
-	EXPIRED,
-	INTERRUPTED,
-	// Fudges
-	PULL_ENDED,
-	OVERLAPPED,
-}
-
+/** State of a group's cooldown. */
 interface CooldownState {
 	start: number
 	end: number
 	hook: TimestampHook
 }
 
-type CooldownGroup = Exclude<Action['cooldownGroup'], undefined>
+/** State of a group's charges. */
+interface ChargeState {
+	current: number
+	maximum: number
+}
 
-/** Configuration for a single cooldown group on an action. */
-interface CooldownGroupConfig {
-	group: CooldownGroup
-	duration: number
+/** Full state for a cooldown group. */
+interface CooldownGroupState {
+	cooldown?: CooldownState
+	charges: ChargeState
+}
+
+/**
+ * Potential reasons for a group's cooldown to be ended. Encompasses both game-
+ * truthful reasons and xiva-specific fudging.
+ */
+enum CooldownEndReason {
+	EXPIRED,
+	INTERRUPTED,
+	// Fudges
+	PULL_ENDED,
+	OVERLAPPED,
 }
 
 export class Cooldowns extends Analyser {
@@ -50,43 +66,17 @@ export class Cooldowns extends Analyser {
 	@dependency private timeline!: Timeline
 
 	private currentCast?: Action['id']
-	private chargeStates = new Map<Action['id'], ChargeState>()
-	private cooldownStates = new Map<CooldownGroup, CooldownState>()
-
-	private actionMapping = {
-		toGroupConfigs: new Map<Action['id'], CooldownGroupConfig[]>(),
-		fromGroup: new Map<CooldownGroup, Action[]>(),
-	}
-
-	private tempTimelineRow = this.timeline.addRow(new SimpleRow({label: 'cd2 temp'}))
+	private groupStates = new Map<CooldownGroup, CooldownGroupState>()
 
 	override initialise() {
-		// Preemptively build a two-directional mapping between actions and cooldown groups
-		for (const action of Object.values(this.data.actions)) {
-			const toGroupConfig: CooldownGroupConfig[] = []
-			this.actionMapping.toGroupConfigs.set(action.id, toGroupConfig)
-
-			for (const config of this.getActionCooldownGroupConfig(action)) {
-				toGroupConfig.push(config)
-
-				let fromGroup = this.actionMapping.fromGroup.get(config.group)
-				if (fromGroup == null) {
-					fromGroup = []
-					this.actionMapping.fromGroup.set(config.group, fromGroup)
-				}
-
-				fromGroup.push(action)
-			}
-		}
-
 		this.addEventHook(
 			{type: 'prepare', source: this.parser.actor.id},
 			this.onPrepare,
 		)
 
 		this.addEventHook(
-			{type: 'interrupt', target: this.parser.actor.id},
-			this.onInterrupt
+			{type: 'interrupt', source: this.parser.actor.id},
+			this.onInterrupt,
 		)
 
 		this.addEventHook(
@@ -105,7 +95,7 @@ export class Cooldowns extends Analyser {
 		// on prepare. As it stands, no 2+ charge action actually has a cast time,
 		// so this is a pretty-safe assumption. Revisit if this ever changes.
 		this.currentCast = event.action
-		this.consumeCharge(action)
+		this.useAction(action)
 	}
 
 	private onInterrupt(event: Events['interrupt']) {
@@ -118,6 +108,9 @@ export class Cooldowns extends Analyser {
 		// Clear out current cast state
 		this.currentCast = undefined
 
+		const action = this.data.getAction(event.action)
+		if (action == null) { return }
+
 		// Reset cooldown for any of the interrupted cast's groups that are currently
 		// active. We avoid inactive ones explicitly, as it's possible to interrupt
 		// a cast beyond the end of all related cooldown groups (i.e. rdm long casts).
@@ -125,10 +118,10 @@ export class Cooldowns extends Analyser {
 		//       at current, there are no multi-charge or non-gcd interruptible
 		//       skills, this is a safe assumption. Re-evaluate if the above changes.
 		// TODO: This logic might make sense as a public "reset" helper.
-		const activeConfigs = (this.actionMapping.toGroupConfigs.get(event.action) ?? [])
-			.filter(config => this.cooldownStates.has(config.group))
+		const activeConfigs = this.getActionConfigs(action)
+			.filter(config => this.getGroupState(config).cooldown != null)
 		for (const config of activeConfigs) {
-			this.endCooldownGroup(config.group, CooldownEndReason.INTERRUPTED)
+			this.endCooldown(config, CooldownEndReason.INTERRUPTED)
 		}
 	}
 
@@ -144,45 +137,49 @@ export class Cooldowns extends Analyser {
 		const action = this.data.getAction(event.action)
 		if (action == null) { return }
 
-		this.consumeCharge(action)
+		this.useAction(action)
 	}
 
 	private onComplete() {
 		// Clean up any cooldown groups that are still active
-		for (const group of this.cooldownStates.keys()) {
-			this.resolveCooldownGroup(group, CooldownEndReason.PULL_ENDED)
+		// Using fake group config, as it's pretty irrelevant at this point of the run
+		const baseConfig = {
+			action: this.data.actions.UNKNOWN,
+			duration: 0,
+			maximumCharges: DEFAULT_CHARGES,
+		}
+
+		for (const [group, state] of this.groupStates.entries()) {
+			if (state.cooldown == null) { continue }
+			this.resolveCooldown(
+				{group, ...baseConfig},
+				CooldownEndReason.PULL_ENDED
+			)
 		}
 	}
 
-	private consumeCharge(action: Action) {
-		// Shouldn't consume a charge if there's no way to then regenerate it.
-		// Realistically, almost everything should have a CD defined.
-		const cooldown = action.cooldown
-		if (cooldown == null) { return }
-
-		// TODO: possibly abstract "get charge state" to method - we might reuse in other CD tracking?
-		// Get the current charge state for the action, filling with pristine state if none exists
-		let chargeState = this.chargeStates.get(action.id)
-		if (chargeState == null) {
-			const maximum = action.charges ?? DEFAULT_CHARGES
-			chargeState = {
-				current: maximum,
-				maximum,
-			}
-			this.chargeStates.set(action.id, chargeState)
+	private useAction(action: Action) {
+		// TODO: precompute?
+		const configs = this.getActionConfigs(action)
+		for (const config of configs) {
+			this.consumeCharge(config)
 		}
+	}
+
+	private consumeCharge(config: CooldownGroupConfig) {
+		const chargeState = this.getGroupState(config).charges
 
 		// If we're trying to consume a charge at 0 charges, something in the state
 		// is very wrong (or the game is being dumb). At EOD, the parse is the source
 		// of truth, so we're fudging the current charge state to respect it.
 		if (chargeState.current <= 0) {
-			this.debug(`Attempting to consume charge of ${action.name} (${action.id}) with no charges remaining, fudging.`)
+			this.debug(`Attempting to consume charge of group ${config.group} with no charges remaining, fudging.`)
 			chargeState.current = 1
 		}
 
-		// If the action was at maximum charges, this usage will trip it's cooldown
+		// If the group was at maximum charges, this usage will trip it's cooldown
 		if (chargeState.current === chargeState.maximum) {
-			this.startGroupsForAction(action)
+			this.startCooldown(config)
 		}
 
 		// Consume the charge
@@ -191,7 +188,7 @@ export class Cooldowns extends Analyser {
 		// TEMP
 		this.debug(() => {
 			const now = this.parser.currentEpochTimestamp - this.parser.pull.timestamp
-			const row = this.tempGetTimelineRow(`charge:${action.name}`)
+			const row = this.tempGetTimelineRow(`group:${config.group}`)
 			row.addItem(new SimpleItem({
 				content: '-',
 				start: now,
@@ -199,10 +196,10 @@ export class Cooldowns extends Analyser {
 		})
 	}
 
-	private gainCharge(action: Action) {
-		// Get the current charge state for the action. If it's already at max, or
+	private gainCharge(config: CooldownGroupConfig) {
+		// Get the current charge state for the group. If it's already at max, or
 		// there's no state (implicitly max), we can noop.
-		const chargeState = this.chargeStates.get(action.id)
+		const chargeState = this.getGroupState(config).charges
 		if (
 			chargeState == null
 			|| chargeState.current === chargeState.maximum
@@ -219,13 +216,13 @@ export class Cooldowns extends Analyser {
 		//       it, which have 2+ charges. The game does not currently contain
 		//       anything which breaks this assumption.
 		if (chargeState.current < chargeState.maximum) {
-			this.startGroupsForAction(action)
+			this.startCooldown(config)
 		}
 
 		// TEMP
 		this.debug(() => {
 			const now = this.parser.currentEpochTimestamp - this.parser.pull.timestamp
-			const row = this.tempGetTimelineRow(`charge:${action.name}`)
+			const row = this.tempGetTimelineRow(`group:${config.group}`)
 			row.addItem(new SimpleItem({
 				content: '+',
 				start: now,
@@ -233,93 +230,63 @@ export class Cooldowns extends Analyser {
 		})
 	}
 
-	private startGroupsForAction(action: Action) {
-		const configs = this.actionMapping.toGroupConfigs.get(action.id) ?? []
+	private startCooldown(config: CooldownGroupConfig) {
+		const groupState = this.getGroupState(config)
 
-		// Check if any of the groups triggered by this action are already on cooldown
-		// - this is technically impossible, but Square Enix™️, so we fudge it by ending
-		// the overlapping groups with a warning.
+		// Check if this group is already on cooldown - this is technically impossible,
+		// but Square Enix™️, so we fudge it by ending the overlapping groups with a warning.
 		// TODO: Even with speed adjustments, CDGs like the GCD (58) have some seriously
 		//       fuzzy timings in logs and cause considerable overlapping anyway. Look into it.
-		const overlappingConfigs = configs.filter(config => this.cooldownStates.has(config.group))
-		if (overlappingConfigs.length > 0) {
+		const cooldownState = groupState.cooldown
+		if (cooldownState != null) {
 			this.debug(({log}) => {
 				const now = this.parser.currentEpochTimestamp
-				const overlaps = overlappingConfigs
-					.map(config => {
-						const expected = this.cooldownStates.get(config.group)?.end ?? 0
-						return `${config.group} (${this.parser.formatEpochTimestamp(expected)}, delta ${now - expected})`
-					})
-					.join(', ')
-				log(`Use of ${action.name} at ${this.parser.formatEpochTimestamp(now)} overlaps currently active groups: ${overlaps}.`)
+				log(`Use of ${config.action.name} at ${this.parser.formatEpochTimestamp(now)} overlaps currently active group ${config.group} with expected expiry ${this.parser.formatEpochTimestamp(cooldownState.end)} (delta ${now - cooldownState.end})`)
 			})
 
-			for (const config of overlappingConfigs) {
-				this.endCooldownGroup(config.group, CooldownEndReason.OVERLAPPED)
-			}
+			this.endCooldown(config, CooldownEndReason.OVERLAPPED)
 		}
 
-		// Start all cooldowns for the action
-		const attribute = action.speedAttribute
-		for (const config of configs) {
-			let duration = config.duration
-			if (attribute != null) {
-				duration = this.speedAdjustments.getAdjustedDuration({
-					duration,
-					attribute,
-				})
-			}
-
-			this.startCooldownGroup(config.group, duration)
-		}
-	}
-
-	private startCooldownGroup(group: CooldownGroup, duration: number) {
-		const cooldownState = this.cooldownStates.get(group)
-		if (cooldownState != null) {
-			throw new Error(`Trying to start cooldown for group ${group} which has an active state.`)
+		// Calculate an adjusted duration based on the triggering action
+		let duration = config.duration
+		if (config.action.speedAttribute != null) {
+			duration = this.speedAdjustments.getAdjustedDuration({
+				duration,
+				attribute: config.action.speedAttribute,
+			})
 		}
 
-		// Build a new cooldown state and save it out
+		// Save cooldown info into the state
 		const start = this.parser.currentEpochTimestamp
 		const end = start + duration
-		this.cooldownStates.set(group, {
+		groupState.cooldown = {
 			start,
 			end,
 			hook: this.addTimestampHook(end, () => {
-				this.endCooldownGroup(group, CooldownEndReason.EXPIRED)
+				this.endCooldown(config, CooldownEndReason.EXPIRED)
 			}),
-		})
-	}
-
-	private endCooldownGroup(group: CooldownGroup, reason: CooldownEndReason) {
-		this.resolveCooldownGroup(group, reason)
-
-		// On expiration of a CDG, all associated actions gain a charge.
-		// TODO: Consider perf of this on the GCD group - it's going to be looping
-		//       through every GCD in data only to noop most of them. Reverse the loop?
-		const actions = this.actionMapping.fromGroup.get(group) ?? []
-		for (const action of actions) {
-			// If _all_ groups related to the action are now off CD, we can regenerate a charge.
-			const configs = this.actionMapping.toGroupConfigs.get(action.id) ?? []
-			const offCooldown = configs.every(config => !this.cooldownStates.has(config.group))
-			if (!offCooldown) { continue }
-
-			this.gainCharge(action)
 		}
 	}
 
-	private resolveCooldownGroup(group: CooldownGroup, reason: CooldownEndReason) {
+	private endCooldown(config: CooldownGroupConfig, reason: CooldownEndReason) {
+		this.resolveCooldown(config, reason)
+
+		// The cooldown ended, we can regenerate a charge on it.
+		this.gainCharge(config)
+	}
+
+	private resolveCooldown(config: CooldownGroupConfig, reason: CooldownEndReason) {
 		// Grab the current cooldown state for the group - if there is none, something
 		// has gone pretty wrong.
-		const cooldownState = this.cooldownStates.get(group)
+		const groupState = this.getGroupState(config)
+		const cooldownState = groupState.cooldown
 		if (cooldownState == null) {
-			throw new Error(`Trying to end cooldown for group ${group} which has no current state.`)
+			throw new Error(`Trying to end cooldown for group ${config.group} which has no current state.`)
 		}
 
 		// Clear the state out of shared structures and update the end to match the
 		// current timestamp (will be a noop if CDG expired uneventfully).
-		this.cooldownStates.delete(group)
+		groupState.cooldown = undefined
 		this.removeTimestampHook(cooldownState.hook)
 		cooldownState.end = this.parser.currentEpochTimestamp
 
@@ -328,7 +295,7 @@ export class Cooldowns extends Analyser {
 			const color = reason === CooldownEndReason.INTERRUPTED
 				? Color('red')
 				: Color('green')
-			const row = this.tempGetTimelineRow(`group:${group}`)
+			const row = this.tempGetTimelineRow(`group:${config.group}`)
 			row.addItem(new SimpleItem({
 				content: <div style={{width: '100%', height: '100%', background: color.alpha(0.25).toString(), borderLeft: `1px solid ${color}`}}/>,
 				start: cooldownState.start - this.parser.pull.timestamp,
@@ -337,7 +304,21 @@ export class Cooldowns extends Analyser {
 		})
 	}
 
-	private getActionCooldownGroupConfig(action: Action): CooldownGroupConfig[] {
+	private getGroupState(config: CooldownGroupConfig) {
+		// Get the CDG's current state, fabricating a fresh one if none exists
+		let groupState = this.groupStates.get(config.group)
+		if (groupState == null) {
+			const maximum = config.maximumCharges
+			groupState = {charges: {
+				current: maximum,
+				maximum,
+			}}
+			this.groupStates.set(config.group, groupState)
+		}
+		return groupState
+	}
+
+	private getActionConfigs(action: Action): CooldownGroupConfig[] {
 		// TODO: Write automated CDG extraction from the data files, current data
 		//       is pretty dumb about this stuff.
 		const groups: CooldownGroupConfig[] = []
@@ -349,8 +330,10 @@ export class Cooldowns extends Analyser {
 		// GCDs all share a CDG.
 		if (action.onGcd) {
 			groups.push({
+				action,
 				group: GCD_COOLDOWN_GROUP,
 				duration: action.gcdRecast ?? action.cooldown,
+				maximumCharges: GCD_CHARGES,
 			})
 
 			// GCDs with a seperate recast are part of two CDGs.
@@ -363,12 +346,15 @@ export class Cooldowns extends Analyser {
 		// in (all actions must have 1+ CDGs from a game POV). Using negative to ensure
 		// that fudged CDGs do not overlap with real data.
 		groups.push({
+			action,
 			group: action.cooldownGroup ?? -action.id,
 			duration: action.cooldown,
+			maximumCharges: action.charges ?? DEFAULT_CHARGES,
 		})
 		return groups
 	}
 
+	private tempTimelineRow = this.timeline.addRow(new SimpleRow({label: 'cd2 temp'}))
 	private tempRows = new Map<string, SimpleRow>()
 	private tempGetTimelineRow(key:string) {
 		let row = this.tempRows.get(key)


### PR DESCRIPTION
Title. Turns out I made a shithouse assumption that fucked up some of the core logic. This refactors CD2 to track both cooldowns _and_ charges on a per-group basis. As a result, also simplifies a bunch of the logic. Neat.

Will be fast track merging this to hopefully resolve some of the sentry that came through.