### PR TITLE
fix: SAM not estimating GCD or ABC correctly

### DIFF
--- a/src/parser/jobs/sam/modules/Shifu.ts
+++ b/src/parser/jobs/sam/modules/Shifu.ts
@@ -12,16 +12,19 @@ export class Shifu extends CastTime {
 			.target(this.parser.actor.id)
 			.status(this.data.statuses.SHIFU.id)
 
-		this.addEventHook(shifuFilter.type('statusApply'), this.onApplyPresence)
-		this.addEventHook(shifuFilter.type('statusRemove'), this.onRemovePresence)
+		this.addEventHook(shifuFilter.type('statusApply'), this.onApplyShifu)
+		this.addEventHook(shifuFilter.type('statusRemove'), this.onRemoveShifu)
 	}
 
-	private onApplyPresence(): void {
-		const shifu = this.data.statuses.SHIFU
-		this.shifuIndex = this.setPercentageAdjustment('all', shifu.speedModifier, 'both')
+	private onApplyShifu(): void {
+		// If this is a reapply for a currently open Shifu window, do not reapply
+		if (this.shifuIndex == null) {
+			const shifu = this.data.statuses.SHIFU
+			this.shifuIndex = this.setPercentageAdjustment('all', shifu.speedModifier, 'both')
+		}
 	}
 
-	private onRemovePresence(): void {
+	private onRemoveShifu(): void {
 		this.reset(this.shifuIndex)
 		this.shifuIndex = null
 	}

--- a/src/reportSources/legacyFflogs/eventAdapter/speedStat.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/speedStat.ts
@@ -4,7 +4,6 @@ import {getDataBy} from 'data/getDataBy'
 import {JobKey} from 'data/JOBS'
 import {getStatuses} from 'data/STATUSES'
 import {Attribute, Event, Events, AttributeValue} from 'event'
-import {FflogsEvent} from 'fflogs'
 import _ from 'lodash'
 import {Actor, Team} from 'report'
 import {getSpeedStat} from 'utilities/speedStatMapper'
@@ -38,15 +37,7 @@ export class SpeedStatsAdapterStep extends AdapterStep {
 	private actorSpeedmodWindows = new Map<Actor['id'], Map<number, SpeedmodWindow[]>>()
 
 	static override debug = false
-	private endTimestamp = 0
-
-	override adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]) {
-		if (baseEvent.type === 'encounterend') {
-			this.endTimestamp = baseEvent.timestamp
-		}
-
-		return adaptedEvents
-	}
+	private endTimestamp = this.pull.timestamp + this.pull.duration
 
 	override postprocess(adaptedEvents: Event[]): Event[] {
 		adaptedEvents.forEach((event) => {
@@ -136,6 +127,7 @@ export class SpeedStatsAdapterStep extends AdapterStep {
 			return
 		}
 
+		this.debug(`Adding speed modifier window for status ${status.name} at timestamp ${event.timestamp}`)
 		windowMap.push({start: event.timestamp})
 	}
 


### PR DESCRIPTION
1) SAM exposed a bug with the SpeedStatAdapter wherein if you have a speed modifier window (e.g. Shifu) that's unclosed at the end of the fight, and FFLogs didn't send an `encounterend` event for the fight, the unclosed window won't be considered at all because the "fight end time" was never set and was treated as 0.  Switched to use parser.pull + parser.duration to compute end time, like similar guards elsewhere in code and resolved that issue.

2) The Shifu cast time override didn't appropriately handle status refreshes and was generating overlapping / stacking Shifu windows which resulted in calculated recastTime for most skills quickly reaching 1.5s, thus resulting in very low ABC estimates and erroneous weaving dings after Iajutusu.