### PR TITLE
DRG: Mark as supported for 6.08

### DIFF
--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -12,7 +12,7 @@ export const DRAGOON = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.05',
+		to: '6.08',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.FALINDRITH, role: ROLES.MAINTAINER},


### PR DESCRIPTION
DRG is (mostly) the same.
Life surge module needs minor adjustments due to potency changes but it works sufficiently well for now. That module was already slated to be re-written eventually so I guess I'm glad I didn't do it yet.