### PR TITLE
Bugfix: BLM - Fix gauge state tracking in case the BLM pulls

### DIFF
--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -82,8 +82,6 @@ export class Gauge extends CoreGauge {
 	private droppedEnoTimestamps: number[] = []
 	private overwrittenPolyglot: number = 0
 
-	private lastHistoryTimestamp: number = this.parser.pull.timestamp
-
 	private fireSpellIds = FIRE_SPELLS.map(key => this.data.actions[key].id)
 	private iceSpellIds = [
 		...ICE_SPELLS_TARGETED.map(key => this.data.actions[key].id),
@@ -156,6 +154,8 @@ export class Gauge extends CoreGauge {
 		},
 	}))
 	private enochianActive: boolean = false
+
+	private previousGaugeState: BLMGaugeState | undefined = this.getGaugeState(this.parser.pull.timestamp)
 
 	override initialise() {
 		super.initialise()
@@ -306,10 +306,9 @@ export class Gauge extends CoreGauge {
 			this.polyglotTimer.start()
 		}
 
-		const lastGaugeState = this.getGaugeState(this.lastHistoryTimestamp)
-		if (this.gaugeValuesChanged(lastGaugeState)) {
-			this.updateCastTimes(lastGaugeState)
-			this.lastHistoryTimestamp = this.parser.currentEpochTimestamp
+		if (this.gaugeValuesChanged(this.previousGaugeState)) {
+			this.updateCastTimes(this.previousGaugeState)
+			this.previousGaugeState = this.getGaugeState(this.parser.currentEpochTimestamp)
 
 			// Queue event to tell other analysers about the change
 			this.parser.queueEvent({


### PR DESCRIPTION
If the BLM happened to get the initial damage event of the log, and that event should've produced a gauge event (likely either setting AF or UI to 3), it wouldn't publish a `blmgauge` event because of how we were comparing current state vs. previous state all at relative timestamp of 0.

Now we'll make sure we have an initial null-Gauge state to compare against to keep this from happening (plus some re-ordering of operations to make this work).