### PR TITLE
Improve BOTD tracking across deaths, fix raise timestamp.

### DIFF
--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.js
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.js
@@ -217,6 +217,7 @@ export default class BloodOfTheDragon extends Module {
 
 	_onDeath() {
 		// RIP
+		this._updateGauge()
 		this._bloodDuration = 0
 		this._lifeDuration = 0
 		this._finishLifeWindow()
@@ -293,6 +294,7 @@ export default class BloodOfTheDragon extends Module {
 	}
 
 	_onComplete() {
+		this._updateGauge()
 		this._finishLifeWindow()
 		this._analyzeLifeWindows()
 		const duration = this.parser.currentDuration - this.death.deadTime


### PR DESCRIPTION
BOTD tracking had a typo that was causing it to not reset event times on raise, leading to some... entertaining values.

It also was not tracking the potential uptime between two deaths if there were no non-death botd related events between them, I've just patched it up by updating the gauge when that happens.