### PR TITLE
Timeline performance improvements round 1: will-change, transform, key fixes

### DIFF
--- a/src/parser/core/modules/Timeline/components/Axis.tsx
+++ b/src/parser/core/modules/Timeline/components/Axis.tsx
@@ -41,7 +41,7 @@ export const Axis = memo(function Axis({
 			}}
 		>
 			{ticks.map((tick, index) => (
-				<Item key={index} left={lefts[index]}>
+				<Item key={tick.getTime()} left={lefts[index]}>
 					<div className={classNames(
 						styles.gridLine,
 						isMajorTick(tick) && styles.major,
@@ -59,7 +59,7 @@ export const Axis = memo(function Axis({
 				height: AXIS_ROW_HEIGHT,
 			}}
 		>
-			{ticks.map((tick, index) => <Fragment key={index}>
+			{ticks.map((tick, index) => <Fragment key={tick.getTime()}>
 				<Item left={lefts[index]}>
 					{/* Second ticks */}
 					<div className={styles.axisTick}>

--- a/src/parser/core/modules/Timeline/components/Item.tsx
+++ b/src/parser/core/modules/Timeline/components/Item.tsx
@@ -66,7 +66,7 @@ export const Item = memo(function Item({
 		<div
 			className={styles.item}
 			style={{
-				left,
+				transform: `translateX(${left}px)`,
 				width: right != null ? right - left : undefined,
 				zIndex: depth,
 			}}

--- a/src/parser/core/modules/Timeline/components/Timeline.module.css
+++ b/src/parser/core/modules/Timeline/components/Timeline.module.css
@@ -120,6 +120,8 @@ Basic diagram:
 	top: 0;
 	height: 100%;
 	pointer-events: all;
+
+	will-change: transform, z-index;
 }
 
 .gridLine {


### PR DESCRIPTION
Title. This PR drastically reduces repaints while scrolling/zooming the timeline. While it doesn't entirely solve performance woes, especially at wide zoom levels, it's a marked improvement on non-beefy machines where paint times are non-trivial.

Greetz to riz, i'll add you to the contrib list one day if it's the last thing i do 🔪