### PR TITLE
Mark SMN for 6.05 support.

### DIFF
--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -20,7 +20,7 @@ export const SUMMONER = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.0',
+		to: '6.05',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.KELOS, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Potency only changes do not affect analysis.