### PR TITLE
Mark patch 6.08 support for WAR

### DIFF
--- a/src/parser/jobs/war/index.tsx
+++ b/src/parser/jobs/war/index.tsx
@@ -16,7 +16,7 @@ export const WARRIOR = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.05',
+		to: '6.08',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AY, role: ROLES.MAINTAINER},


### PR DESCRIPTION
No changelog, because who really cares? Index isn't analyser code and users can see it's supported or not before they can see the changelog anyway.