### PR TITLE
Allow hiding progress for checklist modules

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -236,7 +236,7 @@
   "core.cooldownDowntime.defense-cd-metric": "Using your mitigation and healing cooldowns can help you survive mistakes, or relieve some stress on the healers and let them deal more damage. While you shouldn't use them at the expense of your rotation or buff alignment, you should try to find helpful times to use them.",
   "core.cooldownDowntime.ogcd-cd-metric": "Always make sure to use your actions when they are available, but do not clip your GCD to use them.",
   "core.cooldownDowntime.title": "Cooldown Downtime",
-  "core.cooldownDowntime.use-defense-cds": "Use your defensive cooldowns",
+  "core.cooldownDowntime.use-defense-cds": "Defensive cooldown usage",
   "core.cooldownDowntime.use-ogcd-cds": "Use your cooldowns",
   "core.dblink.loading": "Loading...",
   "core.deaths.content": "Don't die. Between downtime, lost gauge resources, and resurrection debuffs, dying is absolutely <0>crippling</0> to damage output.",

--- a/src/parser/core/modules/Checklist/Component.js
+++ b/src/parser/core/modules/Checklist/Component.js
@@ -48,20 +48,24 @@ class Checklist extends Component {
 				title: {
 					className: styles.title,
 					content: <>
-						<Icon
-							name={ruleStyles.icon}
-							className={ruleStyles.text}
-						/>
-						{rule.name}
-						<div className={styles.percent + ' ' + ruleStyles.text}>
-							{percent.toFixed(1)}%
-							<Progress
-								percent={percent}
-								className={styles.progress}
-								size="small"
-								color={ruleStyles.color}
+						{rule.showProgress &&
+							<Icon
+								name={ruleStyles.icon}
+								className={ruleStyles.text}
 							/>
-						</div>
+						}
+						{rule.name}
+						{rule.showProgress &&
+							<div className={styles.percent + ' ' + ruleStyles.text}>
+								{percent.toFixed(1)}%
+								<Progress
+									percent={percent}
+									className={styles.progress}
+									size="small"
+									color={ruleStyles.color}
+								/>
+							</div>
+						}
 					</>,
 				},
 				content: {

--- a/src/parser/core/modules/Checklist/Rule.js
+++ b/src/parser/core/modules/Checklist/Rule.js
@@ -15,6 +15,7 @@ export default class Rule {
 	requirements = []
 	target = DEFAULT_TARGET
 	displayOrder = DisplayOrder.DEFAULT
+	showProgress = true
 
 	get tier() {
 		return matchClosestLower(

--- a/src/parser/core/modules/CooldownDowntime.tsx
+++ b/src/parser/core/modules/CooldownDowntime.tsx
@@ -105,7 +105,7 @@ export abstract class CooldownDowntime extends Analyser {
 		when they are available, but do not clip your GCD to use them.</Trans>
 	protected checklistTarget = DEFAULT_CHECKLIST_TARGET
 
-	protected defenseChecklistName = <Trans id="core.cooldownDowntime.use-defense-cds">Use your defensive cooldowns</Trans>
+	protected defenseChecklistName = <Trans id="core.cooldownDowntime.use-defense-cds">Defensive cooldown usage</Trans>
 	protected defenseChecklistDescription = <Trans id="core.cooldownDowntime.defense-cd-metric">
 		Using your mitigation and healing cooldowns can help you survive mistakes, or relieve some stress on the healers and let them deal more damage.
 		While you shouldn't use them at the expense of your rotation or buff alignment, you should try to find helpful times to use them.
@@ -210,6 +210,7 @@ export abstract class CooldownDowntime extends Analyser {
 				name: this.defenseChecklistName,
 				description: this.defenseChecklistDescription,
 				requirements: defensiveRequirements,
+				showProgress: false,
 				tiers: this.defenseChecklistTiers,
 			}))
 		}


### PR DESCRIPTION
I am still a React noob so let me know if I did this wrong

This makes the display of progress on a checklist entry hideable. By default it is shown (Maintaining current behaviour)

A second commit changes the defensive cooldown checklist to hide progress. Examples below.

![image](https://user-images.githubusercontent.com/1554753/151268046-0e7ae610-0c69-4762-a5e1-1ffedb3820b4.png)

![image](https://user-images.githubusercontent.com/1554753/151268416-037dacea-3e47-45da-a4a5-50f5e434565d.png)