### PR TITLE
Mark BLM, DNC, and SGE as supported for 6.05

### DIFF
--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -52,4 +52,9 @@ export const changelog = [
 		Changes: () => <>Correct Paradox gauge handling to grant a stack of the active stance, instead of just a timer refresh.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2021-01-04'),
+		Changes: () => <>Mark as supported for 6.05.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/blm/index.tsx
+++ b/src/parser/jobs/blm/index.tsx
@@ -14,7 +14,7 @@ export const BLACK_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.0',
+		to: '6.05',
 	},
 
 	contributors: [

--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -37,4 +37,9 @@ export const changelog = [
 		Changes: () => <>Add defensive cooldown checklist for Dancer.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2021-01-04'),
+		Changes: () => <>Mark as supported for 6.05.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/dnc/index.tsx
+++ b/src/parser/jobs/dnc/index.tsx
@@ -25,7 +25,7 @@ export const DANCER = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.0',
+		to: '6.05',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -37,4 +37,9 @@ export const changelog = [
 		Changes: () => <>Refine overheal categories, and fix a bug in the DoT clipping calculation</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2021-01-04'),
+		Changes: () => <>Mark as supported for 6.05.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/sge/index.tsx
+++ b/src/parser/jobs/sge/index.tsx
@@ -18,7 +18,7 @@ export const SAGE = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.0',
+		to: '6.05',
 	},
 
 	contributors: [


### PR DESCRIPTION
No real changes, the weaponskill-ified Finishes/Tillana don't generate Esprit. Marking all three as supported.