### PR TITLE
Bugfix - BLM - UI Paradox Sharpcast

### DIFF
--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -62,4 +62,9 @@ export const changelog = [
 		Changes: () => <>Mark missed Umbral Ice Paradoxes as a cycle error and update the Rotation Outliers table header copy.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2022-01-10'),
+		Changes: () => <>Fixed a bug causing Sharpcasts to appear as if they were consumed by Umbral Ice Paradoxes in the timeline.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/blm/modules/Sharpcast.tsx
+++ b/src/parser/jobs/blm/modules/Sharpcast.tsx
@@ -78,7 +78,7 @@ export class Sharpcast extends Analyser {
 		const actionId = event.action
 
 		// Paradox doesn't produce a Firestarter proc if not in Astral Fire
-		if (actionId === this.data.actions.PARADOX && this.gauge.getGaugeState(event.timestamp).astralFire <= 0) {
+		if (actionId === this.data.actions.PARADOX.id && this.gauge.getGaugeState(event.timestamp).astralFire <= 0) {
 			return
 		}
 


### PR DESCRIPTION
Missed a `.id` in the check to skip considering a Sharpcast as consumed by Paradox when not in Astral Fire