### PR TITLE
BugFix - Stop pull timestamp gauge events from breaking history correction

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -27,5 +27,10 @@ export const changelog: ChangelogEntry[] = [
 		Changes: () => <>Added Arcane Circle, Radiant Finale, and Searing Light raid buffs to the timeline.</>,
 		contributors: [CONTRIBUTORS.HINT],
 	},
+	{
+		date: new Date('2022-1-3'),
+		Changes: () => <>Fixed a bug causing errors in gauge value simulations under certain circumstances.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 
 ]

--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,11 @@ export const changelog: ChangelogEntry[] = [
 	// },
 	{
 		date: new Date('2022-01-03'),
+		Changes: () => <>Fixed a bug causing errors in gauge value simulations under certain circumstances.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2022-01-03'),
 		Changes: () => <>
 			Use report-provided attribute values to calculate GCD recast time.
 			These values are only available for the player who logged and uploaded the report.
@@ -26,11 +31,6 @@ export const changelog: ChangelogEntry[] = [
 		date: new Date('2021-12-16'),
 		Changes: () => <>Added Arcane Circle, Radiant Finale, and Searing Light raid buffs to the timeline.</>,
 		contributors: [CONTRIBUTORS.HINT],
-	},
-	{
-		date: new Date('2022-1-3'),
-		Changes: () => <>Fixed a bug causing errors in gauge value simulations under certain circumstances.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 
 ]

--- a/src/parser/core/modules/Gauge/CounterGauge.ts
+++ b/src/parser/core/modules/Gauge/CounterGauge.ts
@@ -219,9 +219,9 @@ export class CounterGauge extends AbstractGauge {
 			: NaN
 		if (timestamp === prevTimestamp) {
 			const prevEvent = this.history.pop()
-			// If we both spent and generated gauge at this timestamp, call it a spend to keep from backtracking past it
-			if (prevEvent?.reason === 'spend') {
-				reason = 'spend'
+			// If we already spent or intitialised gauge at this timestamp, retain the reason to keep from backtracking past it
+			if (prevEvent?.reason === 'spend' || prevEvent?.reason === 'init') {
+				reason = prevEvent.reason
 			}
 		}
 


### PR DESCRIPTION
Title. If the player's first action happened at the pull timestamp, and affected a gauge that does history correction, it  would wipe out the init event in the history, which could cause the backtracking to be unable to find a `lastGeneratorIndex` in `correctGaugeHistory` now we'll retain the init type as well as the spend type if overwriting an event in the history.