### PR TITLE
DRG: fix pre-pull synth of coerthan torment

### DIFF
--- a/src/data/ACTIONS/root/DRG.ts
+++ b/src/data/ACTIONS/root/DRG.ts
@@ -168,7 +168,6 @@ export const DRG = ensureActions({
 			from: 7397,
 			end: true,
 		},
-		statusesApplied: ['DRACONIAN_FIRE'],
 	},
 
 	// -----

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -19,6 +19,11 @@ export const DRAGOON = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-01-01'),
+			Changes: () => <>Corrected a data issue where a pre-pull use of Coerthan Torment was being synthesized and displayed on the Timeline.</>,
+			contributors: [CONTRIBUTORS.FALINDRITH],
+		},
+		{
 			date: new Date('2021-12-27'),
 			Changes: () => <>Fixed issues with Battle Litany module incorrectly opening and closing windows due to pets mirroring statuses.</>,
 			contributors: [CONTRIBUTORS.FALINDRITH],


### PR DESCRIPTION
While Coerthan Torment does apply Draconian Fire, it is not the only thing that does so (and the application isn't as simple as a single skill adding it). To prevent this action from being synthesized pre-pull, we'll just remove the status application from the data file.