### PR TITLE
fix: Invert checks for shield breaking

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -104,8 +104,8 @@ interface EventStatusApply extends FieldsTargeted {
 interface EventStatusRemove extends FieldsTargeted {
 	/** XIV Status ID */
 	status: number
-	/** Amount absorbed by this status (if it's a shield) */
-	absorbed?: number
+	/** If this status is a shield, the amount that was remaining unabsorbed when the shield expired */
+	remainingShield?: number
 }
 
 /** The server has confirmed the execution of an action on its target. */

--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -25,6 +25,11 @@ export const DARK_KNIGHT = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-01-15'),
+			Changes: () => <>Fixed an issue with TBN not counting as broken on some logs in 6.05+</>,
+			contributors: [CONTRIBUTORS.AZARIAH],
+		},
+		{
 			date: new Date('2021-12-18'),
 			Changes: () => <>Initial Endwalker support</>,
 			contributors: [CONTRIBUTORS.AZARIAH],

--- a/src/parser/jobs/drk/modules/MPUsage.tsx
+++ b/src/parser/jobs/drk/modules/MPUsage.tsx
@@ -149,7 +149,7 @@ export class MPUsage extends Analyser {
 	}
 
 	private onRemoveBlackestNight(event: Events['statusRemove']) {
-		if ((event.absorbed ?? 0) === 0) {
+		if (event.remainingShield != null && event.remainingShield > 0) {
 			this.droppedTBNs += 1
 		} else {
 			if (this.darkArts) {

--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -42,4 +42,9 @@ export const changelog = [
 		Changes: () => <>Mark as supported for 6.05.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2022-01-15'),
+		Changes: () => <>Fixed an issue with Addersting stacks not counting correctly on some logs in 6.05+</>,
+		contributors: [CONTRIBUTORS.AZARIAH],
+	},
 ]

--- a/src/parser/jobs/sge/modules/Gauge.tsx
+++ b/src/parser/jobs/sge/modules/Gauge.tsx
@@ -43,7 +43,7 @@ const ADDERSTING_CONSUMERS: ActionKey[] = [
 interface DiagnosisData {
 	applyTimestamp?: number,
 	removeTimestamp?: number,
-	absorbed?: number,
+	remainingShield?: number,
 	consumedOrOverwritten?: boolean
 }
 
@@ -165,7 +165,7 @@ export class Gauge extends CoreGauge {
 		const diagnosis = this.diagnoses[event.target]
 		if (diagnosis == null) { return }
 		diagnosis.removeTimestamp = event.timestamp
-		diagnosis.absorbed = event.absorbed
+		diagnosis.remainingShield = event.remainingShield
 		this.addTimestampHook(event.timestamp + 1, () => this.onResolveShield(event.target))
 	}
 
@@ -176,7 +176,7 @@ export class Gauge extends CoreGauge {
 		if (diagnosis.consumedOrOverwritten !== true) {
 			const diagnosisDuration = (diagnosis.removeTimestamp ?? this.parser.currentEpochTimestamp) - (diagnosis.applyTimestamp ?? this.parser.pull.timestamp)
 			// Absorbed doesn't give us an actual look at the real total absorbed, so we have to just assume that a non-overwritten removal before the duration that absorbed anything was a full break
-			if ((diagnosis.absorbed ?? 0) > 0 && diagnosisDuration < this.data.statuses.EUKRASIAN_DIAGNOSIS.duration) {
+			if ((diagnosis.remainingShield != null && diagnosis.remainingShield === 0) && diagnosisDuration < this.data.statuses.EUKRASIAN_DIAGNOSIS.duration) {
 				this.adderstingGauge.generate(1)
 			}
 		}

--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -535,8 +535,8 @@ Array [
 exports[`Event adapter individual events adapts removebuff 1`] = `
 Array [
   Object {
-    "absorbed": undefined,
     "action": 3539,
+    "remainingShield": undefined,
     "source": "1",
     "status": 1001902,
     "target": "1",
@@ -544,7 +544,7 @@ Array [
     "type": "action",
   },
   Object {
-    "absorbed": undefined,
+    "remainingShield": undefined,
     "source": "1",
     "status": 1001902,
     "target": "1",
@@ -552,7 +552,7 @@ Array [
     "type": "statusApply",
   },
   Object {
-    "absorbed": undefined,
+    "remainingShield": undefined,
     "source": "1",
     "status": 1001902,
     "target": "1",
@@ -587,8 +587,8 @@ Array [
 exports[`Event adapter individual events adapts removedebuff 1`] = `
 Array [
   Object {
-    "absorbed": undefined,
     "action": 7436,
+    "remainingShield": undefined,
     "source": "9",
     "status": 1001221,
     "target": "2",
@@ -596,7 +596,7 @@ Array [
     "type": "action",
   },
   Object {
-    "absorbed": undefined,
+    "remainingShield": undefined,
     "source": "9",
     "status": 1001221,
     "target": "2",
@@ -604,7 +604,7 @@ Array [
     "type": "statusApply",
   },
   Object {
-    "absorbed": undefined,
+    "remainingShield": undefined,
     "source": "9",
     "status": 1001221,
     "target": "2",

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -299,7 +299,7 @@ export class TranslateAdapterStep extends AdapterStep {
 			...this.adaptTargetedFields(event),
 			type: 'statusRemove',
 			status: resolveStatusId(event.ability.guid),
-			absorbed: event.absorbed,
+			remainingShield: event.absorb,
 		}
 	}
 

--- a/src/reportSources/legacyFflogs/eventTypes.ts
+++ b/src/reportSources/legacyFflogs/eventTypes.ts
@@ -336,7 +336,7 @@ export interface BuffEvent extends AbilityEventFields {
 		| 'refreshdebuff'
 		| 'removebuff'
 		| 'removedebuff'
-	absorbed?: number
+	absorb?: number
 }
 
 export interface BuffStackEvent extends AbilityEventFields {


### PR DESCRIPTION
This switches from looking for total amount absorbed to total amount remaining on a shield.  Currently, FFLogs is still showing 0 reamining for any shield that has been at least partially absorbed on new logs, but this gets us back to the state of things before the absorb event changes, and once they fix things for partial absorbs then new logs should work as expected.