### PR TITLE
port Core Overheal to Analyser

### DIFF
--- a/src/parser/core/modules/Checklist/Requirement.js
+++ b/src/parser/core/modules/Checklist/Requirement.js
@@ -3,6 +3,7 @@ export default class Requirement {
 	_percent = null
 	value = null
 	target = 100
+	_weight = 1
 	overrideDisplay = null
 
 	get content() {
@@ -19,6 +20,12 @@ export default class Requirement {
 	}
 	set percent(value) {
 		this._percent = value
+	}
+	get weight() {
+		return this._weight
+	}
+	set weight(value) {
+		this._weight = value
 	}
 
 	constructor(options) {

--- a/src/parser/core/modules/Checklist/Rule.js
+++ b/src/parser/core/modules/Checklist/Rule.js
@@ -1,4 +1,3 @@
-import math from 'mathjsCustom'
 import {DISPLAY_ORDER} from 'parser/core/Module'
 import {matchClosestLower} from 'utilities'
 
@@ -25,10 +24,9 @@ export default class Rule {
 	}
 
 	get percent() {
-		// WoWA has a bunch of different modes for this stuff, I'm just going to use mean for now. Because I'm mean. Hue.
-		// TODO: different requirement modes
-		const percents = this.requirements.map(requirement => requirement.percent)
-		return percents.length? math.mean(percents) : 0
+		const weightedPercents = this.requirements.reduce((aggregate, requirement) => aggregate + requirement.percent * requirement.weight, 0)
+		const totalWeight = this.requirements.reduce((aggregate, requirement) => aggregate + requirement.weight, 0)
+		return totalWeight !== 0 ? weightedPercents / totalWeight : 0
 	}
 
 	constructor(options) {

--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -311,12 +311,14 @@ export class Overheal extends Analyser {
 				requirements.push(new InvertedRequirement({
 					name: this.overhealName,
 					percent:  this.direct.percentInverted,
+					weight: 0,
 				}))
 
 				for (const trackedHeal of this.trackedOverheals) {
 					requirements.push(new InvertedRequirement({
 						name: trackedHeal.name,
 						percent: trackedHeal.percentInverted,
+						weight: 0,
 					}))
 				}
 			}

--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -1,8 +1,11 @@
 import {Trans} from '@lingui/react'
 import ACTIONS from 'data/ACTIONS'
-import {HealEvent} from 'fflogs'
-import Module, {dependency} from 'parser/core/Module'
+import {Event, Events} from 'event'
+import {Analyser} from 'parser/core/Analyser'
+import {filter, oneOf} from 'parser/core/filter'
+import {dependency} from 'parser/core/Injectable'
 import Checklist, {Requirement, TARGET, TieredRule} from 'parser/core/modules/Checklist'
+import {Data} from 'parser/core/modules/Data'
 import {DataSet, PieChartStatistic, Statistics} from 'parser/core/modules/Statistics'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import React from 'react'
@@ -57,7 +60,7 @@ export class TrackedOverheal {
 	 * Get current overheal as a percentage
 	 */
 	get percent(): number {
-		if (this.heal > 0) { return 100 * (this.overheal) / (this.heal + this.overheal) }
+		if (this.heal > 0) { return 100 * (this.overheal / this.heal) }
 		return 0
 	}
 
@@ -93,16 +96,18 @@ export class TrackedOverheal {
 	 * Pushes a heal event in for tracking
 	 * @param event - The heal event to track
 	 */
-	pushHeal(event: HealEvent) {
-		this.heal += event.amount
-		this.overheal += event.overheal || 0
+	pushHeal(event: Events['heal']) {
+		this.heal += event.targets.reduce((total, target) => total + target.amount, 0)
+		this.overheal += event.targets.reduce((total, target) => total + target.overheal, 0)
 	}
 }
 
-export class CoreOverheal extends Module {
+export class Overheal extends Analyser {
 	static override handle: string = 'overheal'
+	static override debug = true
 
 	@dependency private checklist!: Checklist
+	@dependency private data!: Data
 	@dependency private suggestions!: Suggestions
 	@dependency private statistics!: Statistics
 
@@ -185,7 +190,7 @@ export class CoreOverheal extends Module {
 		return <Trans id="core.overheal.suggestion.why">You had an overheal of { overhealPercent.toFixed(2) }%</Trans>
 	}
 
-	protected override init() {
+	override initialise() {
 		this.direct = new TrackedOverheal({
 			name: this.overhealName,
 			color: this.overhealColor,
@@ -194,8 +199,12 @@ export class CoreOverheal extends Module {
 			this.trackedOverheals.push(new TrackedOverheal(healCategoryOpts))
 		}
 
-		this.addEventHook('heal', {by: 'player'}, this.onHeal)
-		this.addEventHook('heal', {by: 'pet'}, this.onPetHeal)
+		this.addEventHook(filter<Event>().type('heal').source(this.parser.actor.id), this.onHeal)
+
+		const actorPets = this.parser.pull.actors
+			.filter(actor => actor.owner != null && actor.owner.id === this.parser.actor.id)
+			.map(pet => pet.id)
+		this.addEventHook(filter<Event>().type('heal').source(oneOf(actorPets)), this.onPetHeal)
 		this.addEventHook('complete', this.onComplete)
 	}
 
@@ -205,7 +214,7 @@ export class CoreOverheal extends Module {
 	 * false ignores the heal entirely.
 	 * @param event
 	 */
-	protected considerHeal(_event: HealEvent, _pet: boolean = false): boolean {
+	protected considerHeal(_event: Events['heal'], _pet: boolean = false): boolean {
 		return true
 	}
 
@@ -217,26 +226,27 @@ export class CoreOverheal extends Module {
 		return <Trans id="core.overheal.rule.description">Avoid healing your party for more than is needed. Cut back on unnecessary heals and coordinate with your co-healer to plan resources efficiently.</Trans>
 	}
 
-	private isRegeneration(event: HealEvent): boolean {
-		return event.ability.guid === REGENERATION_ID
+	private isRegeneration(event: Events['heal']): boolean {
+		return event.cause.type === 'action' && event.cause.action === REGENERATION_ID
 	}
 
-	private onHeal(event: HealEvent, petHeal: boolean = false) {
+	private onHeal(event: Events['heal'], petHeal: boolean = false) {
 		if (this.isRegeneration(event) || ! this.considerHeal(event, petHeal)) { return }
 
-		const guid = event.ability.guid
+		const guid = event.cause.type === 'action' ? event.cause.action : event.cause.status
+		const name = event.cause.type === 'action' ? this.data.getAction(guid)?.name : this.data.getStatus(guid)?.name
 		for (const trackedHeal of this.trackedOverheals) {
 			if (trackedHeal.idIsTracked(guid)) {
-				this.debug(`Heal from ${event.ability.name} (${event.ability.guid}) at ${event.timestamp} matched into category ${trackedHeal.name.props.defaults}`)
+				this.debug(`Heal from ${name} (${guid}) at ${event.timestamp} matched into category ${trackedHeal.name.props.defaults}`)
 				trackedHeal.pushHeal(event)
 				return
 			}
 		}
-		this.debug(`Heal from ${event.ability.name} (${event.ability.guid}) at ${event.timestamp} matched into direct healing`)
+		this.debug(`Heal from ${name} (${guid}) at ${event.timestamp} matched into direct healing`)
 		this.direct.pushHeal(event)
 	}
 
-	private onPetHeal(event: HealEvent) {
+	private onPetHeal(event: Events['heal']) {
 		this.onHeal(event, true)
 	}
 
@@ -254,7 +264,7 @@ export class CoreOverheal extends Module {
 				overhealtotal += x.overheal
 			}
 		})
-		const overallOverhealPercent: number = 100 * overhealtotal / (healtotal + overhealtotal)
+		const overallOverhealPercent: number = 100 * overhealtotal / healtotal
 
 		if (this.displayPieChart) {
 			const directPercentage = this.percentageOf(this.direct.overheal, overhealtotal)

--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -104,7 +104,7 @@ export class TrackedOverheal {
 
 export class Overheal extends Analyser {
 	static override handle: string = 'overheal'
-	static override debug = true
+	static override debug = false
 
 	@dependency private checklist!: Checklist
 	@dependency private data!: Data

--- a/src/parser/jobs/sch/index.js
+++ b/src/parser/jobs/sch/index.js
@@ -26,74 +26,81 @@ export default new Meta({
 		{user: CONTRIBUTORS.SUSHIROU, role: ROLES.DEVELOPER},
 		{user: CONTRIBUTORS.NIV, role: ROLES.DEVELOPER},
 	],
-	changelog: [{
-		date: new Date('2021-04-13'),
-		Changes: () => <>Support for 5.5 added – 100 mp cost down on succor won't hurt us!.</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2020-12-7'),
-		Changes: () => <>Support for 5.4 added – potency changes shouldn't affect analysis anyway.</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2020-08-10'),
-		Changes: () => <>Support for 5.3 added – no breaking changes to current analysis.</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2020-06-30'),
-		Changes: () => <>Add potions as a module – show up with all the move used under them.</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2020-05-16'),
-		Changes: () => <>Added Recitation and Overheal visualization to SCH – huge thanks to people in #sch_lounge in the balance for feedback with content!</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2020-04-07'),
-		Changes: () => <>Add Faerie actions to timeline</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2020-02-18'),
-		Changes: () => <>Support for 5.2; happy raiding SCHs!</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2019-10-29'),
-		Changes: () => <>Support for 5.1; additionally, only warn on faerie gauge overcap starting at 50</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2019-09-19'),
-		Changes: () => <>Track interrupts; a big thanks to Tonto Draksbane and Yuni in the balance for help with this feature</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2019-08-09'),
-		Changes: () => <>
-			Initial support for Shadowbringers:&nbsp;
-			<ul>
-				<li>Add gauge tracking</li>
-				<li>Track Chain Strategem use</li>
-				<li>Fix issue with Recitation creating negative Aetherflow counts</li>
-				<li>Add Energy Drain back as a valid Aetherflow consumer</li>
-			</ul>
-		</>,
-		contributors: [CONTRIBUTORS.NONO],
-	},
-	{
-		date: new Date('2019-07-12'),
-		Changes: () => <>
-			Initial changes for Shadowbringers:&nbsp;
-			<ul>
-				<li>Updated 5.0 action list</li>
-				<li>Updated DoT module to check Biolysis</li>
-				<li>Removed outdated modules and actions</li>
-			</ul>
-		</>,
-		contributors: [CONTRIBUTORS.NIV],
-	}],
+	changelog: [
+		{
+			date: new Date('2021-10-28'),
+			Changes: () => <>Improve overheal calculations to better consider casts that fully overheal.</>,
+			contributors: [CONTRIBUTORS.AZARIAH],
+		},
+		{
+			date: new Date('2021-04-13'),
+			Changes: () => <>Support for 5.5 added – 100 mp cost down on succor won't hurt us!.</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2020-12-7'),
+			Changes: () => <>Support for 5.4 added – potency changes shouldn't affect analysis anyway.</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2020-08-10'),
+			Changes: () => <>Support for 5.3 added – no breaking changes to current analysis.</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2020-06-30'),
+			Changes: () => <>Add potions as a module – show up with all the move used under them.</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2020-05-16'),
+			Changes: () => <>Added Recitation and Overheal visualization to SCH – huge thanks to people in #sch_lounge in the balance for feedback with content!</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2020-04-07'),
+			Changes: () => <>Add Faerie actions to timeline</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2020-02-18'),
+			Changes: () => <>Support for 5.2; happy raiding SCHs!</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2019-10-29'),
+			Changes: () => <>Support for 5.1; additionally, only warn on faerie gauge overcap starting at 50</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2019-09-19'),
+			Changes: () => <>Track interrupts; a big thanks to Tonto Draksbane and Yuni in the balance for help with this feature</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2019-08-09'),
+			Changes: () => <>
+				Initial support for Shadowbringers:&nbsp;
+				<ul>
+					<li>Add gauge tracking</li>
+					<li>Track Chain Strategem use</li>
+					<li>Fix issue with Recitation creating negative Aetherflow counts</li>
+					<li>Add Energy Drain back as a valid Aetherflow consumer</li>
+				</ul>
+			</>,
+			contributors: [CONTRIBUTORS.NONO],
+		},
+		{
+			date: new Date('2019-07-12'),
+			Changes: () => <>
+				Initial changes for Shadowbringers:&nbsp;
+				<ul>
+					<li>Updated 5.0 action list</li>
+					<li>Updated DoT module to check Biolysis</li>
+					<li>Removed outdated modules and actions</li>
+				</ul>
+			</>,
+			contributors: [CONTRIBUTORS.NIV],
+		},
+	],
 })

--- a/src/parser/jobs/sch/modules/Overheal.js
+++ b/src/parser/jobs/sch/modules/Overheal.js
@@ -1,7 +1,7 @@
 import {Trans} from '@lingui/macro'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-import {CoreOverheal, SuggestedColors} from 'parser/core/modules/Overheal'
+import {Overheal as CoreOverheal, SuggestedColors} from 'parser/core/modules/Overheal'
 import React from 'react'
 
 export default class Overheal extends CoreOverheal {

--- a/src/parser/jobs/whm/index.js
+++ b/src/parser/jobs/whm/index.js
@@ -30,6 +30,11 @@ export default new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2021-10-28'),
+			Changes: () => <>Improve overheal calculations to better consider casts that fully overheal.</>,
+			contributors: [CONTRIBUTORS.AZARIAH],
+		},
+		{
 			date: new Date('2021-05-21'),
 			Changes: () => <>Add 5.5 support for WHM</>,
 			contributors: [CONTRIBUTORS.ASHE],

--- a/src/parser/jobs/whm/modules/Overheal.js
+++ b/src/parser/jobs/whm/modules/Overheal.js
@@ -1,7 +1,7 @@
 import {Trans} from '@lingui/react'
 import ACTIONS from 'data/ACTIONS'
 import STATUSES from 'data/STATUSES'
-import {CoreOverheal, SuggestedColors} from 'parser/core/modules/Overheal'
+import {Overheal as CoreOverheal, SuggestedColors} from 'parser/core/modules/Overheal'
 import React from 'react'
 
 export default class Overheal extends CoreOverheal {

--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -158,7 +158,7 @@ Array [
     "targets": Array [
       Object {
         "amount": 36194,
-        "overheal": 0,
+        "overheal": 36194,
         "sourceModifier": 2,
         "target": "3",
       },
@@ -363,6 +363,37 @@ Array [
       "y": 9999,
     },
     "timestamp": 1600107457863,
+    "type": "actorUpdate",
+  },
+]
+`;
+
+exports[`Event adapter individual events adapts heal 3`] = `
+Array [
+  Object {
+    "action": 3571,
+    "sequence": 4570,
+    "source": "3",
+    "target": "3",
+    "timestamp": 1600007412071,
+    "type": "execute",
+  },
+  Object {
+    "actor": "3",
+    "hp": Object {
+      "current": 122214,
+      "maximum": 122214,
+    },
+    "mp": Object {
+      "current": 9800,
+      "maximum": 10000,
+    },
+    "position": Object {
+      "bearing": -208,
+      "x": 9887,
+      "y": 10642,
+    },
+    "timestamp": 1600007412071,
     "type": "actorUpdate",
   },
 ]

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -328,6 +328,37 @@ const fakeEvents: Record<FflogsEvent['type'], FflogsEvent[]> = {
 			absorb: 43,
 		},
 		...fakeHitTypeFields,
+	},
+	{
+		timestamp: 7412071,
+		type: 'heal',
+		sourceID: 3,
+		sourceIsFriendly: true,
+		targetID: 3,
+		targetIsFriendly: true,
+		ability: {
+			name: 'Assize',
+			guid: 3571,
+			type: 1024,
+			abilityIcon: '002000-002634.png',
+		},
+		hitType: 2,
+		amount: 10000,
+		overheal: 26194,
+		packetID: 4570,
+		targetResources: {
+			hitPoints: 122214,
+			maxHitPoints: 122214,
+			mp: 9800,
+			maxMP: 10000,
+			tp: 0,
+			maxTP: 1000,
+			x: 9887,
+			y: 10642,
+			facing: -208,
+			absorb: 0,
+		},
+		...fakeHitTypeFields,
 	}],
 	begincast: [{
 		timestamp: 7446878,
@@ -920,5 +951,26 @@ describe('Event adapter', () => {
 			position: {x: 150, y: 50},
 		}])
 		/* eslint-enable @typescript-eslint/no-magic-numbers */
+	})
+
+	it('merges overheal from heal effect events to the matching heal event', () => {
+		const result = adaptEvents(report, pull, [
+			fakeEvents.calculatedheal[0],
+			fakeEvents.heal[2],
+		])
+
+		const heal = result.filter((event): event is Events['heal'] => event.type === 'heal')
+		// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+		expect(heal[0].targets[0].overheal).toEqual(26194)
+	})
+
+	it('marks unmatched heal events as fully overheal', () => {
+		const result = adaptEvents(report, pull, [
+			fakeEvents.calculatedheal[0],
+		])
+
+		const heal = result.filter((event): event is Events['heal'] => event.type === 'heal')
+		// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+		expect(heal[0].targets[0].overheal).toEqual(36194)
 	})
 })

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -2,6 +2,7 @@ import {Event} from 'event'
 import {FflogsEvent} from 'fflogs'
 import {sortEvents} from 'parser/core/EventSorting'
 import {Pull, Report} from 'report'
+import {AssignOverhealStep} from './assignOverheal'
 import {AdapterOptions, AdapterStep} from './base'
 import {DeduplicateActorUpdateStep} from './deduplicateActorUpdates'
 import {DeduplicateAoEStep} from './deduplicateAoE'
@@ -35,6 +36,7 @@ class EventAdapter {
 		this.adaptionSteps = [
 			new ReassignUnknownActorStep(opts),
 			new TranslateAdapterStep(opts),
+			new AssignOverhealStep(opts),
 			new InterruptsAdapterStep(opts),
 			new DeduplicateAoEStep(opts),
 			new DeduplicateStatusApplicationStep(opts),

--- a/src/reportSources/legacyFflogs/eventAdapter/assignOverheal.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/assignOverheal.ts
@@ -1,0 +1,70 @@
+import {Event, Events} from 'event'
+import {FflogsEvent, HealEvent} from 'fflogs'
+import {AdapterStep} from './base'
+
+/**
+ * FFLogs models damage or healing events as "calculateddamage" or "calculatedheal" events at the time of cast (e.g. Character prepares Action on Target Amount)
+ * and then as "damage" or "heal" events at the time the effect resolves (e.g. Character Action Target Amount)
+ * The two separate events have the same SequenceID, but overkill / overheal is reported on the effect resolution packet only.
+ * We need to add the overkill / overheal amounts to the main damage / heal events as well
+ *
+ * IMPORTANT: This adapter MUST run before the AOE deduplication adapter, as the AOE deduplication breaks the assumption of this adapter that only one target exists per event
+ */
+export class AssignOverhealStep extends AdapterStep {
+	private healEvents = new Map<string, Events['heal']>()
+
+	override adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
+		switch (baseEvent.type) {
+		case 'calculatedheal':
+			this.storeHealEvent(adaptedEvents)
+			break
+		case 'heal':
+			this.populateOverheal(baseEvent, adaptedEvents)
+			break
+		}
+
+		return adaptedEvents
+	}
+
+	override postprocess(adaptedEvents: Event[]) {
+		this.setUnmatchedHealsToOverheal()
+		return adaptedEvents
+	}
+
+	private storeHealEvent(adaptedEvents: Event[]) {
+		const healEvent = adaptedEvents.find((e): e is Events['heal'] => e.type === 'heal')
+		if (healEvent != null && healEvent.sequence != null) {
+			this.healEvents.set(this.buildIdentifierFromMultiTarget(healEvent), healEvent)
+		}
+	}
+
+	private populateOverheal(baseEvent: HealEvent, adaptedEvents: Event[]) {
+		const executeEvent = adaptedEvents.find((e): e is Events['execute'] => e.type === 'execute')
+		if (executeEvent != null) {
+			const eventIdentifier = this.buildIdentifierFromSingleTarget(executeEvent)
+			const healEvent = this.healEvents.get(eventIdentifier)
+			if (healEvent != null) {
+				healEvent.targets[0].overheal = baseEvent.overheal ?? 0
+				this.healEvents.delete(eventIdentifier)
+			}
+		}
+	}
+
+	private setUnmatchedHealsToOverheal() {
+		// Any heal events remaining in the state tracker were unpaired, assume fully overheal
+		//   (they may also have ghosted if the target died, but this matches the vastly more common case, and what FFLogs's data tables assume)
+		this.healEvents.forEach(event => event.targets[0].overheal = event.targets[0].amount)
+	}
+
+	private buildIdentifierFromMultiTarget(event: Events['heal']): string {
+		if (event.sequence == null) {
+			return ''
+		}
+
+		return `${event.sequence.toString()}-${event.targets[0].target}`
+	}
+
+	private buildIdentifierFromSingleTarget(event: Events['execute']): string {
+		return `${event.sequence.toString()}-${event.target}`
+	}
+}

--- a/src/reportSources/legacyFflogs/eventAdapter/deduplicateAoE.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/deduplicateAoE.ts
@@ -12,6 +12,9 @@ export class DeduplicateAoEStep extends AdapterStep {
 	override postprocess(adaptedEvents: Event[]) {
 
 		adaptedEvents.forEach(adaptedEvent => {
+			// N.B.: For performance reasons, we are not cloning the events, just working with them as-is and keeping track of which events we want to keep in the deduplicatedEvents array
+			//   Separate array for the return so we don't mess with the iterator of our forEach, but just add the events onto the dedupe array as references - no cloning
+			//   This means that if you're debugging, the targets property of events will change in both the adaptedEvents and deduplicatedEvents arrays as you step through things
 			const matchingEvent = this.getMatchingEvent(adaptedEvent)
 			if (matchingEvent != null) {
 				if (adaptedEvent.type === 'damage') {
@@ -33,7 +36,8 @@ export class DeduplicateAoEStep extends AdapterStep {
 			return undefined
 		}
 
-		return this.deduplicatedEvents.find(e => e.type === event.type && e.sequence === event.sequence)
+		// Events with no sequence ID are from over time effects or the passive regeneration, do not deduplicate
+		return this.deduplicatedEvents.find(e => e.type === event.type && e.sequence != null && e.sequence === event.sequence)
 	}
 
 }


### PR DESCRIPTION
As is tradition, I fiddled with the calculations on this port as well...

- Currently, the overheal module was only hooking the FFLogs `heal` events (the effect events in the new structure)
- The game, and thus FFLogs, does not consistently report `heal` events for heals that fully overheal (in general, it looks like any full-overheal on another target doesn't report an effect event)
- This caused our overheal numbers to be consistently low (significantly so if the player was doing a substantial amount of full-overheal)
- FFLogs's data tables currently treat all unmatched `calculatedheal` events as fully overheal (there's a possibility they could be ghosts from the target dying before the heal resolved, but that's a fairly infrequent occurrence)
- After this port, we will now also treat all unmatched `calculatedheal` events as fully overheal.

This doesn't quite get us to exact mapping with FFLogs' overheal %, because we are not considering shield absorption as healing at all.  The shield data comes in on the `removebuff` event for the shield and we aren't currently synthing that into healing events in the adapter steps.  Even on those remove buff events, the data is a little rough, and certain shield types seem to not ever report as expired/overheal *cough*Galvanize*cough*, so I am not adding shield handling at this time.  

Converting AST to core overheal will be a follow-up PR.