### PR TITLE
DNC - Bugfix for bogus Technical Finish windows

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -27,4 +27,9 @@ export const changelog = [
 		Changes: () => <>Update Devilment timing suggestion, and mark job as supported for Endwalker.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2021-12-23'),
+		Changes: () => <>Bugfix for Technical Finish windows opening due to non-player-controlled units spawning.</>,
+		contributors: [CONTRIBUTORS.MYPS],
+	},
 ]

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -73,8 +73,23 @@ export class Technicalities extends Analyser {
 
 	override initialise() {
 		const techFinishFilter = filter<Event>().type('statusApply').status(this.data.statuses.TECHNICAL_FINISH.id)
-		this.addEventHook(techFinishFilter.target(this.parser.actor.id), this.tryOpenWindow)
-		this.addEventHook(techFinishFilter.source(this.parser.actor.id), this.countTechBuffs)
+
+		// Ignore any actors besides players
+		const playerCharacters = this.parser.pull.actors
+			.filter(actor => actor.playerControlled)
+			.map(actor => actor.id)
+
+		this.addEventHook(
+			techFinishFilter
+				.target(this.parser.actor.id),
+			this.tryOpenWindow)
+
+		this.addEventHook(
+			techFinishFilter
+				.source(this.parser.actor.id)
+				.target(oneOf(playerCharacters)),
+			this.countTechBuffs)
+
 		this.addEventHook(
 			filter<Event>()
 				.type('statusRemove')


### PR DESCRIPTION
It seems there were some non-player actors that were throwing off the logic and opening new Technical Finish windows when they shouldn't. You can see the issue on this parse (there is only 1 dancer): https://xivanalysis.com/fflogs/acFQK8Lm7jwJAVtN/1/4

This change is simply filtering out non-player-controlled actors when counting buffs.

Before:
![image](https://user-images.githubusercontent.com/52140480/147314527-382464ab-eddf-4c6c-bc3a-adc68e89d48b.png)
![image](https://user-images.githubusercontent.com/52140480/147314561-81821b79-c74e-4a7e-b293-8c385b294c77.png)

After:
(no warning)
![image](https://user-images.githubusercontent.com/52140480/147314587-b964f67f-38d2-4c78-b8b2-940fd0b746d4.png)
