### PR TITLE
BugFix - BLM - onComplete reprocessing of invuln cycles was breaking

### DIFF
--- a/src/parser/jobs/blm/modules/RotationWatchdog.tsx
+++ b/src/parser/jobs/blm/modules/RotationWatchdog.tsx
@@ -445,7 +445,7 @@ export class RotationWatchdog extends Analyser {
 				types: ['invulnerable'],
 			})) {
 				cycle.finalOrDowntime = true
-				cycle.overrideErrorCode(this.CYCLE_ERRORS.NONE)
+				cycle.overrideErrorCode(NO_ERROR)
 				this.processCycle(cycle)
 			}
 		})


### PR DESCRIPTION
When I did the change to stop depending on ACTIONS in RotationWatchdog, I had to move the CYCLE_ERRORS definitions into the class, instead of being a const outside (probably reverting this in EW now that we have DataLink). One spot where the old CYCLE_ERRORS.NONE code was being referenced got missed when switching that to the NO_ERROR const object, which was causing the error code to end up undefined (side note to self, how to ensure type safety on that object...)