### PR TITLE
[Core] Add overridable prop for prepended messages on ActionWindow

### DIFF
--- a/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
+++ b/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
@@ -48,7 +48,7 @@ export abstract class ActionWindow extends Analyser {
 	protected rotationTableHeader?: JSX.Element
 
 	/**
-	 * Implementing modules MAY provide a Message element to appear above the RotationTable
+	 * Implementing modules MAY provide a JSX element to appear above the RotationTable
 	 * If prepending multiple nodes, you MUST provide a JSX.Element <Fragment> tag
 	 */
 	protected prependMessages?: JSX.Element

--- a/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
+++ b/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
@@ -48,8 +48,8 @@ export abstract class ActionWindow extends Analyser {
 	protected rotationTableHeader?: JSX.Element
 
 	/**
-	 * Implementing modules MAY provide a value to override the "Rotation" title in the header of the rotation section
-	 * If implementing, you MUST provide a JSX.Element <Trans> or <Fragment> tag (Trans tag preferred)
+	 * Implementing modules MAY provide a Message element to appear above the RotationTable
+	 * If prepending multiple nodes, you MUST provide a JSX.Element <Fragment> tag
 	 */
 	protected prependMessages?: JSX.Element
 

--- a/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
+++ b/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
@@ -48,6 +48,12 @@ export abstract class ActionWindow extends Analyser {
 	protected rotationTableHeader?: JSX.Element
 
 	/**
+	 * Implementing modules MAY provide a value to override the "Rotation" title in the header of the rotation section
+	 * If implementing, you MUST provide a JSX.Element <Trans> or <Fragment> tag (Trans tag preferred)
+	 */
+	protected prependMessages?: JSX.Element
+
+	/**
 	 * Adds an evaluator to be run on the windows.
 	 * @param evaluator An evaluator to be run on the windows
 	 */
@@ -148,7 +154,7 @@ export abstract class ActionWindow extends Analyser {
 		if (this.history.entries.length === 0) { return undefined }
 
 		const actionHistory = this.mapHistoryActions()
-		const evalColumns: EvaluationOutput[]  = []
+		const evalColumns: EvaluationOutput[] = []
 		for (const ev of this.evaluators) {
 			const maybeColumns = ev.output(actionHistory)
 			if (maybeColumns == null) { continue }
@@ -181,18 +187,21 @@ export abstract class ActionWindow extends Analyser {
 				}
 			})
 
-		return <RotationTable
-			targets={rotationTargets}
-			data={rotationData}
-			notes={notesData}
-			onGoto={this.timeline.show}
-			headerTitle={this.rotationTableHeader}
-		/>
+		return <>
+			{this.prependMessages}
+			<RotationTable
+				targets={rotationTargets}
+				data={rotationData}
+				notes={notesData}
+				onGoto={this.timeline.show}
+				headerTitle={this.rotationTableHeader}
+			/></>
 	}
 
 	private mapHistoryActions(): Array<HistoryEntry<EvaluatedAction[]>> {
 		return this.history.entries
-			.map(entry => ({start: entry.start,
+			.map(entry => ({
+				start: entry.start,
 				end: entry.end,
 				data: entry.data
 					.map(ev => {


### PR DESCRIPTION
Example screaming elements illustrated below can be added anytime you implement something that implements ActionWindow via overriding prependMessages

![image](https://user-images.githubusercontent.com/22470093/151337360-e96d1f4d-b2d3-405f-9d01-ad4c6e00dc61.png)
