### PR TITLE
[MCH] Harden Reassemble detection

### DIFF
--- a/src/parser/jobs/mch/index.tsx
+++ b/src/parser/jobs/mch/index.tsx
@@ -20,6 +20,11 @@ export const MACHINIST = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-01-28'),
+			Changes: () => <>Fixed a rare bug that erroneously marked Reassembles as dropped.</>,
+			contributors: [CONTRIBUTORS.HINT],
+		},
+		{
 			date: new Date('2022-01-06'),
 			Changes: () => <>Marked as supported for 6.05.</>,
 			contributors: [CONTRIBUTORS.HINT],

--- a/src/parser/jobs/mch/modules/Reassemble.tsx
+++ b/src/parser/jobs/mch/modules/Reassemble.tsx
@@ -10,6 +10,9 @@ import {Data} from 'parser/core/modules/Data'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import React from 'react'
 
+// Rarely, reassembled fade timestamps don't match the GCD cast timestamps - deal with it
+const DELAY_THRESHOLD_MS = 100
+
 // These are the only GCDs that should be reassembled under normal circumstances
 const REASSEMBLE_GCDS: ActionKey[] = [
 	'CHAIN_SAW',
@@ -93,7 +96,7 @@ export class Reassemble extends Analyser {
 	}
 
 	private onRemove(event: Events['statusRemove']) {
-		if (event.timestamp !== this.state.lastGcdTime) {
+		if (event.timestamp > this.state.lastGcdTime + DELAY_THRESHOLD_MS) {
 			this.history.droppedUses += 1
 		}
 		if (this.state.gcdHook != null) {


### PR DESCRIPTION
Fixes a bug where a reassemble was flagged as dropped because its statusRemove timestamp is ~1 millisecond later than the GCD cast timestamp.