### PR TITLE
6.08 patch bump for BLM, SGE, and DNC

### DIFF
--- a/src/parser/jobs/blm/index.tsx
+++ b/src/parser/jobs/blm/index.tsx
@@ -14,7 +14,7 @@ export const BLACK_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.05',
+		to: '6.08',
 	},
 
 	contributors: [

--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -47,4 +47,9 @@ export const changelog = [
 		Changes: () => <>Removed Step drift suggestions that duplicated cooldown checklist feedback.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2022-01-25'),
+		Changes: () => <>Update AoE checks for Windmill and mark supported for 6.08.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/dnc/index.tsx
+++ b/src/parser/jobs/dnc/index.tsx
@@ -25,7 +25,7 @@ export const DANCER = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.05',
+		to: '6.08',
 	},
 
 	contributors: [

--- a/src/parser/jobs/dnc/modules/AoEUsages.ts
+++ b/src/parser/jobs/dnc/modules/AoEUsages.ts
@@ -7,7 +7,7 @@ export class AoEUsages extends CoreAoE {
 		{
 			aoeAction: this.data.actions.WINDMILL,
 			stActions: [this.data.actions.CASCADE],
-			minTargets: 2,
+			minTargets: 3,
 		},
 		{
 			aoeAction: this.data.actions.RISING_WINDMILL,

--- a/src/parser/jobs/sge/index.tsx
+++ b/src/parser/jobs/sge/index.tsx
@@ -18,7 +18,7 @@ export const SAGE = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.05',
+		to: '6.08',
 	},
 
 	contributors: [


### PR DESCRIPTION
- No changes to analysis for BLM and SGE
- DNC's only change is an increase to the min targets necessary for Windmill to pull past Cascade