### PR TITLE
Excise legacy functions - Part 1

### DIFF
--- a/src/parser/core/modules/Procs.tsx
+++ b/src/parser/core/modules/Procs.tsx
@@ -3,7 +3,6 @@ import {Trans, Plural} from '@lingui/react'
 import {Action} from 'data/ACTIONS'
 import {Status} from 'data/STATUSES'
 import {Event, Events} from 'event'
-import {CastEvent} from 'fflogs'
 import {Actors} from 'parser/core/modules/Actors'
 import Suggestions, {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 import {SimpleRow, StatusItem, Timeline} from 'parser/core/modules/Timeline'
@@ -116,12 +115,6 @@ export abstract class Procs extends Analyser {
 	 */
 	public checkEventWasProc(event: Events['action']): boolean {
 		return this.checkActionWasProc(event.action, event.timestamp)
-	}
-	/**
-	 * Module-space accessor for checkEventWasProc
-	 * @deprecated */
-	public checkFflogsEventWasProc(event: CastEvent): boolean {
-		return this.checkActionWasProc(event.ability.guid, this.parser.fflogsToEpoch(event.timestamp))
 	}
 	/**
 	 * Checks to see if the specified action consumed a proc at a given timestamp

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -45,11 +45,6 @@ declare module 'event' {
 		blmgauge: EventBLMGauge
 	}
 }
-declare module 'legacyEvent' {
-	interface EventTypeRepository {
-		blmgauge: EventBLMGauge
-	}
-}
 
 interface EnochianDowntimeWindow {
 	start: number,
@@ -159,12 +154,6 @@ export default class Gauge extends Analyser {
 			gaugeState = this.gaugeHistory.get(historyKey)
 		}
 		return gaugeState
-	}
-	/**
-	 * Fflogs compatibility function to retrieve gauge state at a particular timestamp
-	 * @deprecated */
-	public getFflogsGaugeState(timestamp: number = this.parser.currentTimestamp): BLMGaugeState | undefined {
-		return this.getGaugeState(this.parser.fflogsToEpoch(timestamp))
 	}
 
 	//#region onCast and gauge state modification
@@ -285,10 +274,6 @@ export default class Gauge extends Analyser {
 			this.parser.queueEvent({
 				type: 'blmgauge',
 				timestamp: this.parser.currentEpochTimestamp,
-			})
-			this.parser.fabricateLegacyEvent({
-				type: 'blmgauge',
-				timestamp: this.parser.currentTimestamp,
 			})
 		}
 	}

--- a/src/parser/jobs/dnc/modules/Gauge.tsx
+++ b/src/parser/jobs/dnc/modules/Gauge.tsx
@@ -146,12 +146,6 @@ export class Gauge extends Analyser {
 		this.addEventHook('complete', this.onComplete)
 	}
 
-	/* Public functions */
-	/** @deprecated */
-	public feathersSpentInRangeLegacy(start: number, end: number): number {
-		return this.feathersSpentInRange(this.parser.fflogsToEpoch(start), this.parser.fflogsToEpoch(end))
-	}
-
 	public feathersSpentInRange(start: number, end: number): number {
 		if (start > end) {
 			return -1


### PR DESCRIPTION
Deleting a few legacy support functions that are no longer necessary due to ongoing Analyser port work:
- Gauge state accessor in BLM Gauge
- Feather consumption accessor in DNC Gauge
- Proc usage accessor in core Procs