### PR TITLE
Update Trick Attack modules for proper opener tracking

### DIFF
--- a/src/parser/jobs/nin/index.tsx
+++ b/src/parser/jobs/nin/index.tsx
@@ -21,6 +21,11 @@ export const NINJA = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-02-02'),
+			Changes: () => <>Updated Trick Attack modules for correct handling of the opener.</>,
+			contributors: [CONTRIBUTORS.TOASTDEIB],
+		},
+		{
 			date: new Date('2022-01-10'),
 			Changes: () => <>Fixed issue with GCD uptime not considering Huton active.</>,
 			contributors: [CONTRIBUTORS.AZARIAH],

--- a/src/parser/jobs/nin/modules/TrickAttackUsage.tsx
+++ b/src/parser/jobs/nin/modules/TrickAttackUsage.tsx
@@ -12,7 +12,7 @@ import Suggestions, {TieredSuggestion, SEVERITY} from 'parser/core/modules/Sugge
 import React from 'react'
 import {matchClosestHigher} from 'utilities'
 
-const OPTIMAL_GCD_COUNT = 5 // Opener should be Suiton > AE combo > SE before Trick
+const OPTIMAL_GCD_COUNT = 4 // Opener should be Suiton > AE combo before Trick
 
 const MUDRAS: ActionKey[] = [
 	'TEN',


### PR DESCRIPTION
Per recent chatter in #fb-ninja, I'm updating the TA usage/window modules to reflect the correct opener (according to The Balance). Trick should be a GCD earlier than the analysis was previously expecting, and there should only be one non-TCJ Raiton in the opener burst to make room for a second Bhava.

Opener: https://cdn.discordapp.com/attachments/277968398103609344/929518167036928070/nin2.png