### PR TITLE
Opo opo combo fix

### DIFF
--- a/src/parser/jobs/mnk/changelog.tsx
+++ b/src/parser/jobs/mnk/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2022-02-14'),
+		Changes: () => <>Fix opo opo form combo resets.</>,
+		contributors: [CONTRIBUTORS.MALP],
+	},
+	{
 		date: new Date('2022-02-10'),
 		Changes: () => <>Cleanup Riddle of Fire module.</>,
 		contributors: [CONTRIBUTORS.MALP],

--- a/src/parser/jobs/mnk/changelog.tsx
+++ b/src/parser/jobs/mnk/changelog.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 export const changelog = [
 	{
 		date: new Date('2022-02-14'),
-		Changes: () => <>Fix opo opo form combo resets.</>,
+		Changes: () => <>Fix incorrect combo resets bug when Dragon Kick is spammed.</>,
 		contributors: [CONTRIBUTORS.MALP],
 	},
 	{

--- a/src/parser/jobs/mnk/modules/Forms.tsx
+++ b/src/parser/jobs/mnk/modules/Forms.tsx
@@ -111,6 +111,7 @@ export class Forms extends Analyser {
 	private onGain(event: Events['statusApply']): void {
 		this.lastFormChanged = event.timestamp
 
+		// Reset forms - we need this to avoid DK spam rotations leaving trailing hooks
 		this.resetFormHook()
 
 		this.formHook = this.addEventHook(

--- a/src/parser/jobs/mnk/modules/Forms.tsx
+++ b/src/parser/jobs/mnk/modules/Forms.tsx
@@ -111,6 +111,8 @@ export class Forms extends Analyser {
 	private onGain(event: Events['statusApply']): void {
 		this.lastFormChanged = event.timestamp
 
+		this.resetFormHook()
+
 		this.formHook = this.addEventHook(
 			filter<Event>()
 				.source(this.parser.actor.id)
@@ -122,6 +124,10 @@ export class Forms extends Analyser {
 	private onRemove(event: Events['statusRemove']): void {
 		this.lastFormDropped = event.timestamp
 
+		this.resetFormHook()
+	}
+
+	private resetFormHook() {
 		if (this.formHook != null) {
 			this.removeEventHook(this.formHook)
 			this.formHook = undefined


### PR DESCRIPTION
On the meme rotation there was 3.4k reset events
![image](https://user-images.githubusercontent.com/17149559/153972483-3795b42f-425d-4eb8-bee0-0a7d33d50605.png)

Clearly that's not possible.

What happens is when DK gets used, it applied Raptor Form, but it never removes it, only applies it again
![image](https://user-images.githubusercontent.com/17149559/153972786-cc8d22aa-3ca7-4ec9-9254-da2d6102301d.png)

So what would happen is dangling `addEventHook` would come in and spam the event numbers