### PR TITLE
Fix: DNC - Missed an ActionKey[].map in Gauge

### DIFF
--- a/src/parser/jobs/dnc/modules/Gauge.tsx
+++ b/src/parser/jobs/dnc/modules/Gauge.tsx
@@ -81,7 +81,7 @@ export class Gauge extends Analyser {
 	private improvTickHook!: TimestampHook
 	private improvTicks: number = 0
 
-	private espritGenerationExceptions = [
+	private espritGenerationExceptions: number[] = [
 		...FINISHES.map(key => this.data.actions[key].id),
 		this.data.actions.FUMA_SHURIKEN.id,
 		this.data.actions.FUMA_SHURIKEN_TCJ_TEN.id,

--- a/src/parser/jobs/dnc/modules/Gauge.tsx
+++ b/src/parser/jobs/dnc/modules/Gauge.tsx
@@ -82,7 +82,7 @@ export class Gauge extends Analyser {
 	private improvTicks: number = 0
 
 	private espritGenerationExceptions = [
-		...FINISHES,
+		...FINISHES.map(key => this.data.actions[key].id),
 		this.data.actions.FUMA_SHURIKEN.id,
 		this.data.actions.FUMA_SHURIKEN_TCJ_TEN.id,
 		this.data.actions.FUMA_SHURIKEN_TCJ_CHI.id,


### PR DESCRIPTION
The `FINISHES` const is now ActionKey[], so I needed to map to the ID for the array of actions that don't generate Esprit. Adding a type to the array to ensure future oops like that don't happen