### PR TITLE
GNB: Fix for Incorrect GCD Uptime

### DIFF
--- a/src/data/ACTIONS/root/GNB.ts
+++ b/src/data/ACTIONS/root/GNB.ts
@@ -124,6 +124,7 @@ export const GNB = ensureActions({
 		name: 'Double Down',
 		icon: 'https://xivapi.com/i/003000/003432_hr1.png',
 		onGcd: true,
+		gcdRecast: 2500,
 		cooldown: 60000,
 		speedAttribute: Attribute.SKILL_SPEED,
 	},


### PR DESCRIPTION
* Added gcdRecast value to correct for Double Down recast time being added in full.

Bug:
![image](https://user-images.githubusercontent.com/65277/146839705-b774e7f9-b1dd-4a07-91ff-4bc9d5c94a15.png)

Fixed:
![image](https://user-images.githubusercontent.com/65277/146839766-2e8e0a63-a3c1-4406-b547-fc37516ee5d8.png)
