### PR TITLE
port Darkside to core Gauge as a Timer Gauge

### DIFF
--- a/src/parser/core/modules/Gauge/Gauge.tsx
+++ b/src/parser/core/modules/Gauge/Gauge.tsx
@@ -1,7 +1,7 @@
 import {t} from '@lingui/macro'
 import TimeLineChart from 'components/ui/TimeLineChart'
 import {StatusKey} from 'data/STATUSES'
-import {Event} from 'event'
+import {Event, Events} from 'event'
 import {Analyser} from 'parser/core/Analyser'
 import {filter} from 'parser/core/filter'
 import {dependency} from 'parser/core/Injectable'
@@ -65,7 +65,7 @@ export class Gauge extends Analyser {
 		return gauge
 	}
 
-	protected onDeath() {
+	protected onDeath(_event: Events['death']) {
 		this.gauges.forEach(gauge => gauge.reset())
 	}
 

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -6,6 +6,7 @@ import {DataLink} from 'components/ui/DbLink'
 import {ActionKey} from 'data/ACTIONS'
 import JOBS from 'data/JOBS'
 import {Cause, Event, Events, FieldsBase} from 'event'
+import {TimestampHookArguments} from 'parser/core/Dispatcher'
 import {filter, oneOf} from 'parser/core/filter'
 import {dependency} from 'parser/core/Injectable'
 import BrokenLog from 'parser/core/modules/BrokenLog'
@@ -356,7 +357,11 @@ export class Gauge extends CoreGauge {
 	//#endregion
 
 	//#region Astral Fire and Umbral Ice
-	private onAstralUmbralTimeout(flagIssues: boolean = true) {
+	private onAstralUmbralTimeout(_args: TimestampHookArguments) {
+		this.onAstralUmbralEnd(true)
+	}
+
+	private onAstralUmbralEnd(flagIssues: boolean) {
 		this.astralFireTimer.reset()
 		this.astralFireGauge.reset()
 
@@ -368,7 +373,7 @@ export class Gauge extends CoreGauge {
 
 	private onGainAstralFireStacks(stackCount: number, dropsElementOnSwap: boolean = true) {
 		if (!this.umbralIceGauge.empty && dropsElementOnSwap) {
-			this.onAstralUmbralTimeout()
+			this.onAstralUmbralEnd(true)
 		} else {
 			this.umbralIceTimer.reset()
 			this.umbralIceGauge.reset()
@@ -382,7 +387,7 @@ export class Gauge extends CoreGauge {
 
 	private onGainUmbralIceStacks(stackCount: number, dropsElementOnSwap: boolean = true) {
 		if (!this.astralFireGauge.empty && dropsElementOnSwap) {
-			this.onAstralUmbralTimeout()
+			this.onAstralUmbralEnd(true)
 		} else {
 			this.astralFireTimer.reset()
 			this.astralFireGauge.reset()
@@ -477,7 +482,7 @@ export class Gauge extends CoreGauge {
 
 	override onDeath() {
 		// Not counting the loss towards the rest of the gauge loss, that'll just double up on the suggestions
-		this.onAstralUmbralTimeout(false)
+		this.onAstralUmbralEnd(false)
 	}
 
 	private onComplete() {

--- a/src/parser/jobs/dnc/modules/Gauge.tsx
+++ b/src/parser/jobs/dnc/modules/Gauge.tsx
@@ -130,8 +130,8 @@ export class Gauge extends CoreGauge {
 		this.addEventHook('complete', this.onComplete)
 	}
 
-	override onDeath() {
-		super.onDeath()
+	override onDeath(event: Events['death']) {
+		super.onDeath(event)
 		this.pauseGeneration = true
 	}
 

--- a/src/parser/jobs/drk/modules/Darkside.tsx
+++ b/src/parser/jobs/drk/modules/Darkside.tsx
@@ -1,94 +1,80 @@
 import {MessageDescriptor} from '@lingui/core'
 import {t} from '@lingui/macro'
 import {Trans} from '@lingui/react'
-import {ActionLink} from 'components/ui/DbLink'
+import {DataLink} from 'components/ui/DbLink'
 import NormalisedMessage from 'components/ui/NormalisedMessage'
-import ACTIONS from 'data/ACTIONS'
-import {Event} from 'legacyEvent'
-import Module, {dependency} from 'parser/core/Module'
+import {ActionKey} from 'data/ACTIONS'
+import {Event, Events} from 'event'
+import {TimestampHookArguments} from 'parser/core/Dispatcher'
+import {filter} from 'parser/core/filter'
+import {dependency} from 'parser/core/Injectable'
 import Checklist, {Requirement, Rule} from 'parser/core/modules/Checklist'
-import {Death} from 'parser/core/modules/Death'
-import {NormalisedDamageEvent} from 'parser/core/modules/NormalisedEvents'
+import Downtime from 'parser/core/modules/Downtime'
+import {Gauge, TimerGauge} from 'parser/core/modules/Gauge'
 import React from 'react'
 import {Table} from 'semantic-ui-react'
+import {isSuccessfulHit} from 'utilities'
 
 const DARKSIDE_MAX_DURATION = 60000
-const DARKSIDE_EXTENSION = {
-	[ACTIONS.FLOOD_OF_SHADOW.id]: 30000,
-	[ACTIONS.EDGE_OF_SHADOW.id]: 30000,
-}
-const INITIAL_APPLICATION_FORGIVENESS = 2500
+const DARKSIDE_EXTENSION_ACTIONS: ActionKey[] = [
+	'FLOOD_OF_SHADOW',
+	'EDGE_OF_SHADOW',
+]
+const DARKSIDE_EXTENSION_TIME = 30000
+const APPLICATION_FORGIVENESS = 2500
 
 interface DarksideDrop {
 	timestamp: number,
 	reason: MessageDescriptor
 }
 
-export class Darkside extends Module {
+export class Darkside extends Gauge {
 	static override handle = 'Darkside'
 
 	static override title = t('drk.darkside.title')`Darkside`
 	@dependency private checklist!: Checklist
-	@dependency private death!: Death
+	@dependency private downtime!: Downtime
 
-	private currentDuration = 0
-	private downtime = 0
-	private lastEventTime: number | null = null
+	private darksideGauge = this.add(new TimerGauge({
+		maximum: DARKSIDE_MAX_DURATION,
+		onExpiration: this.onDarksideExpiration,
+	}))
 	private darksideDrops: DarksideDrop[] = []
 
-	protected override init() {
-		this.addEventHook('normaliseddamage', {by: 'player', abilityId: Object.keys(DARKSIDE_EXTENSION).map(Number)}, this.updateDarkside)
-		this.addEventHook('death', {to: 'player'}, this.onDeath)
-		this.addEventHook('raise', {to: 'player'}, this.onRaise)
+	override initialise() {
+		this.addEventHook(filter<Event>().type('damage').cause(this.data.matchCauseAction(DARKSIDE_EXTENSION_ACTIONS)), (event) => {
+			if (event.cause.type === 'action' && isSuccessfulHit(event)) {
+				this.darksideGauge.extend(DARKSIDE_EXTENSION_TIME, false)
+			}
+		})
 		this.addEventHook('complete', this.onComplete)
 	}
 
-	private updateDarkside(event: Event | NormalisedDamageEvent) {
-		if (this.lastEventTime === null) {
-			// First application - allow up to 1 GCD to apply before counting downtime
-			const elapsedTime = event.timestamp - this.parser.fight.start_time
-			this.downtime = Math.max(elapsedTime - INITIAL_APPLICATION_FORGIVENESS, 0)
-		} else {
-			const elapsedTime = event.timestamp - this.lastEventTime
-			this.currentDuration -= elapsedTime
-			if (this.currentDuration <= 0) {
-				this.downtime += Math.abs(this.currentDuration)
-
-				if (event.type !== 'death') {
-					const droppedAt = event.timestamp + this.currentDuration
-					this.darksideDrops.push({timestamp: droppedAt, reason: t('drk.darkside.drop.reason.timeout')`Timeout`})
-				}
-
-				this.currentDuration = 0
-			}
-		}
-
-		if (event.type === 'normaliseddamage') {
-			const abilityId = event.ability.guid
-			this.currentDuration = Math.min(this.currentDuration + DARKSIDE_EXTENSION[abilityId], DARKSIDE_MAX_DURATION)
-			this.lastEventTime = event.timestamp
-		}
-	}
-
-	private onDeath(event: Event) {
+	protected override onDeath(event: Events['death']) {
+		super.onDeath(event)
 		this.darksideDrops.push({timestamp: event.timestamp, reason: t('drk.darkside.drop.reason.death')`Death`})
-		this.updateDarkside(event)
-		this.currentDuration = 0
 	}
 
-	private onRaise(event: Event) {
-		// So floor time doesn't count against Darkside uptime
-		this.lastEventTime = event.timestamp
+	private onDarksideExpiration(args: TimestampHookArguments) {
+		this.darksideDrops.push({timestamp: args.timestamp, reason: t('drk.darkside.drop.reason.timeout')`Timeout`})
 	}
 
-	private onComplete(event: Event) {
-		this.updateDarkside(event)
-		const duration = this.parser.currentDuration - this.death.deadTime
-		const uptime = ((duration - this.downtime) / duration) * 100
+	private onComplete() {
+		this.darksideGauge.pause()
+
+		const fightDowntimes = this.downtime.getDowntimeWindows()
+		const adjustedFightDuration = this.parser.pull.duration - this.downtime.getDowntime()
+
+		const requireDarksideStartedBy = this.parser.pull.timestamp + APPLICATION_FORGIVENESS
+		const endOfPull = this.parser.currentEpochTimestamp
+		const expiredDuration = this.darksideGauge.getExpirationTime(requireDarksideStartedBy, endOfPull, fightDowntimes, APPLICATION_FORGIVENESS)
+
+		const uptime = ((adjustedFightDuration - expiredDuration) / adjustedFightDuration) * 100
+
 		this.checklist.add(new Rule({
 			name: 'Keep Darkside up',
 			description: <Trans id="drk.darkside.uptime.why">
-				Darkside is gained by using <ActionLink {...ACTIONS.EDGE_OF_SHADOW}/> or <ActionLink {...ACTIONS.FLOOD_OF_SHADOW}/> and provides you with a 10% damage increase.  As such, it is a significant part of a DRK's personal DPS.  Do your best not to let it drop, and recover it as quickly as possible if it does.
+				Darkside is gained by using <DataLink action="EDGE_OF_SHADOW"/> or <DataLink action="FLOOD_OF_SHADOW"/> and provides you with a 10% damage increase.  As such, it is a significant part of a DRK's personal DPS.  Do your best not to let it drop, and recover it as quickly as possible if it does.
 			</Trans>,
 			requirements: [
 				new Requirement({
@@ -101,27 +87,29 @@ export class Darkside extends Module {
 	}
 
 	override output() {
-		if (this.darksideDrops.length > 0) {
-			return (
-				<Table collapsing unstackable>
-					<Table.Header>
-						<Table.Row>
-							<Table.HeaderCell><Trans id="drk.darkside.drop.at">Dropped Time</Trans></Table.HeaderCell>
-							<Table.HeaderCell><Trans id="drk.darkside.drop.reason">Reason</Trans></Table.HeaderCell>
-						</Table.Row>
-					</Table.Header>
-					<Table.Body>
-						{this.darksideDrops
-							.map((d, idx) => {
-								return <Table.Row key={`darksidedrop-${idx}`}>
-									<Table.Cell>{this.parser.formatTimestamp(d.timestamp)}</Table.Cell>
-									<Table.Cell><NormalisedMessage message={d.reason} id={Module.i18n_id}/></Table.Cell>
-								</Table.Row>
-							})
-						}
-					</Table.Body>
-				</Table>
-			)
+		if (this.darksideDrops.length === 0) {
+			return false
 		}
+
+		return (
+			<Table collapsing unstackable>
+				<Table.Header>
+					<Table.Row>
+						<Table.HeaderCell><Trans id="drk.darkside.drop.at">Dropped Time</Trans></Table.HeaderCell>
+						<Table.HeaderCell><Trans id="drk.darkside.drop.reason">Reason</Trans></Table.HeaderCell>
+					</Table.Row>
+				</Table.Header>
+				<Table.Body>
+					{this.darksideDrops
+						.map((d, idx) => {
+							return <Table.Row key={`darksidedrop-${idx}`}>
+								<Table.Cell>{this.parser.formatTimestamp(d.timestamp)}</Table.Cell>
+								<Table.Cell><NormalisedMessage message={d.reason}/></Table.Cell>
+							</Table.Row>
+						})
+					}
+				</Table.Body>
+			</Table>
+		)
 	}
 }


### PR DESCRIPTION
Also did a little bit of cleanup in core TimerGauge:
1. Now passes the TimestampHookArguments (the timestamp of the timeout) to onExpirationCallback consumers
2. Adjusted variable naming and documentation comments to indicate any fight downtime windows are valid, and some documentation of cases when you would prefer UTA downtime versus full fight downtime
3. Allow refresh and extend to specify whether the action should refresh/extend a gauge that wasn't previously running (to allow basic consumers like Darkside to just call extend always, as both their gauge extenders add 30 seconds regardless of whether the gauge was already running or not - you don't have to use a specific skill to initially start the gauge).