### PR TITLE
Fix MNK speed adjustments

### DIFF
--- a/src/parser/core/modules/SpeedAdjustments.ts
+++ b/src/parser/core/modules/SpeedAdjustments.ts
@@ -6,7 +6,7 @@ import {Analyser} from '../Analyser'
 import {dependency} from '../Injectable'
 import {Actors} from './Actors'
 
-type SpeedAttribute = Attribute.SKILL_SPEED | Attribute.SPELL_SPEED
+export type SpeedAttribute = Attribute.SKILL_SPEED | Attribute.SPELL_SPEED
 
 export class SpeedAdjustments extends Analyser {
 	static override handle = 'speedAdjustments'

--- a/src/parser/jobs/mnk/changelog.tsx
+++ b/src/parser/jobs/mnk/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2022-01-01'),
+		Changes: () => <>Fix GL speed modifier bug.</>,
+		contributors: [CONTRIBUTORS.AY],
+	},
+	{
 		date: new Date('2021-12-19'),
 		Changes: () => <>Update basic buffs and cooldown tracking, and add new actions.</>,
 		contributors: [CONTRIBUTORS.AY],

--- a/src/parser/jobs/mnk/modules/GreasedLightning.ts
+++ b/src/parser/jobs/mnk/modules/GreasedLightning.ts
@@ -1,13 +1,24 @@
-import CastTime from 'parser/core/modules/CastTime'
+import {JOBS} from 'data/JOBS'
+import {SpeedAdjustments, SpeedAttribute} from 'parser/core/modules/SpeedAdjustments'
+import {Actor} from 'report'
 
 const GREASED_LIGHTNING_MODIFIER = 0.8
 
-export class GreasedLightning extends CastTime {
-	private pomIndex: number | null = null
+export class GreasedLightning extends SpeedAdjustments {
+	override getAdjustedDuration({
+		duration,
+		attribute = JOBS[this.parser.actor.job].speedStat,
+		actor = this.parser.actor.id,
+	}: {
+		duration: number,
+		attribute?: SpeedAttribute,
+		actor?: Actor['id']
+	}) {
+		// Safety check so that only the MNK is affected
+		if (actor === this.parser.actor.id) {
+			return super.getAdjustedDuration({duration, attribute, actor}) * GREASED_LIGHTNING_MODIFIER
+		}
 
-	override initialise() {
-		super.initialise()
-
-		this.setPercentageAdjustment('all', GREASED_LIGHTNING_MODIFIER, 'both')
+		return super.getAdjustedDuration({duration, attribute, actor})
 	}
 }


### PR DESCRIPTION
GL previously adjusted CastTime which doesn't affect core GlobalCooldown. This PR ports it to SpeedAdjustments which is used by both modules so should have correct GCD in both the timeline and buff windows.