### PR TITLE
BLM - Bugfixes and mark supported

### DIFF
--- a/src/data/ACTIONS/root/BLM.ts
+++ b/src/data/ACTIONS/root/BLM.ts
@@ -240,7 +240,7 @@ export const BLM = ensureActions({
 		id: 25796,
 		name: 'Amplifier',
 		icon: 'https://xivapi.com/i/002000/002671.png',
-		cooldown: 12000,
+		cooldown: 120000,
 	},
 	PARADOX: {
 		id: 25797,

--- a/src/data/STATUSES/root/BLM.ts
+++ b/src/data/STATUSES/root/BLM.ts
@@ -16,7 +16,7 @@ export const BLM = ensureStatuses({
 		id: 163,
 		name: 'Thunder III',
 		icon: 'https://xivapi.com/i/010000/010459.png',
-		duration: 24000,
+		duration: 30000,
 	},
 	THUNDER_IV: {
 		id: 1210,
@@ -57,7 +57,7 @@ export const BLM = ensureStatuses({
 		id: 867,
 		name: 'Sharpcast',
 		icon: 'https://xivapi.com/i/012000/012655.png',
-		duration: 15000,
+		duration: 30000,
 	},
 	MANAWARD: {
 		id: 168,

--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -32,4 +32,9 @@ export const changelog = [
 		Changes: () => <>Handle Paradox being instant-cast in Umbral Ice.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2021-12-15'),
+		Changes: () => <>Miscellaneous bug fixes, and marking supported for Endwalker.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/blm/index.tsx
+++ b/src/parser/jobs/blm/index.tsx
@@ -12,10 +12,10 @@ export const BLACK_MAGE = new Meta({
 		<Trans id="blm.about.description">This analyser aims to identify how you're not actually casting <DataLink action="FIRE_IV" /> as much as you think you are.</Trans>
 	</>,
 
-	// supportedPatches: {
-	// 	from: '6.0',
-	// 	to: '6.0',
-	// },
+	supportedPatches: {
+		from: '6.0',
+		to: '6.0',
+	},
 
 	contributors: [
 		{user: CONTRIBUTORS.AKAIRYU, role: ROLES.MAINTAINER},

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -129,6 +129,16 @@ export class Gauge extends CoreGauge {
 		},
 	}))
 
+	/** Paradox */
+	private paradoxGauge = this.add(new CounterGauge({
+		maximum: PARADOX_MAX_STACKS,
+		graph: {
+			label: <Trans id="blm.gauge.resource.paradox">Paradox</Trans>,
+			color: FIRE_COLOR.fade(GAUGE_FADE),
+		},
+		correctHistory: true,
+	}))
+
 	/** Umbral Hearts */
 	private umbralHeartsGauge = this.add(new CounterGauge({
 		maximum: UMBRAL_HEARTS_MAX_STACKS,
@@ -154,16 +164,6 @@ export class Gauge extends CoreGauge {
 			label: <Trans id="blm.gauge.resource.polyglot-timer">Polyglot Timer</Trans>,
 			color: POLYGLOT_COLOR.fade(TIMER_FADE),
 		},
-	}))
-
-	/** Paradox */
-	private paradoxGauge = this.add(new CounterGauge({
-		maximum: PARADOX_MAX_STACKS,
-		graph: {
-			label: <Trans id="blm.gauge.resource.paradox">Paradox</Trans>,
-			color: FIRE_COLOR.fade(GAUGE_FADE),
-		},
-		correctHistory: true,
 	}))
 
 	private previousGaugeState: BLMGaugeState = this.getGaugeState(this.parser.pull.timestamp)

--- a/src/parser/jobs/blm/modules/Thunder.tsx
+++ b/src/parser/jobs/blm/modules/Thunder.tsx
@@ -19,6 +19,7 @@ import DISPLAY_ORDER from './DISPLAY_ORDER'
 import Procs from './Procs'
 
 const MAX_ALLOWED_BAD_GCD_THRESHOLD = 2000
+const MAX_ALLOWED_T3_CLIPPING = 3000
 
 interface ThunderApplicationData {
 	event: Events['statusApply'],
@@ -49,8 +50,6 @@ export class Thunder extends Analyser {
 	@dependency private procs!: Procs
 	@dependency private statuses!: Statuses
 	@dependency private suggestions!: Suggestions
-
-	private readonly maxAllowedT3Clipping = Math.max(this.data.statuses.THUNDER_III.duration - this.data.statuses.THUNDERCLOUD.duration, 0)
 
 	// Can never be too careful :blobsweat:
 	private readonly STATUS_DURATION = {
@@ -148,7 +147,7 @@ export class Thunder extends Analyser {
 
 		// Suggestions to not spam T3 too much
 		const sumClip = this.clip[this.data.statuses.THUNDER_III.id]
-		const maxExpectedClip = (this.thunder3Casts - 1) * this.maxAllowedT3Clipping
+		const maxExpectedClip = (this.thunder3Casts - 1) * MAX_ALLOWED_T3_CLIPPING
 		if (sumClip > maxExpectedClip) {
 			this.suggestions.add(new Suggestion({
 				icon: this.data.actions.THUNDER_III.icon,
@@ -189,10 +188,10 @@ export class Thunder extends Analyser {
 						const renderClipTime = event.clip != null ? this.parser.formatDuration(event.clip) : '-'
 						let clipSeverity: ReactNode = renderClipTime
 						// Make it white for expected clipping, yellow if the GCD aligned poorly, and red if it was definitely clipped too hard
-						if (thisClip > this.maxAllowedT3Clipping && thisClip <= this.maxAllowedT3Clipping + MAX_ALLOWED_BAD_GCD_THRESHOLD) {
+						if (thisClip > MAX_ALLOWED_T3_CLIPPING && thisClip <= MAX_ALLOWED_T3_CLIPPING + MAX_ALLOWED_BAD_GCD_THRESHOLD) {
 							clipSeverity = <span className="text-warning">{clipSeverity}</span>
 						}
-						if (thisClip > this.maxAllowedT3Clipping + MAX_ALLOWED_BAD_GCD_THRESHOLD) {
+						if (thisClip > MAX_ALLOWED_T3_CLIPPING + MAX_ALLOWED_BAD_GCD_THRESHOLD) {
 							clipSeverity = <span className="text-error">{clipSeverity}</span>
 						}
 						return <Table.Row key={event.event.timestamp}>


### PR DESCRIPTION
- Fixed Amplifier's cooldown (Typo, missed a 0)
- Updated T3 and Sharpcast status durations (missed in expac data PR)
- Fixed T3 clipping calculations (Thundercloud duration is now longer than the DoT, whee)
- Marked BLM as supported for 6.0