### PR TITLE
Update MNK text and timeline

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -536,7 +536,7 @@
   "mnk.steppies.suggestions.bootshine.why": "{0, plural, one {# use of} other {# uses of}} <0/> executed with incorrect position.",
   "mnk.steppies.suggestions.dragon_kick.content": "Avoid unbuffed <0/> by using <1/> before it.",
   "mnk.steppies.suggestions.dragon_kick.why": "{0} potency lost to missing <0/> buff {1} times.",
-  "mnk.twinsnakes.checklist.description": "Twin Snakes is an easy 10% buff to your DPS.",
+  "mnk.twinsnakes.checklist.description": "Disciplined Fist is an easy 15% buff to your DPS.",
   "mnk.twinsnakes.checklist.name": "Keep <0/> up",
   "mnk.twinsnakes.checklist.requirement.name": "<0/> uptime",
   "mnk.twinsnakes.suggestions.antman.content": "Try to get <0/> up before using <1/> to take advantage of its free refresh.",

--- a/src/parser/jobs/mnk/changelog.tsx
+++ b/src/parser/jobs/mnk/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2022-01-03'),
+		Changes: () => <>Update Twin Snakes buff description, and adjust timeline order.</>,
+		contributors: [CONTRIBUTORS.AY],
+	},
+	{
 		date: new Date('2022-01-01'),
 		Changes: () => <>Fix GL speed modifier bug.</>,
 		contributors: [CONTRIBUTORS.AY],

--- a/src/parser/jobs/mnk/modules/ActionTimeline.tsx
+++ b/src/parser/jobs/mnk/modules/ActionTimeline.tsx
@@ -13,10 +13,10 @@ export class ActionTimeline extends CoreActionTimeline {
 		'RIDDLE_OF_FIRE',
 		'BROTHERHOOD',
 		'PERFECT_BALANCE',
-		'THUNDERCLAP',
 		'RIDDLE_OF_WIND',
 		'RIDDLE_OF_EARTH',
 		'MANTRA',
+		'THUNDERCLAP',
 		'ANATMAN',
 	]
 }

--- a/src/parser/jobs/mnk/modules/TwinSnakes.tsx
+++ b/src/parser/jobs/mnk/modules/TwinSnakes.tsx
@@ -148,11 +148,11 @@ export class TwinSnakes extends Analyser {
 
 		this.checklist.add(new Rule({
 			name: <Trans id="mnk.twinsnakes.checklist.name">Keep <DataLink status="DISCIPLINED_FIST" showIcon={false}/> up</Trans>,
-			description: <Trans id="mnk.twinsnakes.checklist.description">Twin Snakes is an easy 10% buff to your DPS.</Trans>,
+			description: <Trans id="mnk.twinsnakes.checklist.description">Disciplined Fist is an easy 15% buff to your DPS.</Trans>,
 			displayOrder: DISPLAY_ORDER.TWIN_SNAKES,
 			requirements: [
 				new Requirement({
-					name: <Trans id="mnk.twinsnakes.checklist.requirement.name"><DataLink action="TWIN_SNAKES"/> uptime</Trans>,
+					name: <Trans id="mnk.twinsnakes.checklist.requirement.name"><DataLink status="DISCIPLINED_FIST"/> uptime</Trans>,
 					percent: () => this.getBuffUptimePercent(this.data.statuses.DISCIPLINED_FIST.id),
 				}),
 			],


### PR DESCRIPTION
Display changes and a slight adjustment to description numbers. Twin Snakes' buff is now Disciplined Fist as in earlier PR, description text updated to reflect that as well as the new strength. Thunderclap moved further down as it no longer does damage while Riddle of Wind *is* a damage buff, and then I wanted to keep the riddles together.