### PR TITLE
feat: update core for 6.08 support

### DIFF
--- a/src/generated/unableToActStatusIds.ts
+++ b/src/generated/unableToActStatusIds.ts
@@ -169,5 +169,6 @@ export const UNABLE_TO_ACT_STATUS_IDS = [
 	2953, // Stun (lockActions)
 	2955, // Will to Live (lockActions)
 	2961, // Down for the Count (lockActions)
+	2983, // Sleep (lockActions)
 	2999, // In Event (lockActions, lockControl)
 ]

--- a/src/parser/core/index.tsx
+++ b/src/parser/core/index.tsx
@@ -15,7 +15,7 @@ export const CORE = new Meta({
 	// Read `docs/patch-checklist.md` before editing the following values.
 	supportedPatches: {
 		from: '6.0',
-		to: '6.05',
+		to: '6.08',
 	},
 })
 


### PR DESCRIPTION
One new sleep status ID from the UTA generation script, but no other new content / content changes for 6.08 support.