### PR TITLE
NIN - Update Huton analyser for 6.0

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -533,7 +533,7 @@
   "nin.huton.checklist.description.warning": "As Huton is now a gauge instead of a buff, please bear in mind that this is an estimate, not an exact value. This also applies to any Huton-related suggestions below.",
   "nin.huton.checklist.name": "Keep Huton up",
   "nin.huton.checklist.requirement.name": "<0/> uptime",
-  "nin.huton.suggestions.clipping.content": "Avoid using <0/> when <1/> has more than 40 seconds left on its duration. The excess time is wasted, so using <2/> is typically the better option.",
+  "nin.huton.suggestions.clipping.content": "Avoid using <0/> when <1/> has more than 30 seconds left on its duration. The excess time is wasted, so using <2/> is typically the better option.",
   "nin.huton.suggestions.clipping.why": "You clipped {0} of Huton with early Armor Crushes.",
   "nin.huton.suggestions.futile-ac.content": "Avoid using <0/> when <1/> is down, as it provides no benefit and does less DPS than your other combo finishers.",
   "nin.huton.suggestions.futile-ac.why": "You used Armor Crush {badAcs, plural, one {# time} other {# times}} when Huton was down.",

--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -116,6 +116,14 @@ export const NIN = ensureActions({
 		speedAttribute: Attribute.SKILL_SPEED,
 	},
 
+	PHANTOM_KAMAITACHI_BUNSHIN: {
+		id: 25775,
+		name: 'Phantom Kamaitachi',
+		icon: 'https://xivapi.com/i/002000/002929.png',
+		onGcd: true,
+		speedAttribute: Attribute.SKILL_SPEED,
+	},
+
 	TEN: {
 		id: 2259,
 		name: 'Ten',

--- a/src/parser/jobs/nin/index.tsx
+++ b/src/parser/jobs/nin/index.tsx
@@ -21,6 +21,11 @@ export const NINJA = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2021-12-17'),
+			Changes: () => <>Updated Huton analyser for 6.0.</>,
+			contributors: [CONTRIBUTORS.TOASTDEIB],
+		},
+		{
 			date: new Date('2021-12-11'),
 			Changes: () => <>Added an analyser for tracking dropped Forked/Fleeting Raiju Ready buffs.</>,
 			contributors: [CONTRIBUTORS.TOASTDEIB],

--- a/src/parser/jobs/nin/modules/Huton.tsx
+++ b/src/parser/jobs/nin/modules/Huton.tsx
@@ -2,7 +2,7 @@ import {Trans, Plural} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
 import {ActionKey} from 'data/ACTIONS'
 import {EncounterKey} from 'data/ENCOUNTERS'
-import {Event, Events} from 'event'
+import {Cause, Event, Events} from 'event'
 import {Analyser} from 'parser/core/Analyser'
 import {filter, oneOf} from 'parser/core/filter'
 import {dependency} from 'parser/core/Injectable'
@@ -14,18 +14,18 @@ import React, {Fragment} from 'react'
 import {Icon, Message} from 'semantic-ui-react'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
-const HUTON_MAX_DURATION_MILLIS = 70000 // Not in STATUSES/NIN.js because lolgauges
+const HUTON_MAX_DURATION_MILLIS = 60000 // Not in STATUSES/NIN.js because lolgauges
 
 // TODO - Revisit how this sim works in the first place because it's fucky
-const HUTON_START_DURATION_MILLIS_HIGH = 65000
-const HUTON_START_DURATION_MILLIS_LOW = 59000
+const HUTON_START_DURATION_MILLIS_HIGH = 55000
+const HUTON_START_DURATION_MILLIS_LOW = 49000
 
-const HUTON_EXTENSION_AC = 30000
-const HUTON_EXTENSION_HM = 10000
+const HUTON_EXTENSION_LONG = 30000
+const HUTON_EXTENSION_SHORT = 10000
 
 const HUTON_EXTENSION_MILLIS: Array<[ActionKey, number]> = [
-	['ARMOR_CRUSH', HUTON_EXTENSION_AC],
-	['HAKKE_MUJINSATSU', HUTON_EXTENSION_HM],
+	['ARMOR_CRUSH', HUTON_EXTENSION_LONG],
+	['HAKKE_MUJINSATSU', HUTON_EXTENSION_SHORT],
 ]
 
 const DOWNTIME_DIFFERENCE_TOLERANCE = 10000 // If the downtime estimates are off by more than this, we can probably toss the low estimate
@@ -70,8 +70,13 @@ export class Huton extends Analyser {
 
 	override initialise() {
 		const playerFilter = filter<Event>().source(this.parser.actor.id)
-		this.addEventHook(playerFilter.type('action').action(this.data.actions.HUTON.id), this.onHutonCast)
-		this.addEventHook(playerFilter.type('combo').action(oneOf(HUTON_EXTENSION_MILLIS.map(pair => this.data.actions[pair[0]].id))), this.onHutonExtension)
+		const pets = this.parser.pull.actors.filter(actor => actor.owner === this.parser.actor).map(actor => actor.id)
+		this.addEventHook(playerFilter.type('action').action(oneOf([this.data.actions.HUTON.id, this.data.actions.HURAIJIN.id])), this.onHutonCast)
+		this.addEventHook(playerFilter.type('combo').action(oneOf(HUTON_EXTENSION_MILLIS.map(pair => this.data.actions[pair[0]].id))), this.onHutonCombo)
+		this.addEventHook(filter<Event>()
+			.source(oneOf(pets))
+			.type('damage')
+			.cause(filter<Cause>().action(this.data.actions.PHANTOM_KAMAITACHI_BUNSHIN.id)), this.onKamaitachi)
 		this.addEventHook({type: 'death', actor: this.parser.actor.id}, this.onDeath)
 		this.addEventHook({type: 'raise', actor: this.parser.actor.id}, this.onRaise)
 		this.addEventHook('complete', this.onComplete)
@@ -105,7 +110,7 @@ export class Huton extends Analyser {
 		}
 	}
 
-	private onHutonExtension(event: Events['combo']) {
+	private onHutonCombo(event: Events['combo']) {
 		const elapsedTime = (event.timestamp - this.lastEventTime)
 		const action = this.data.getAction(event.action)
 		if (action == null) { return }
@@ -114,6 +119,13 @@ export class Huton extends Analyser {
 		const extension = this.hutonExtensionMillis.get(action.id) ?? 0
 		this.handleHutonExtension(this.highEstimate, extension, elapsedTime)
 		this.handleHutonExtension(this.lowEstimate, extension, elapsedTime)
+		this.lastEventTime = event.timestamp
+	}
+
+	private onKamaitachi(event: Events['damage']) {
+		const elapsedTime = (event.timestamp - this.lastEventTime)
+		this.handleHutonExtension(this.highEstimate, HUTON_EXTENSION_SHORT, elapsedTime)
+		this.handleHutonExtension(this.lowEstimate, HUTON_EXTENSION_SHORT, elapsedTime)
 		this.lastEventTime = event.timestamp
 	}
 
@@ -174,7 +186,7 @@ export class Huton extends Analyser {
 		this.suggestions.add(new TieredSuggestion({
 			icon: this.data.actions.HUTON.icon,
 			content: <Trans id="nin.huton.suggestions.clipping.content">
-				Avoid using <ActionLink action="ARMOR_CRUSH"/> when <ActionLink action="HUTON"/> has more than 40 seconds left on its duration. The excess time is wasted, so using <ActionLink action="AEOLIAN_EDGE"/> is typically the better option.
+				Avoid using <ActionLink action="ARMOR_CRUSH"/> when <ActionLink action="HUTON"/> has more than 30 seconds left on its duration. The excess time is wasted, so using <ActionLink action="AEOLIAN_EDGE"/> is typically the better option.
 			</Trans>,
 			tiers: {
 				5000: SEVERITY.MINOR,

--- a/src/parser/jobs/nin/modules/Ninki.tsx
+++ b/src/parser/jobs/nin/modules/Ninki.tsx
@@ -14,6 +14,7 @@ type GaugeModifier = Partial<Record<Event['type'], number>>
 
 // Constants
 const BUNSHIN_GAIN = 5
+const BUNSHIN_GAIN_KAMAITACHI = 10
 
 const OVERCAP_SEVERITY = {
 	20: SEVERITY.MINOR,
@@ -48,7 +49,6 @@ export class Ninki extends CoreGauge {
 			this.data.actions.HURAIJIN.id,
 			this.data.actions.FORKED_RAIJU.id,
 			this.data.actions.FLEETING_RAIJU.id,
-			this.data.actions.PHANTOM_KAMAITACHI.id,
 			this.data.actions.THROWING_DAGGER.id,
 			this.data.actions.MUG.id,
 		],
@@ -65,7 +65,6 @@ export class Ninki extends CoreGauge {
 		[this.data.actions.HURAIJIN.id, {damage: 5}],
 		[this.data.actions.FORKED_RAIJU.id, {damage: 5}],
 		[this.data.actions.FLEETING_RAIJU.id, {damage: 5}],
-		[this.data.actions.PHANTOM_KAMAITACHI.id, {damage: 5}],
 		[this.data.actions.THROWING_DAGGER.id, {damage: 5}],
 		[this.data.actions.MUG.id, {damage: 40}],
 		[this.data.actions.MEISUI.id, {action: 50}],
@@ -85,13 +84,17 @@ export class Ninki extends CoreGauge {
 		this.addEventHook(playerFilter.type('action').action(oneOf(this.ninkiFilters.action)), this.onGaugeModifier)
 		this.addEventHook(playerFilter.type('combo').action(oneOf(this.ninkiFilters.combo)), this.onGaugeModifier)
 		this.addEventHook(playerFilter.type('damage').cause(filter<Cause>().action(oneOf(this.ninkiFilters.damage))), this.onDamage)
-		this.addEventHook(filter<Event>().source(oneOf(pets)).type('action'), this.onBunshinHit)
+		this.addEventHook(filter<Event>().source(oneOf(pets)).type('damage'), this.onBunshinHit)
 		this.addEventHook(playerFilter.type('damage').cause(filter<Cause>().action(this.data.actions.HELLFROG_MEDIUM.id)), this.onHellfrog)
 		this.addEventHook('complete', this.onComplete)
 	}
 
-	private onBunshinHit() {
-		this.ninkiGauge.modify(BUNSHIN_GAIN)
+	private onBunshinHit(event: Events['damage']) {
+		if (event.cause.type === 'action' && event.cause.action === this.data.actions.PHANTOM_KAMAITACHI_BUNSHIN.id) {
+			this.ninkiGauge.modify(BUNSHIN_GAIN_KAMAITACHI)
+		} else {
+			this.ninkiGauge.modify(BUNSHIN_GAIN)
+		}
 	}
 
 	private onDamage(event: Events['damage']) {


### PR DESCRIPTION
One of these days I'd love to rewrite this nightmare of an analyser from scratch, but for now, it's updated to account for the changes in Endwalker (60s timer, new extension actions). I also fixed a small bug in the Ninki sim while I was at it, since it related to the way Phantom Kamaitachi is handled under the hood (it was only generating 5 in the sim, not 10).