### PR TITLE
RDM - moving modules to use DataLink

### DIFF
--- a/src/parser/jobs/rdm/modules/Dualcast.tsx
+++ b/src/parser/jobs/rdm/modules/Dualcast.tsx
@@ -1,6 +1,6 @@
 import {t} from '@lingui/macro'
 import {Trans, Plural} from '@lingui/react'
-import {ActionLink, StatusLink} from 'components/ui/DbLink'
+import {DataLink} from 'components/ui/DbLink'
 import Rotation from 'components/ui/Rotation'
 import {BASE_GCD} from 'data/CONSTANTS'
 import {Event, Events} from 'event'
@@ -80,7 +80,7 @@ export class DualCast extends Analyser {
 			this.suggestions.add(new TieredSuggestion({
 				icon: this.data.statuses.DUALCAST.icon,
 				content: <Trans id="rdm.dualcast.suggestions.wasted.content">
-					Spells used while <StatusLink {...this.data.statuses.DUALCAST}/> is up should be limited to <ActionLink {...this.data.actions.VERAERO_III}/>, <ActionLink {...this.data.actions.VERTHUNDER_III}/>, or <ActionLink {...this.data.actions.VERRAISE}/>
+					Spells used while <DataLink status="DUALCAST"/> is up should be limited to <DataLink action="VERAERO_III"/>, <DataLink action="VERTHUNDER_III"/>, or <DataLink action="VERRAISE"/>
 				</Trans>,
 				tiers: SEVERITY_WASTED_DUALCAST,
 				value: this.wastedDualCasts.length,

--- a/src/parser/jobs/rdm/modules/Interrupts.tsx
+++ b/src/parser/jobs/rdm/modules/Interrupts.tsx
@@ -1,5 +1,5 @@
 import {Trans} from '@lingui/react'
-import {ActionLink} from 'components/ui/DbLink'
+import {DataLink} from 'components/ui/DbLink'
 import {Interrupts as CoreInterrupts} from 'parser/core/modules/Interrupts'
 import React from 'react'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
@@ -7,6 +7,6 @@ import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 export class Interrupts extends CoreInterrupts {
 	static override displayOrder = DISPLAY_ORDER.INTERRUPTED_CASTS
 	override suggestionContent = <Trans id="rdm.interrupts.suggestion.content">
-		Avoid interrupting casts by either prepositioning yourself or utilizing slidecasting where possible. If you need to move, try to save a use of <ActionLink {...this.data.actions.SWIFTCAST}/>, <ActionLink {...this.data.actions.ACCELERATION}/>, or pool mana for a melee combo or if none of these are available use <ActionLink {...this.data.actions.ENCHANTED_REPRISE}/>.
+		Avoid interrupting casts by either prepositioning yourself or utilizing slidecasting where possible. If you need to move, try to save a use of <DataLink action="SWIFTCAST"/>, <DataLink action="ACCELERATION"/>, or pool mana for a melee combo or if none of these are available use <DataLink action="ENCHANTED_REPRISE"/>.
 	</Trans>
 }

--- a/src/parser/jobs/rdm/modules/MeleeCombos.tsx
+++ b/src/parser/jobs/rdm/modules/MeleeCombos.tsx
@@ -1,6 +1,6 @@
 import {t} from '@lingui/macro'
 import {Trans, Plural} from '@lingui/react'
-import {ActionLink, DataLink, StatusLink} from 'components/ui/DbLink'
+import {ActionLink, DataLink} from 'components/ui/DbLink'
 import Rotation from 'components/ui/Rotation'
 import {Action} from 'data/ACTIONS/type'
 import {Status} from 'data/STATUSES/type'
@@ -272,9 +272,9 @@ export class MeleeCombos extends Analyser {
 										combo.data.procs.map((key) => {
 											switch (key) {
 											case this.data.statuses.VERSTONE_READY:
-												return (<StatusLink key="verstone" showName={false} {...this.data.statuses.VERSTONE_READY}/>)
+												return (<DataLink key="verstone" showName={false} status="VERSTONE_READY"/>)
 											case this.data.statuses.VERFIRE_READY:
-												return (<StatusLink key="verfire" showName={false} {...this.data.statuses.VERFIRE_READY}/>)
+												return (<DataLink key="verfire" showName={false} status="VERFIRE_READY"/>)
 											}
 										})
 									}</span>

--- a/src/parser/jobs/rdm/modules/Procs.tsx
+++ b/src/parser/jobs/rdm/modules/Procs.tsx
@@ -1,6 +1,6 @@
 import {t} from '@lingui/macro'
 import {Trans, Plural} from '@lingui/react'
-import {ActionLink, StatusLink} from 'components/ui/DbLink'
+import {DataLink} from 'components/ui/DbLink'
 import {Events} from 'event'
 import {Procs as CoreProcs} from 'parser/core/modules/Procs'
 import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
@@ -44,16 +44,16 @@ export class Procs extends CoreProcs {
 	private getMissedProcContent(missedFire: number, missedStone: number) {
 		if (missedFire > 0 && missedStone > 0) {
 			return <Trans id="rdm.procs.suggestions.missed.content">
-				Try to use <ActionLink {...this.data.actions.VERFIRE} /> whenever you have <StatusLink {...this.data.statuses.VERFIRE_READY} /> or <ActionLink {...this.data.actions.VERSTONE} /> whenever you have <StatusLink {...this.data.statuses.VERSTONE_READY} /> to avoid losing out on mana gains.
+				Try to use <DataLink action="VERFIRE" /> whenever you have <DataLink status="VERFIRE_READY"/> or <DataLink action="VERSTONE" /> whenever you have <DataLink status="VERSTONE_READY"/> to avoid losing out on mana gains.
 			</Trans>
 		}
 		if (missedFire > 0) {
 			return <Trans id="rdm.procs.suggestions.missed-fire.content">
-				Try to use <ActionLink {...this.data.actions.VERFIRE} /> whenever you have <StatusLink {...this.data.statuses.VERFIRE_READY} /> to avoid losing out on mana gains.
+				Try to use <DataLink action="VERFIRE" /> whenever you have <DataLink status="VERFIRE_READY"/> to avoid losing out on mana gains.
 			</Trans>
 		}
 		return <Trans id="rdm.procs.suggestions.missed-stone.content">
-			Try to use <ActionLink {...this.data.actions.VERSTONE} /> whenever you have <StatusLink {...this.data.statuses.VERSTONE_READY} /> to avoid losing out on mana gains.
+			Try to use <DataLink action="VERSTONE" /> whenever you have <DataLink status="VERSTONE_READY"/> to avoid losing out on mana gains.
 		</Trans>
 	}
 
@@ -76,16 +76,16 @@ export class Procs extends CoreProcs {
 	private getOverwrittenProcContent(overWrittenFire: number, overWrittenStone: number) {
 		if (overWrittenFire > 0 && overWrittenStone > 0) {
 			return <Trans id="rdm.procs.suggestions.overwritten.content">
-				Don't cast <ActionLink {...this.data.actions.VERTHUNDER_III} /> when you have <StatusLink {...this.data.statuses.VERFIRE_READY} /> or <ActionLink {...this.data.actions.VERAERO_III} /> when you have <StatusLink {...this.data.statuses.VERSTONE_READY} />.
+				Don't cast <DataLink action="VERTHUNDER_III"/> when you have <DataLink status="VERFIRE_READY"/> or <DataLink action="VERAERO_III"/> when you have <DataLink status="VERSTONE_READY"/>.
 			</Trans>
 		}
 		if (overWrittenFire > 0) {
 			return <Trans id="rdm.procs.suggestions.overwritten-fire.content">
-				Don't cast <ActionLink {...this.data.actions.VERTHUNDER_III} /> when you have <StatusLink {...this.data.statuses.VERFIRE_READY} />.
+				Don't cast <DataLink action="VERTHUNDER_III" /> when you have <DataLink status="VERFIRE_READY"/>.
 			</Trans>
 		}
 		return <Trans id="rdm.procs.suggestions.overwritten-stone.content">
-			Don't cast <ActionLink {...this.data.actions.VERAERO_III} /> when you have <StatusLink {...this.data.statuses.VERSTONE_READY} />.
+			Don't cast <DataLink action="VERAERO_III" /> when you have <DataLink status="VERSTONE_READY"/>.
 		</Trans>
 	}
 
@@ -108,16 +108,16 @@ export class Procs extends CoreProcs {
 	private getInvulnProcContent(invulnFire: number, invulnStone: number) {
 		if (invulnFire > 0 && invulnStone > 0) {
 			return <Trans id="rdm.procs.suggestions.invuln.content">
-				Try not to use <ActionLink {...this.data.actions.VERFIRE} /> and <ActionLink {...this.data.actions.VERSTONE} /> while the boss is invulnerable.
+				Try not to use <DataLink action="VERFIRE"/> and <DataLink action="VERSTONE"/> while the boss is invulnerable.
 			</Trans>
 		}
 		if (invulnFire > 0) {
 			return <Trans id="rdm.procs.suggestions.invuln-fire.content">
-				Try not to use <ActionLink {...this.data.actions.VERFIRE} /> while the boss is invulnerable.
+				Try not to use <DataLink action="VERFIRE"/> while the boss is invulnerable.
 			</Trans>
 		}
 		return <Trans id="rdm.procs.suggestions.invuln-stone.content">
-			Try not to use <ActionLink {...this.data.actions.VERSTONE} /> while the boss is invulnerable.
+			Try not to use <DataLink action="VERSTONE"/> while the boss is invulnerable.
 		</Trans>
 	}
 


### PR DESCRIPTION
- Per suggestion in Discord #notifications channel (on 10/26/2021)
- Had to keep one ActionLink in MeleeCombos as it is dynamically rendered without any access to the Action key that DataLink needs.