### PR TITLE
Mark WHM as supported for 6.05

### DIFF
--- a/src/parser/jobs/whm/index.tsx
+++ b/src/parser/jobs/whm/index.tsx
@@ -19,10 +19,10 @@ export const WHITE_MAGE = new Meta({
 	Description: () => <>
 		<TransMarkdown source={description}/>
 	</>,
-	// supportedPatches: {
-	// 	from: '6.0',
-	// 	to: '6.0',
-	// },
+	supportedPatches: {
+		from: '6.0',
+		to: '6.05',
+	},
 	contributors: [
 		// {user: CONTRIBUTORS.YOU, role: ROLES.DEVELOPER},
 		{user: CONTRIBUTORS.INNI, role: ROLES.DEVELOPER},
@@ -48,6 +48,11 @@ export const WHITE_MAGE = new Meta({
 			date: new Date('2022-01-04'),
 			Changes: () => <>Updated to add defensive cooldowns and include Liturgy of the bell and Aquaveil</>,
 			contributors: [CONTRIBUTORS.KERRIS],
+		},
+		{
+			date: new Date('2022-01-09'),
+			Changes: () => <>Marked WHM as supported for 6.05</>,
+			contributors: [CONTRIBUTORS.INNI],
 		},
 	],
 })


### PR DESCRIPTION
Thin Air got updated, oGCDs and Overhealing got adjusted for 6.05. Looks (tentatively) good to go, as the rewrites and possible additional modules aren't needed to support 6.05 per se.