### PR TITLE
Fix Swiftcast end of fight bug

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,13 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2022-02-11'),
+		Changes: () => <>
+			Fix Swiftcast end of fight forgiveness. It was increasing the number of expected GCDs to 2 instead of reducing it to 0.
+		</>,
+		contributors: [CONTRIBUTORS.DEAN],
+	},
+	{
 		date: new Date('2022-01-31'),
 		Changes: () => <>
 			Fix overcorrection caused by prior death-related changes that were leading to player deaths being ignored.

--- a/src/parser/core/modules/Swiftcast.tsx
+++ b/src/parser/core/modules/Swiftcast.tsx
@@ -71,7 +71,7 @@ export abstract class Swiftcast extends BuffWindow {
 	private adjustExpectedGcdCount(window: HistoryEntry<EvaluatedAction[]>) {
 		const fightTimeRemaining = (this.parser.pull.timestamp + this.parser.pull.duration) - window.start
 		const gcdEstimate = this.globalCooldown.getDuration()
-		return (fightTimeRemaining > gcdEstimate) ? 0 : 1
+		return (fightTimeRemaining > gcdEstimate) ? 0 : -1
 	}
 
 	override onWindowAction(event: Events['action']) {


### PR DESCRIPTION
Forgiving a missed Swift at the end means 1 - 1 = 0, instead of 1 + 1 = 2.

https://discord.com/channels/441414116914233364/915957728155959356/934127115656388618

This logic is still slightly too permissive, instead of checking 1 GCD it can check something like 0.5 - 1.5s, but being more permissive at EoF is also fine.