### PR TITLE
Add RPR and SGE labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,10 +25,14 @@ Parser - PLD:
   - src/parser/jobs/pld/**/*
 Parser - RDM:
   - src/parser/jobs/rdm/**/*
+Parser - RPR:
+  - src/parser/jobs/rpr/**/*
 Parser - SAM:
   - src/parser/jobs/sam/**/*
 Parser - SCH:
   - src/parser/jobs/sch/**/*
+Parser - SGE:
+  - src/parser/jobs/sge/**/*
 Parser - SMN:
   - src/parser/jobs/smn/**/*
 Parser - WAR:


### PR DESCRIPTION
Labels are created, colours to be updated once we have them from fflogs I guess. For now it's (conveniently role-accurate) GitHub default colours from when I created them. This PR is so the labeler action can properly tag the new jobs in Endwalker.