### PR TITLE
[bugfix] RPR CDDT list

### DIFF
--- a/src/parser/jobs/rpr/changelog.tsx
+++ b/src/parser/jobs/rpr/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2021-12-28'),
+		Changes: () => <>Replace Enshroud with Soul Slice and Soul Scythe in Use your cooldowns checklist.</>,
+		contributors: [CONTRIBUTORS.KELOS],
+	},
+	{
 		date: new Date('2021-12-18'),
 		Changes: () => <>Add a Tincture module.</>,
 		contributors: [CONTRIBUTORS.HINT],

--- a/src/parser/jobs/rpr/modules/CooldownDowntime.ts
+++ b/src/parser/jobs/rpr/modules/CooldownDowntime.ts
@@ -9,8 +9,7 @@ export class CooldownDowntime extends CoreCooldownDowntime {
 		},
 
 		{
-			cooldowns: [this.data.actions.SOUL_SLICE,
-				this.data.actions.SOUL_SCYTHE],
+			cooldowns: [this.data.actions.SOUL_SLICE, this.data.actions.SOUL_SCYTHE],
 			// Both openers use this as 2nd GCD
 			firstUseOffset: 4000,
 		},

--- a/src/parser/jobs/rpr/modules/CooldownDowntime.ts
+++ b/src/parser/jobs/rpr/modules/CooldownDowntime.ts
@@ -9,9 +9,10 @@ export class CooldownDowntime extends CoreCooldownDowntime {
 		},
 
 		{
-			cooldowns: [this.data.actions.ENSHROUD],
-			// Delayed Enshroud opener is just before 6th GCD
-			firstUseOffset: 12500,
+			cooldowns: [this.data.actions.SOUL_SLICE,
+				this.data.actions.SOUL_SCYTHE],
+			// Both openers use this as 2nd GCD
+			firstUseOffset: 4000,
 		},
 
 		{


### PR DESCRIPTION
Removed Enshroud as it is limited by gauge rather than just CD.
Added missing Soul Slice and Soul Scythe.