### PR TITLE
Use actual GCD accounting instead of trusting status in PB drop math

### DIFF
--- a/src/data/STATUSES/root/MNK.ts
+++ b/src/data/STATUSES/root/MNK.ts
@@ -7,6 +7,7 @@ export const MNK = ensureStatuses({
 		name: 'Perfect Balance',
 		icon: 'https://xivapi.com/i/010000/010217.png',
 		duration: 10000,
+		stacksApplied: 0,
 	},
 
 	OPO_OPO_FORM: {

--- a/src/parser/jobs/mnk/modules/PerfectBalance.tsx
+++ b/src/parser/jobs/mnk/modules/PerfectBalance.tsx
@@ -58,14 +58,6 @@ export class PerfectBalance extends Analyser {
 		this.addEventHook(playerFilter.type('statusApply').status(this.data.statuses.PERFECT_BALANCE.id), this.onStacc)
 		this.addEventHook(playerFilter.type('statusRemove').status(this.data.statuses.PERFECT_BALANCE.id), this.onDrop)
 
-		// Hook death because we can't share a filter with statusRemove due to lack of status on death
-		this.addEventHook(
-			filter<Event>()
-				.type('death')
-				.actor(this.parser.actor.id),
-			this.onDrop,
-		)
-
 		this.addEventHook('complete', this.onComplete)
 	}
 

--- a/src/parser/jobs/mnk/modules/PerfectBalance.tsx
+++ b/src/parser/jobs/mnk/modules/PerfectBalance.tsx
@@ -46,8 +46,6 @@ export class PerfectBalance extends Analyser {
 	private current: Balance | undefined
 	private history: Balance[] = []
 
-	private maxStacks: number = 0
-
 	private perfectHook?: EventHook<Events['action']>
 
 	override initialise() {
@@ -79,7 +77,7 @@ export class PerfectBalance extends Analyser {
 		if (event.data == null) { return }
 
 		// New window who dis - check for new window before updating just in case
-		if (event.data === this.maxStacks) {
+		if (event.data === this.data.statuses.PERFECT_BALANCE.stacksApplied) {
 			this.current = {bads: 0, stacks: event.data, used: 0}
 
 			// Create the hook to check GCDs in PB
@@ -127,7 +125,7 @@ export class PerfectBalance extends Analyser {
 		this.stopAndSave()
 
 		// Stacks are hard set instead of being subtracted, so we need to take used from max rather than raw remaining
-		const droppedGcds = this.history.reduce((drops, current) => drops + (current.used - this.maxStacks), 0)
+		const droppedGcds = this.history.reduce((drops, current) => drops + (current.used - this.data.statuses.PERFECT_BALANCE.stacksApplied), 0)
 		const badActions = this.history.reduce((bads, current) => bads + current.bads, 0)
 
 		this.suggestions.add(new TieredSuggestion({

--- a/src/parser/jobs/mnk/modules/constants.ts
+++ b/src/parser/jobs/mnk/modules/constants.ts
@@ -36,3 +36,9 @@ export const COEURL_SKILLS: ActionKey[] = [
 	'DEMOLISH',
 	'ROCKBREAKER',
 ]
+
+export const FORM_SKILLS: ActionKey[] = [
+	...OPO_OPO_SKILLS,
+	...RAPTOR_SKILLS,
+	...COEURL_SKILLS,
+]


### PR DESCRIPTION
Stacks remaining at the end of a window are 1 rather than 0, however we can't just subtract because it's possible for a legit stack to be left. Realistically it goes from 5->0 but the game prefers to do 6->1 and then just delete it. I have no idea how consistent this will even be, so I've changed the drop accounting to track the used GCDs and compare with the max stacks instead.

The constant is kinda silly, but `stacksApplied` is an optional field. Open to a cleaner way to do this tho, since I'm not sure if a null check is actually better in this case. This module is being rewritten in 6.0 since the entire skill is changing, so I'm not too fussed about expecting future changes in the 5.x branch anyway.