### PR TITLE
Add CN TLD to search handler regex

### DIFF
--- a/src/reportSources/legacyFflogs/searchHandlers.ts
+++ b/src/reportSources/legacyFflogs/searchHandlers.ts
@@ -11,7 +11,7 @@ export const legacyFflogsSearchHandlers: SearchHandler[] = [
 	 * 1234567890abcdef#fight=1&source=1
 	 */
 	{
-		regexp: /^(?:.*fflogs\.com\/reports\/)?(?<code>(?:a:)?[a-zA-Z0-9]{16})\/?(?:#(?=(?:.*fight=(?<fight>[^&]*))?)(?=(?:.*source=(?<source>[^&]*))?).*)?$/,
+		regexp: /^(?:.*(?:fflogs\.com|ffxivlogs\.cn)\/reports\/)?(?<code>(?:a:)?[a-zA-Z0-9]{16})\/?(?:#(?=(?:.*fight=(?<fight>[^&]*))?)(?=(?:.*source=(?<source>[^&]*))?).*)?$/,
 		handler: ({code, fight, source}) => {
 			if (fight === 'last') {
 				return {


### PR DESCRIPTION
Title. Looks like the main site's API still has the data regardless of the URL change.

Resolves #1332