### PR TITLE
Mark PLD supported for 6.08

### DIFF
--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -19,7 +19,7 @@ export const PALADIN = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.05',
+		to: '6.08',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.ARIA, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Only potency changes, nothing rotational.