### PR TITLE
Endwalker - BLM - AoEUsages and Thunder changes

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -147,7 +147,7 @@
   "blm.thunder.checklist.dots.name": "Keep your <0/> DoT up",
   "blm.thunder.checklist.dots.requirement.name": "<0/> uptime",
   "blm.thunder.clip": "Clip",
-  "blm.thunder.clip-disclaimer": "Due to the nature of <0/> procs, you will run into situations where you will use your <1/> proc before it runs out, while your <2/> is still running on your enemy. At most, this could theoretically lead to refreshing <3/> a maximum of ~6 seconds early every single refresh. Since this amount of clipping is still considered optimal, we quantify and call this the maximum clip time.",
+  "blm.thunder.clip-disclaimer": "Due to the nature of <0/> procs, you will run into situations where you will use your <1/> proc before it runs out, while your <2/> is still running on your enemy. At most, this could theoretically lead to refreshing <3/> a maximum of ~3 seconds early every single refresh. Since this amount of clipping is still considered optimal, we quantify and call this the maximum clip time.",
   "blm.thunder.source": "Source",
   "blm.thunder.suggestions.excess-thunder.content": "Casting <0/> too frequently can cause you to lose DPS by casting fewer <1/>. Try not to cast <2/> unless your <3/> DoT or <4/> proc are about to wear off. Check the <5><6/></5> module for more information.",
   "blm.thunder.suggestions.excess-thunder.why": "Total DoT clipping exceeded the maximum clip time of {0} by {1}.",

--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -12,4 +12,9 @@ export const changelog = [
 		Changes: () => <>Initial data scaffolding and basic updates to handle removal of Enochian ability.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2021-11-27'),
+		Changes: () => <>Update handling for AoE vs. single-target spells and revise T3 clip timing calculations due to changed status durations.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/blm/modules/AoEUsages.ts
+++ b/src/parser/jobs/blm/modules/AoEUsages.ts
@@ -12,12 +12,37 @@ export class AoEUsages extends CoreAoE {
 		{
 			aoeAction: this.data.actions.FLARE,
 			stActions: [this.data.actions.DESPAIR],
-			minTargets: 2,
+			minTargets: 3,
 		},
 		{
 			aoeAction: this.data.actions.THUNDER_IV,
 			stActions: [this.data.actions.THUNDER_III],
 			minTargets: 2,
+		},
+		{
+			aoeAction: this.data.actions.BLIZZARD_II,
+			stActions: [this.data.actions.BLIZZARD_III],
+			minTargets: 3,
+		},
+		{
+			aoeAction: this.data.actions.HIGH_BLIZZARD_II,
+			stActions: [this.data.actions.BLIZZARD_III],
+			minTargets: 3,
+		},
+		{
+			aoeAction: this.data.actions.FIRE_II,
+			stActions: [this.data.actions.FIRE_III, this.data.actions.FIRE_IV],
+			minTargets: 3,
+		},
+		{
+			aoeAction: this.data.actions.HIGH_FIRE_II,
+			stActions: [this.data.actions.FIRE_III, this.data.actions.FIRE_IV],
+			minTargets: 3,
+		},
+		{
+			aoeAction: this.data.actions.FREEZE,
+			stActions: [this.data.actions.BLIZZARD_IV],
+			minTargets: 3,
 		},
 	]
 }


### PR DESCRIPTION
- Adds AoEUsages entries for [High] [Blizzard/Fire] II and Freeze
- Adjust AoEUsages entry for Flare since it's base potency is lower now 😢 
- Updates Thunder's clipping calculations for T3 since the status durations have been adjusted