### PR TITLE
Fixed timeline jumping from the Searing Light table

### DIFF
--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -28,6 +28,11 @@ export const SUMMONER = new Meta({
 
 	changelog: [
 		{
+			date: new Date('2022-01-13'),
+			Changes: () => <>Jumping to the timeline from the Searing Light table now has the expected zoom.</>,
+			contributors: [CONTRIBUTORS.KELOS],
+		},
+		{
 			date: new Date('2022-01-09'),
 			Changes: () => <>Adjusted module display order and now start Summon windows with errors opened.</>,
 			contributors: [CONTRIBUTORS.KELOS],

--- a/src/parser/jobs/smn/modules/SearingLight.tsx
+++ b/src/parser/jobs/smn/modules/SearingLight.tsx
@@ -259,7 +259,7 @@ export class SearingLight extends Analyser {
 					executed: this.getNotesIcon(slUse.data.ghosted),
 				}
 				const windowStart = slUse.start - this.parser.pull.timestamp
-				const windowEnd = slUse.end ?? (this.parser.pull.timestamp + this.parser.pull.duration)
+				const windowEnd = (slUse.end ?? (this.parser.pull.timestamp + this.parser.pull.duration)) - this.parser.pull.timestamp
 				const ret: RotationTableEntry = {
 					start: windowStart,
 					end: windowEnd,


### PR DESCRIPTION
No longer tries to zoom so far out it breaks the timeline.