### PR TITLE
fixed issue with embolden only tracking final stack in raid buffs

### DIFF
--- a/src/parser/core/modules/RaidBuffs.ts
+++ b/src/parser/core/modules/RaidBuffs.ts
@@ -82,7 +82,9 @@ export class RaidBuffs extends Analyser {
 
 		// Record the start time of the status
 		const applications = this.getTargetApplications(event.target)
-		applications.set(statusId, event.timestamp)
+		if (!applications.has(statusId)) {
+			applications.set(statusId, event.timestamp)
+		}
 	}
 
 	private onRemove(event: Events['statusRemove']) {


### PR DESCRIPTION
This just fixes an issue with Embolden (and any other stacked buff) not showing full duration in raid buffs.