### PR TITLE
SAM - Mark Fuko as a combo starter

### DIFF
--- a/src/data/ACTIONS/root/SAM.ts
+++ b/src/data/ACTIONS/root/SAM.ts
@@ -129,7 +129,7 @@ export const SAM = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
 		combo: {
-			from: [7483, 25780],
+			from: [25780],
 			end: true,
 		},
 		statusesApplied: ['FUKA'],
@@ -162,6 +162,9 @@ export const SAM = ensureActions({
 		icon: 'https://xivapi.com/i/003000/003189.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
+		combo: {
+			start: true,
+		},
 	},
 
 	OGI_NAMIKIRI: {

--- a/src/parser/jobs/sam/changelog.tsx
+++ b/src/parser/jobs/sam/changelog.tsx
@@ -8,6 +8,10 @@ export const changelog = [
 	// 	contrubutors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2022-02-09'),
+		Changes: () => <>Fixed a bug that erroneously flagged AoE combos as broken.</>,
+		contributors: [CONTRIBUTORS.HINT],
+	}, {
 		date: new Date('2022-01-28'),
 		Changes: () => <>Fixed flawed logic that assumes SAM's can surpass their limits and get more than 3 gcds under the meikyo shisui buff.</>,
 		contributors: [CONTRIBUTORS.RYAN],


### PR DESCRIPTION
Also clean up dead ID from oka's combo data.