### PR TITLE
[AST] 6.05 support

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -49,7 +49,7 @@
   "ast.draw.suggestions.draw-no-usage.content": "No uses of <0/> at all.",
   "ast.draw.suggestions.draw-no-usage.why": "No draws used.",
   "ast.draw.suggestions.draw-uses.content": "Consider casting <0/> as soon as its available to maximize both MP regen and the number of cards played.",
-  "ast.draw.suggestions.draw-uses.why": "About {drawsMissed, plural, one {# use} other {# uses}} of <0/> were missed by holding two cards on full cooldown for at least a total of {0}.",
+  "ast.draw.suggestions.draw-uses.why": "About {drawsMissed, plural, one {# use} other {# uses}} of <0/> {drawsMissed, plural, one {was} other {were}} missed by holding two cards on full cooldown for at least a total of {0}.",
   "ast.draw.title": "Draw",
   "ast.earthly-star.suggestion.missed-use.content": "Use <0/> more frequently. It may save a healing GCD and results in more damage output.",
   "ast.earthly-star.suggestion.missed-use.why": "About {usesMissed} uses of Earthly Star were missed by holding it for at least a total of {0}.",

--- a/src/parser/jobs/ast/index.tsx
+++ b/src/parser/jobs/ast/index.tsx
@@ -36,12 +36,11 @@ export const ASTROLOGIAN = new Meta({
 	],
 	changelog: [
 		{
-			date: new Date('2022-01-04'),
+			date: new Date('2022-01-06'),
 			Changes: () => <>
 				<strong>6.05 Support</strong>
 				<ul>
 					<li> Actually fixed <DataLink action="DRAW" /> math instead of whatever the other person (it was me T.T ) did. </li>
-					<li> Updated <DataLink action="LUCID_DREAMING" /> thresholds to be higher since AST manamanagement is better utilized using <DataLink action="DRAW" /> and <DataLink action="ASTRODYNE" />. </li>
 					<li> Updated to 6.05 support which didn't involve a whole lot for AST. </li>
 				</ul>
 			</>,

--- a/src/parser/jobs/ast/index.tsx
+++ b/src/parser/jobs/ast/index.tsx
@@ -29,12 +29,24 @@ export const ASTROLOGIAN = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.0',
+		to: '6.05',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.OTOCEPHALY, role: ROLES.DEVELOPER},
 	],
 	changelog: [
+		{
+			date: new Date('2022-01-04'),
+			Changes: () => <>
+				<strong>6.05 Support</strong>
+				<ul>
+					<li> Actually fixed <DataLink action="DRAW" /> math instead of whatever the other person (it was me T.T ) did. </li>
+					<li> Updated <DataLink action="LUCID_DREAMING" /> thresholds to be higher since AST manamanagement is better utilized using <DataLink action="DRAW" /> and <DataLink action="ASTRODYNE" />. </li>
+					<li> Updated to 6.05 support which didn't involve a whole lot for AST. </li>
+				</ul>
+			</>,
+			contributors: [CONTRIBUTORS.OTOCEPHALY],
+		},
 		{
 			date: new Date('2021-12-31'),
 			Changes: () => <>

--- a/src/parser/jobs/ast/modules/LucidDreaming.tsx
+++ b/src/parser/jobs/ast/modules/LucidDreaming.tsx
@@ -12,7 +12,7 @@ import React, {Fragment} from 'react'
 const SEVERITIES = {
 	USE_PERCENT_THRESHOLD: {
 		0.8: SEVERITY.MAJOR, //less than 20% of the available time is close to not using it at all or barely
-		0.4: SEVERITY.MEDIUM, //60% is not using it enough -- risks not having enough mana throughout the fight, but with cards, this may not be as applicable
+		0.6: SEVERITY.MEDIUM, //40% is not using it enough -- risks not having enough mana throughout the fight, but with cards, this may not be as applicable
 		0.2: SEVERITY.MINOR, //80% of the time is used to keep it on the radar, but not punish
 	},
 }

--- a/src/parser/jobs/ast/modules/LucidDreaming.tsx
+++ b/src/parser/jobs/ast/modules/LucidDreaming.tsx
@@ -12,7 +12,7 @@ import React, {Fragment} from 'react'
 const SEVERITIES = {
 	USE_PERCENT_THRESHOLD: {
 		0.8: SEVERITY.MAJOR, //less than 20% of the available time is close to not using it at all or barely
-		0.6: SEVERITY.MEDIUM, //40% is not using it enough -- risks not having enough mana throughout the fight, but with cards, this may not be as applicable
+		0.4: SEVERITY.MEDIUM, //60% is not using it enough -- risks not having enough mana throughout the fight, but with cards, this may not be as applicable
 		0.2: SEVERITY.MINOR, //80% of the time is used to keep it on the radar, but not punish
 	},
 }


### PR DESCRIPTION
nothing major here
reduced thresholds for lucid dreaming because ast is nice with mana this patch and the focus should be on astrodyne and draw
updated draw math because it still wasn't calculating correctly. This time I am confident that the calculation is actually right. If you're curious, it should line up with the white gaps in the timeline for draw which is what sparked me to investigate why it didn't 