### PR TITLE
Improve friendly death adjustment logic

### DIFF
--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -6,6 +6,7 @@ import {AdapterOptions, AdapterStep} from './base'
 import {DeduplicateActorUpdateStep} from './deduplicateActorUpdates'
 import {DeduplicateAoEStep} from './deduplicateAoE'
 import {DeduplicateStatusApplicationStep} from './deduplicateStatus'
+import {ErroneousFriendDeathAdapterStep} from './erroneousFriendDeath'
 import {InterruptsAdapterStep} from './interrupts'
 import {OneHpLockAdapterStep} from './oneHpLock'
 import {PrepullActionAdapterStep} from './prepullAction'
@@ -36,6 +37,7 @@ class EventAdapter {
 		this.adaptionSteps = [
 			new ReassignUnknownActorStep(opts),
 			new TranslateAdapterStep(opts),
+			new ErroneousFriendDeathAdapterStep(opts),
 			new AssignOverhealStep(opts),
 			new InterruptsAdapterStep(opts),
 			new DeduplicateAoEStep(opts),

--- a/src/reportSources/legacyFflogs/eventAdapter/deduplicateActorUpdates.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/deduplicateActorUpdates.ts
@@ -1,13 +1,12 @@
 import {AttributeValue, Event, Events, Position, Resource} from 'event'
 import _ from 'lodash'
 import {Actor} from 'report'
-import {FflogsEvent} from '../eventTypes'
 import {AdapterStep} from './base'
 
 export class DeduplicateActorUpdateStep extends AdapterStep {
 	private actorState = new Map<Actor['id'], Events['actorUpdate']>()
 
-	override adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
+	override postprocess(adaptedEvents: Event[]): Event[] {
 		const out: Event[] = []
 		for (const event of adaptedEvents) {
 			const adapted = event.type === 'actorUpdate'

--- a/src/reportSources/legacyFflogs/eventAdapter/erroneousFriendDeath.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/erroneousFriendDeath.ts
@@ -1,0 +1,71 @@
+import {Event, Events} from 'event'
+import {Actor} from 'parser/core/modules/Actors'
+import {Team} from 'report'
+import {FflogsEvent} from '../eventTypes'
+import {AdapterStep} from './base'
+
+/**
+ * FF Logs is doing some incorrect adjustments to HP resources that cause a 0 HP
+ * report without an accompanying death. These are typically caused by 1-hit
+ * mecahnics being survived due to either fight mechanics or tank invulnerabilities.
+ *
+ * To resolve, we're capping resource updates at 1 HP, and then adjusting those
+ * back down to 0 HP if we see a death.
+ */
+export class ErroneousFriendDeathAdapterStep extends AdapterStep {
+	private adjustedEvents = new Map<Actor['id'], Array<Events['actorUpdate']>>()
+	private deadActors = new Set<Actor['id']>()
+
+	override adapt(baseEvent: FflogsEvent, adaptedEvents: Event[]) {
+		for (const adaptedEvent of adaptedEvents) {
+			if (adaptedEvent.type !== 'actorUpdate') { continue }
+			this.processActorUpdate(baseEvent, adaptedEvent)
+		}
+
+		return adaptedEvents
+	}
+
+	private processActorUpdate(baseEvent: FflogsEvent, adaptedEvent: Events['actorUpdate']) {
+		// We only care about friendly actors
+		const actor = this.pull.actors.find(actor => actor.id === adaptedEvent.actor)
+		if (actor?.team !== Team.FRIEND) { return }
+
+		// If we see HP > 0, we can safely assume that changes we've made are sane,
+		// and that the actor is alive.
+		if (adaptedEvent.hp?.current !== 0) {
+			this.adjustedEvents.delete(actor.id)
+			this.deadActors.delete(actor.id)
+			return
+		}
+
+		// If we see an actor death, the changes we've made were incorrect - backtrack
+		// and undo the changes, and mark the actor dead so we don't adjust future ones.
+		if (baseEvent.type === 'death') {
+			const actorEvents = this.adjustedEvents.get(actor.id)
+			actorEvents?.forEach(event => {
+				if (event.hp?.current == null) { return }
+				event.hp.current = 0
+			})
+
+			this.adjustedEvents.delete(actor.id)
+			this.deadActors.add(actor.id)
+			return
+		}
+
+		// If we know the actor is already dead, there's no need to do any adjustment
+		if (this.deadActors.has(actor.id)) { return }
+
+		// If we get to here, we're assuming for now that the actor isn't dead, and
+		// adjusting their HP up to 1
+		adaptedEvent.hp.current = 1
+
+		// Record this adjusted event in case we need to backtrack
+		let actorEvents = this.adjustedEvents.get(actor.id)
+		if (actorEvents == null) {
+			actorEvents = []
+			this.adjustedEvents.set(actor.id, actorEvents)
+		}
+
+		actorEvents.push(adaptedEvent)
+	}
+}


### PR DESCRIPTION
Title. This beefs up the logic around fixing fflogs' dumb death bullshit, and moves it into a separate adapter so it's not cluttering up translate.

I've also swapped actor update dedupe onto postprocess instead of adapt because it being on the adapt pass makes it nigh impossible to track how events are changing through the pipeline.

Before:
![image](https://user-images.githubusercontent.com/534235/154833758-7687517c-2697-4958-bb47-a5d46cfea80e.png)

After:
![image](https://user-images.githubusercontent.com/534235/154833768-03022024-d129-4a89-af0f-31ff69eb76b1.png)
