### PR TITLE
fix: Consider Huton for NIN's ABC calculations

### DIFF
--- a/src/parser/jobs/nin/index.tsx
+++ b/src/parser/jobs/nin/index.tsx
@@ -21,6 +21,11 @@ export const NINJA = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-01-10'),
+			Changes: () => <>Fixed issue with GCD uptime not considering Huton active.</>,
+			contributors: [CONTRIBUTORS.AZARIAH],
+		},
+		{
 			date: new Date('2022-01-04'),
 			Changes: () => <>Updated Raiju module for 6.05 changes.</>,
 			contributors: [CONTRIBUTORS.TOASTDEIB],

--- a/src/parser/jobs/nin/modules/HutonCastTime.ts
+++ b/src/parser/jobs/nin/modules/HutonCastTime.ts
@@ -1,0 +1,15 @@
+import CastTime from 'parser/core/modules/CastTime'
+
+const HUTON_MODIFIER = 0.85
+
+// This is a TEMPORARY workaround to the lack of a status for Huton, only until the Huton module can be ported to Analyser (requires Combos to be ported)
+//   Move this to the Huton module so it synthesizes the CastTime adjustment after it is ported
+export class HutonCastTime extends CastTime {
+	private pomIndex: number | null = null
+
+	override initialise() {
+		super.initialise()
+
+		this.setPercentageAdjustment('all', HUTON_MODIFIER, 'both')
+	}
+}

--- a/src/parser/jobs/nin/modules/index.ts
+++ b/src/parser/jobs/nin/modules/index.ts
@@ -1,6 +1,7 @@
 import {ActionTimeline} from './ActionTimeline'
 import {Combos} from './Combos'
 import {Huton} from './Huton'
+import {HutonCastTime} from './HutonCastTime'
 import {Kassatsu} from './Kassatsu'
 import {Ninjutsu} from './Ninjutsu'
 import {Ninki} from './Ninki'
@@ -14,6 +15,7 @@ export default [
 	ActionTimeline,
 	Combos,
 	Huton,
+	HutonCastTime,
 	Kassatsu,
 	Ninjutsu,
 	Ninki,


### PR DESCRIPTION
This reapplies the originally intended naive handling for Huton - just assume it's always up.  This was previously added in the Speed Stat adapter rewrite, but never actually wired up correctly.