### PR TITLE
Allow procs timeline row to be hidden

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,14 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2022-02-17'),
+		Changes: () => <>
+			Allow core procs to hide the timeline row. This was previously enforced, jobs can now hide it.
+			This is useful for jobs that have GCDs with lots of procs getting duplicated information.
+		</>,
+		contributors: [CONTRIBUTORS.AY],
+	},
+	{
 		date: new Date('2022-02-11'),
 		Changes: () => <>
 		Fix Swiftcast end of fight forgiveness. It was increasing the number of expected GCDs to 2 instead of reducing it to 0.


### PR DESCRIPTION
The default is unchanged from existing behaviour, so this won't impact any current jobs. The change was made to allow RPR to hide the row as it's *heavily* duplicated with the GCD status rows.