### PR TITLE
Enemy action timeline

### DIFF
--- a/src/parser/core/modules/EnemyTimeline.tsx
+++ b/src/parser/core/modules/EnemyTimeline.tsx
@@ -1,0 +1,122 @@
+import Tooltip from 'components/ui/DbLink'
+import {Action} from 'data/ACTIONS'
+import {Event, Events} from 'event'
+import _ from 'lodash'
+import React from 'react'
+import {Actor, Team} from 'report'
+import {Analyser} from '../Analyser'
+import {filter, oneOf} from '../filter'
+import {dependency} from '../Injectable'
+import {SimpleItem, SimpleRow, Timeline} from './Timeline'
+
+interface Hit {
+	prepare?: Events['prepare']
+	action?: Events['action']
+}
+
+export class EnemyTimeline extends Analyser {
+	static override handle = 'enemyTimeline'
+
+	@dependency timeline!: Timeline
+
+	private hits = new Map<Actor['id'], Hit[]>()
+
+	override initialise() {
+		const foes = this.parser.pull.actors
+			.filter(actor => actor.team === Team.FOE)
+			.map(actor => actor.id)
+
+		this.addEventHook(
+			filter<Event>()
+				.type('prepare')
+				.source(oneOf(foes)),
+			this.onPrepare,
+		)
+
+		this.addEventHook(
+			filter<Event>()
+				.type('action')
+				.source(oneOf(foes)),
+			this.onAction
+		)
+
+		this.addEventHook('complete', this.onComplete)
+	}
+
+	private onPrepare(event: Events['prepare']) {
+		const hits = this.getActorHits(event.source)
+		hits.push({prepare: event})
+	}
+
+	private onAction(event: Events['action']) {
+		const hits = this.getActorHits(event.source)
+		const lastHit = _.last(hits)
+
+		// yi kes
+		if (
+			lastHit?.prepare?.action === event.action
+			&& lastHit?.prepare.target === event.target
+		) {
+			lastHit.action = event
+			return
+		}
+
+		hits.push({action: event})
+	}
+
+	private getActorHits(actorId: Actor['id']) {
+		let hits = this.hits.get(actorId)
+		if (hits != null) { return hits }
+
+		hits = []
+		this.hits.set(actorId, hits)
+		return hits
+	}
+
+	private onComplete() {
+		const rootRow = this.timeline.addRow(new SimpleRow({
+			label: 'enemy',
+		}))
+
+		// big yikes
+		for (const [actorId, hits] of this.hits) {
+			const actorRow = rootRow.addRow(new SimpleRow({
+				label: actorId,
+			}))
+
+			const actionRowCache = new Map<Action['id'], SimpleRow>()
+
+			for (const hit of hits) {
+				const meta = hit.action ?? hit.prepare
+				if (meta == null) { continue }
+
+				let actionRow = actionRowCache.get(meta.action)
+				if (actionRow == null) {
+					actionRow = actorRow.addRow(new SimpleRow({
+						label: <Tooltip id={meta.action} sheet="Action"/>,
+					}))
+					actionRowCache.set(meta.action, actionRow)
+				}
+
+				const start = hit.prepare != null
+					? hit.prepare.timestamp
+					: hit.action?.timestamp ?? this.parser.currentEpochTimestamp
+
+				const end = hit.prepare != null
+					? hit.action?.timestamp ?? undefined
+					: undefined
+
+				// yikmes
+				actionRow.addItem(new SimpleItem({
+					start: start - this.parser.pull.timestamp,
+					end: end && end - this.parser.pull.timestamp,
+					content: <div style={{
+						width: end == null ? 1 : undefined,
+						height: '100%',
+						background: 'red',
+					}}/>,
+				}))
+			}
+		}
+	}
+}

--- a/src/parser/core/modules/index.js
+++ b/src/parser/core/modules/index.js
@@ -12,6 +12,7 @@ import {Data} from './Data'
 import {Death} from './Death'
 import Downtime from './Downtime'
 import {Dummy} from './Dummy'
+import {EnemyTimeline} from './EnemyTimeline'
 import {EventsView} from './EventsView'
 import {GlobalCooldown} from './GlobalCooldown'
 import {Invulnerability} from './Invulnerability'
@@ -42,6 +43,7 @@ export default [
 	Death,
 	Downtime,
 	Dummy,
+	EnemyTimeline,
 	EventsView,
 	GlobalCooldown,
 	Invulnerability,


### PR DESCRIPTION
**This is a proof of concept.** It should not be merged as-is - there's significant issues with the current output that need to be resolved before it's useable.

This PR implements an "action timeline" for enemies in the fight. Ideally, this would make it possible to see exact timing of mechanics as they occur, rather than needing to cross-reference other timeline sources.

The main blocker of this current implementation is the amount of data - a lot of bosses use a _lot_ of copies of themselves to cast things, and a lot of actions have a multitude of copies with different action IDs that are effectively the same in practice.

Any solution for this would need to be something that needs as _little_ boss-specific configuration as is reasonably possible - we don't want to be manually adding support for every single boss more than we have to already.

Image of current output showing what it can do - and the problem it faces:

![image](https://user-images.githubusercontent.com/534235/153810058-5582b5d4-cb90-439f-b6bf-e27534492d9f.png)
