### PR TITLE
Remove deprecated timestamp corrections from MNK

### DIFF
--- a/src/parser/jobs/mnk/modules/Forms.tsx
+++ b/src/parser/jobs/mnk/modules/Forms.tsx
@@ -55,10 +55,7 @@ export class Forms extends Analyser {
 		// Check the current form, or zero for no form
 		const currentForm = this.forms.find(form => this.actors.current.hasStatus(form)) || 0
 		const untargetable = this.lastFormChanged != null
-			? this.downtime.getDowntime(
-				this.parser.fflogsToEpoch(this.lastFormChanged),
-				this.parser.fflogsToEpoch(event.timestamp),
-			)
+			? this.downtime.getDowntime(this.lastFormChanged, event.timestamp)
 			: 0
 
 		if (action.id === this.data.actions.FORM_SHIFT.id) {


### PR DESCRIPTION
Downtime uses the Analyser system with correct timestamps, so correcting for fflogs timestamps isn't necessary anymore. Ignore the branch name.