### PR TITLE
RDM - Allowing proc losses in opener

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -651,6 +651,7 @@
   "rdm.meleecombos.recommendation.delaycombo": "Starte deine Kombo nicht mit einem Finisher-Proc aktiv. Eventuell solltest du einen Proc benutzen bevor du in deine Nahkampf-Kombo übergehst, solange du weniger als <0/> Mana durch Überlauf verlierst",
   "rdm.meleecombos.recommendation.delaycombo.short": "",
   "rdm.meleecombos.recommendation.delaycombo.why": "{0, plural, one {# Proc ist durch Starten der Nahkampf-Kombo verloren gegangen.} other {# Procs sind durch Starten der Nahkampf-Kombo verloren gegangen.}}",
+  "rdm.meleecombos.recommendation.opener.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher": "",
   "rdm.meleecombos.recommendation.wrongfinisher.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher.why": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -651,6 +651,7 @@
   "rdm.meleecombos.recommendation.delaycombo": "Do not enter your combo with your finisher's proc up. Consider dumping a proc before entering the melee combo as long as you waste less than {0} mana to overcapping.",
   "rdm.meleecombos.recommendation.delaycombo.short": "Delay combo",
   "rdm.meleecombos.recommendation.delaycombo.why": "{0, plural, one {# Proc cast was lost due to entering the melee combo with the finisher proc up.} other {# Proc casts were lost due to entering the melee combo with the finisher proc up.}}",
+  "rdm.meleecombos.recommendation.opener.short": "It's okay to lose procs in the opener.",
   "rdm.meleecombos.recommendation.wrongfinisher": "You should use <0/> when your black mana is lower or <1/> when your white mana is lower.",
   "rdm.meleecombos.recommendation.wrongfinisher.short": "Wrong finisher",
   "rdm.meleecombos.recommendation.wrongfinisher.why": "{0, plural, one {# Verfire/Verstone cast was lost due to using the incorrect finisher.} other {# Verfire/Verstone casts were lost due to using the incorrect finisher.}}",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -651,6 +651,7 @@
   "rdm.meleecombos.recommendation.delaycombo": "Ne commencez pas votre combo avec votre proc de fin. Envisagez de sauter une proc avant d’entrer dans votre combo de mêlée tant que vous perdez moins de <0/> mana pour y arriver",
   "rdm.meleecombos.recommendation.delaycombo.short": "",
   "rdm.meleecombos.recommendation.delaycombo.why": "{0, plural, one {# Proc casté perdu à cause d'un commencent du combo de mêlée avec votre proc de finisher actif.} other {# Procs castés perdus à cause d'un commencent du combo de mêlée avec votre proc de finisher actif.}}",
+  "rdm.meleecombos.recommendation.opener.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher": "",
   "rdm.meleecombos.recommendation.wrongfinisher.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher.why": "",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -651,6 +651,7 @@
   "rdm.meleecombos.recommendation.delaycombo": "オーバーフローによるマナの損失が{0} 以下になりそうな場合は、ヴァルフレア/ホーリーの発動で生じるProcを確定させるために魔法剣コンボの開始を少し遅らせましょう。",
   "rdm.meleecombos.recommendation.delaycombo.short": "",
   "rdm.meleecombos.recommendation.delaycombo.why": "",
+  "rdm.meleecombos.recommendation.opener.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher": "",
   "rdm.meleecombos.recommendation.wrongfinisher.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher.why": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -651,6 +651,7 @@
   "rdm.meleecombos.recommendation.delaycombo": "",
   "rdm.meleecombos.recommendation.delaycombo.short": "",
   "rdm.meleecombos.recommendation.delaycombo.why": "{0, plural, one {# 개의 프록이 같은 속성의 근접 콤보 마지막 공격으로 인해 손실되었습니다.} other {# 개의 프록이 같은 속성의 근접 콤보 마지막 공격으로 인해 손실되었습니다.}}",
+  "rdm.meleecombos.recommendation.opener.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher": "",
   "rdm.meleecombos.recommendation.wrongfinisher.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher.why": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -651,6 +651,7 @@
   "rdm.meleecombos.recommendation.delaycombo": "",
   "rdm.meleecombos.recommendation.delaycombo.short": "",
   "rdm.meleecombos.recommendation.delaycombo.why": "由于在魔元较低的一方有触发时进入魔连击而损失了 {0} 次触发。",
+  "rdm.meleecombos.recommendation.opener.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher": "",
   "rdm.meleecombos.recommendation.wrongfinisher.short": "",
   "rdm.meleecombos.recommendation.wrongfinisher.why": "",

--- a/src/parser/jobs/rdm/index.tsx
+++ b/src/parser/jobs/rdm/index.tsx
@@ -30,6 +30,11 @@ export const RED_MAGE = new Meta({
 
 	changelog: [
 		{
+			date: new Date('2021-12-22'),
+			Changes: () => <>Updated suggestions to allow procs to be overwritten during the opener.</>,
+			contributors: [CONTRIBUTORS.MYPS],
+		},
+		{
 			date: new Date('2021-12-18'),
 			Changes: () => <>Showing recommended actions in cases where melee combo should be delayed.</>,
 			contributors: [CONTRIBUTORS.MYPS],

--- a/src/parser/jobs/rdm/modules/MeleeCombos.tsx
+++ b/src/parser/jobs/rdm/modules/MeleeCombos.tsx
@@ -83,6 +83,7 @@ export class MeleeCombos extends Analyser {
 	}
 	private readonly _ignoreFinisherProcsManaThreshold = 4
 	private readonly _upperComboTimeFrame = 13
+	private readonly _openerDelayForgivenessDuration = 15000
 
 	private readonly _suggestionText: Record<SuggestionKey, JSX.Element> = {
 		[SuggestionKey.WRONG_FINISHER]: <Trans id="rdm.meleecombos.recommendation.wrongfinisher">
@@ -288,7 +289,10 @@ export class MeleeCombos extends Analyser {
 											return (<ActionLink key={action.id} showName={false} {...action}/>)
 										})
 									}
-									<br />{recommendation}
+									{
+										recommendedActions.length > 0 && <br />
+									}
+									{recommendation}
 								</Table.Cell>
 							</Table.Row>)
 						})
@@ -366,6 +370,10 @@ export class MeleeCombos extends Analyser {
 			if (recommendedFinisher === this._finishers) {
 				// a recommendation of both finishers means ignore the finisher, either one is valid
 				combo.data.finisher.recommendedActions.push(finisherAction)
+			} else if (combo.start - this.parser.pull.timestamp < this._openerDelayForgivenessDuration) {
+				combo.data.finisher.recommendation = <Fragment>
+					<Trans id="rdm.meleecombos.recommendation.opener.short">It's okay to lose procs in the opener.</Trans>
+				</Fragment>
 			} else {
 				// a recommendation of an array of actions is to delay the combo
 				Array.prototype.push.apply(combo.data.finisher.recommendedActions, recommendedFinisher)


### PR DESCRIPTION
- The current opener for RDM makes it very likely that you will overwrite a proc during the opener.
- This change will simply prevent the "delay" message from showing on any combo that starts in the first 15 seconds of a pull.

Before:
![image](https://user-images.githubusercontent.com/52140480/147078152-c5763fa5-9726-496a-87f9-a6f4df667dee.png)

After:
![image](https://user-images.githubusercontent.com/52140480/147078179-04dd3c26-1095-4834-876c-0adcb5a074ee.png)
