### PR TITLE
Synth pre-pull max stacks apply if first seen with fewer than max stacks

### DIFF
--- a/src/data/STATUSES/root/RDM.ts
+++ b/src/data/STATUSES/root/RDM.ts
@@ -24,7 +24,6 @@ export const RDM = ensureStatuses({
 		name: 'Acceleration',
 		icon: 'https://xivapi.com/i/013000/013405.png',
 		duration: 20000,
-		stacksApplied: 3,
 	},
 	EMBOLDEN_PARTY: {
 		// Note that this is the Embolden that other people receive from RDM

--- a/src/data/STATUSES/root/SAM.ts
+++ b/src/data/STATUSES/root/SAM.ts
@@ -56,6 +56,7 @@ export const SAM = ensureStatuses({
 		name: 'Meikyo Shisui',
 		icon: 'https://xivapi.com/i/013000/013309.png',
 		duration: 15000,
+		stacksApplied: 3,
 	},
 
 	ENHANCED_ENPI: {

--- a/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
@@ -115,9 +115,11 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 	private synthesizeStatusApply(event: StatusEvent, stacks?: number) {
 		const applyEvent: Events['statusApply'] = {
 			...event,
-			data: stacks,
 			type: 'statusApply',
 			timestamp: this.pull.timestamp + PREPULL_OFFSETS.STATUS_APPLY,
+		}
+		if (stacks != null) {
+			applyEvent.data = stacks
 		}
 
 		this.precastEvents.push(applyEvent)

--- a/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
@@ -1,4 +1,4 @@
-import {getDataArrayBy} from 'data'
+import {getDataArrayBy, getDataBy} from 'data'
 import {getActions} from 'data/ACTIONS'
 import {StatusKey, getStatuses} from 'data/STATUSES'
 import {Event, Events} from 'event'
@@ -25,7 +25,23 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 			}
 
 			if (event.type === 'statusApply') {
+				const observed = this.observedStatuses.get(event.target)
+				if (observed && observed.has(event.status)) {
+					// If we've already seen a matching apply event, skip
+					continue
+				}
+
 				this.synthesizeActionIfNew(event)
+
+				// If the first observed instance of a status that is applied
+				// with stacks has fewer than the applied value, synth an apply
+				// apply with max stacks.
+				const applied = getDataBy(getStatuses(this.report), 'id', event.status)
+				if (applied != null && applied.stacksApplied != null && applied.stacksApplied > 0 &&
+					event.data != null && event.data < applied.stacksApplied) {
+					this.synthesizeStatusApply(event, applied.stacksApplied)
+				}
+
 				this.observeStatus(event.status, event.target)
 
 			} else if (event.type === 'statusRemove') {
@@ -96,9 +112,10 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 		this.observeAction(action.id, event.source)
 	}
 
-	private synthesizeStatusApply(event: StatusEvent) {
+	private synthesizeStatusApply(event: StatusEvent, stacks?: number) {
 		const applyEvent: Events['statusApply'] = {
 			...event,
+			data: stacks,
 			type: 'statusApply',
 			timestamp: this.pull.timestamp + PREPULL_OFFSETS.STATUS_APPLY,
 		}


### PR DESCRIPTION
This addresses the issues where SAM is being credited with an uncomboed skill at pull and the first Meikyo Shisui window is listed as 2/2 instead of 3/3.

Meikyo Shisui is used pre-pull, but the status was not being detected as active at pull due to how stacked buffs interact with pre-pull synthing.