### PR TITLE
fix: track the Salt and Darkness damage packet correctly

### DIFF
--- a/src/data/ACTIONS/root/DRK.ts
+++ b/src/data/ACTIONS/root/DRK.ts
@@ -126,6 +126,12 @@ export const DRK = ensureActions({
 		icon: 'https://xivapi.com/i/003000/003090.png',
 		cooldown: 20000,
 	},
+	SALT_AND_DARKNESS_DAMAGE: {
+		id: 25756,
+		name: 'Salt and Darkness',
+		icon: 'https://xivapi.com/i/003000/003090.png',
+		cooldown: 20000,
+	},
 	SHADOWBRINGER: {
 		id: 25757,
 		name: 'Shadowbringer',

--- a/src/parser/jobs/drk/modules/SaltAndDarkness.tsx
+++ b/src/parser/jobs/drk/modules/SaltAndDarkness.tsx
@@ -40,7 +40,7 @@ export class SaltAndDarkness extends Analyser {
 		const playerFilter = filter<Event>().source(this.parser.actor.id)
 		this.addEventHook(playerFilter.type('action').action(this.data.actions.SALTED_EARTH.id), () => this.saltedEarthUsed++)
 		this.addEventHook(playerFilter.type('action').action(this.data.actions.SALT_AND_DARKNESS.id), () => this.saltAndDarknessUsed++)
-		this.addEventHook(playerFilter.type('damage').cause(this.data.matchCauseAction(['SALT_AND_DARKNESS'])), this.onSaltDarknessDamage)
+		this.addEventHook(playerFilter.type('damage').cause(this.data.matchCauseAction(['SALT_AND_DARKNESS_DAMAGE'])), this.onSaltDarknessDamage)
 		this.addEventHook('complete', this.onComplete)
 	}
 


### PR DESCRIPTION
The game (and thus ACT/FFLogs) uses different IDs for the damage hit of S&D vs the cast action.  This updates our tracking to correctly see the damage hits