### PR TITLE
BugFix: Fix downtime/negative window duration filter in NotCasting

### DIFF
--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -67,4 +67,9 @@ export const changelog = [
 		Changes: () => <>Fixed a bug causing Sharpcasts to appear as if they were consumed by Umbral Ice Paradoxes in the timeline.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2022-03-19'),
+		Changes: () => <>Fixed a bug with the Not Casting check that was giving incorrect results for fight downtime and end-of-fight casts.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/blm/modules/NotCasting.tsx
+++ b/src/parser/jobs/blm/modules/NotCasting.tsx
@@ -134,7 +134,7 @@ export class NotCasting extends Analyser {
 				{this.noCastWindows.history.map(notCasting => {
 					return <Table.Row key={notCasting.start}>
 						<Table.Cell>{this.parser.formatEpochTimestamp(notCasting.start)}</Table.Cell>
-						<Table.Cell>&ge;{this.parser.formatDuration((notCasting.stop ?? notCasting.start) -notCasting.start - gcdLength - GCD_ERROR_OFFSET)}</Table.Cell>
+						<Table.Cell>&ge;{this.parser.formatDuration((notCasting.stop ?? notCasting.start) - notCasting.start - gcdLength - GCD_ERROR_OFFSET)}</Table.Cell>
 						<Table.Cell>
 							<Button onClick={() =>
 								this.timeline.show(notCasting.start - this.parser.pull.timestamp, (notCasting.stop ?? notCasting.start) - this.parser.pull.timestamp)}>

--- a/src/parser/jobs/blm/modules/NotCasting.tsx
+++ b/src/parser/jobs/blm/modules/NotCasting.tsx
@@ -115,7 +115,7 @@ export class NotCasting extends Analyser {
 				windows.start,
 				windows.stop ?? windows.start,
 			)
-			return duration === 0 || (windows.stop ?? windows.start) - windows.start > gcdLength + GCD_ERROR_OFFSET
+			return duration === 0 && (windows.stop ?? windows.start) - windows.start > gcdLength + GCD_ERROR_OFFSET
 		})
 	}
 
@@ -134,7 +134,7 @@ export class NotCasting extends Analyser {
 				{this.noCastWindows.history.map(notCasting => {
 					return <Table.Row key={notCasting.start}>
 						<Table.Cell>{this.parser.formatEpochTimestamp(notCasting.start)}</Table.Cell>
-						<Table.Cell>&ge;{this.parser.formatDuration((notCasting.stop ?? notCasting.start) -notCasting.start-gcdLength-GCD_ERROR_OFFSET)}</Table.Cell>
+						<Table.Cell>&ge;{this.parser.formatDuration((notCasting.stop ?? notCasting.start) -notCasting.start - gcdLength - GCD_ERROR_OFFSET)}</Table.Cell>
 						<Table.Cell>
 							<Button onClick={() =>
 								this.timeline.show(notCasting.start - this.parser.pull.timestamp, (notCasting.stop ?? notCasting.start) - this.parser.pull.timestamp)}>


### PR DESCRIPTION
Filtering the notCast history should keep windows where there is no downtime AND the window's length is positive. Boolean logic shenanigans.