### PR TITLE
RDM - New CastTime module to account for Acceleration instant casts

### DIFF
--- a/src/parser/jobs/rdm/modules/CastTime.ts
+++ b/src/parser/jobs/rdm/modules/CastTime.ts
@@ -4,6 +4,7 @@ import CoreCastTime from 'parser/core/modules/CastTime'
 
 export class CastTime extends CoreCastTime {
 	private accelerationIndex: number | null = null
+	private dualcastIndex: number | null = null
 
 	override initialise() {
 		super.initialise()
@@ -12,11 +13,18 @@ export class CastTime extends CoreCastTime {
 			.target(this.parser.actor.id)
 			.status(this.data.statuses.ACCELERATION.id)
 
-		this.addEventHook(accelerationFilter.type('statusApply'), this.onApplyAcceleration)
+		this.addEventHook(accelerationFilter.type('statusApply'), this.onGainAcceleration)
 		this.addEventHook(accelerationFilter.type('statusRemove'), this.onRemoveAcceleration)
+
+		const dualcastFilter = filter<Event>()
+			.target(this.parser.actor.id)
+			.status(this.data.statuses.DUALCAST.id)
+
+		this.addEventHook(dualcastFilter.type('statusApply'), this.onGainDualcast)
+		this.addEventHook(dualcastFilter.type('statusRemove'), this.onRemoveDualcast)
 	}
 
-	private onApplyAcceleration(): void {
+	private onGainAcceleration(): void {
 		this.onRemoveAcceleration() // Close the previous stack's adjustment before starting a new one
 		this.accelerationIndex = this.setInstantCastAdjustment([
 			this.data.actions.VERAERO.id,
@@ -31,5 +39,14 @@ export class CastTime extends CoreCastTime {
 	private onRemoveAcceleration(): void {
 		this.reset(this.accelerationIndex)
 		this.accelerationIndex = null
+	}
+
+	private onGainDualcast(): void {
+		this.dualcastIndex = this.setInstantCastAdjustment()
+	}
+
+	private onRemoveDualcast(): void {
+		this.reset(this.dualcastIndex)
+		this.dualcastIndex = null
 	}
 }

--- a/src/parser/jobs/rdm/modules/CastTime.ts
+++ b/src/parser/jobs/rdm/modules/CastTime.ts
@@ -1,0 +1,35 @@
+import {Event} from 'event'
+import {filter} from 'parser/core/filter'
+import CoreCastTime from 'parser/core/modules/CastTime'
+
+export class CastTime extends CoreCastTime {
+	private accelerationIndex: number | null = null
+
+	override initialise() {
+		super.initialise()
+
+		const accelerationFilter = filter<Event>()
+			.target(this.parser.actor.id)
+			.status(this.data.statuses.ACCELERATION.id)
+
+		this.addEventHook(accelerationFilter.type('statusApply'), this.onApplyAcceleration)
+		this.addEventHook(accelerationFilter.type('statusRemove'), this.onRemoveAcceleration)
+	}
+
+	private onApplyAcceleration(): void {
+		this.onRemoveAcceleration() // Close the previous stack's adjustment before starting a new one
+		this.accelerationIndex = this.setInstantCastAdjustment([
+			this.data.actions.VERAERO.id,
+			this.data.actions.VERAERO_III.id,
+			this.data.actions.VERTHUNDER.id,
+			this.data.actions.VERTHUNDER_III.id,
+			this.data.actions.SCATTER.id,
+			this.data.actions.IMPACT.id,
+		])
+	}
+
+	private onRemoveAcceleration(): void {
+		this.reset(this.accelerationIndex)
+		this.accelerationIndex = null
+	}
+}

--- a/src/parser/jobs/rdm/modules/Dualcast.tsx
+++ b/src/parser/jobs/rdm/modules/Dualcast.tsx
@@ -7,7 +7,6 @@ import {Event, Events} from 'event'
 import {Analyser} from 'parser/core/Analyser'
 import {filter} from 'parser/core/filter'
 import {dependency} from 'parser/core/Injectable'
-import CastTime from 'parser/core/modules/CastTime'
 import {Data} from 'parser/core/modules/Data'
 import Downtime from 'parser/core/modules/Downtime'
 import Suggestions, {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
@@ -31,7 +30,6 @@ export class DualCast extends Analyser {
 	static override title = t('rdm.dualcast.title')`Dualcast`
 	static override displayOrder = DISPLAY_ORDER.DUALCAST
 
-	@dependency private castTime!: CastTime
 	@dependency private data!: Data
 	@dependency private downtime!: Downtime
 	@dependency private suggestions!: Suggestions
@@ -39,7 +37,6 @@ export class DualCast extends Analyser {
 	private wastedDualCasts: Array<Events['action']> = []
 	private expiredDualCasts = 0
 	private dualcastActive = false
-	private dualcastIndex: number | null = null
 
 	override initialise() {
 		const playerEvents = filter<Event>().source(this.parser.actor.id)
@@ -67,7 +64,6 @@ export class DualCast extends Analyser {
 
 	private onGain() {
 		this.dualcastActive = true
-		this.dualcastIndex = this.castTime.setInstantCastAdjustment()
 	}
 
 	private onRemove() {
@@ -77,7 +73,6 @@ export class DualCast extends Analyser {
 			}
 		}
 		this.dualcastActive = false
-		this.castTime.reset(this.dualcastIndex)
 	}
 
 	private onComplete() {

--- a/src/parser/jobs/rdm/modules/index.tsx
+++ b/src/parser/jobs/rdm/modules/index.tsx
@@ -1,5 +1,6 @@
 import {AlwaysBeCasting} from 'parser/core/modules/AlwaysBeCasting'
 import {Tincture} from 'parser/core/modules/Tincture'
+import {CastTime} from './CastTime'
 import {Combos} from './Combos'
 import {DualCast} from './Dualcast'
 import {Embolden} from './Embolden'
@@ -16,6 +17,7 @@ export default [
 	AlwaysBeCasting,
 	Embolden,
 	Gauge,
+	CastTime,
 	DualCast,
 	//I've been asked to disconnect this for now until it's decided exactly what it should be
 	//EngagementDisplacementTracking,


### PR DESCRIPTION
- Adding a new CastTime module for RDM that is responsible for any cast time adjustments
- Added logic for Acceleration instant casts to new module
- Moved existing DualCast cast adjustments to this module (leaving the DualCast module just for finding player mistakes)

This is what the weaving issue and timeline looked like prior to this change. Weaving logic couldn't determine that the Veraero was instant, it was assuming the full cast time:
![image](https://user-images.githubusercontent.com/52140480/146490889-1fc0b186-49aa-4105-bc65-39b187d22354.png)
Afterwards, this weaving issue is no longer present.