### PR TITLE
Update ABCs

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,12 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2022-03-29'),
+		Changes: () => <>
+			Update Always Be Casting to target 98% and show at top of checklist.
+		</>,
+		contributors: [CONTRIBUTORS.AY],
+	},	{
 		date: new Date('2022-02-17'),
 		Changes: () => <>
 			Allow core procs to hide the timeline row. This was previously enforced, jobs can now hide it.

--- a/src/parser/core/modules/AlwaysBeCasting.tsx
+++ b/src/parser/core/modules/AlwaysBeCasting.tsx
@@ -13,6 +13,8 @@ import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
 import {SpeedAdjustments} from 'parser/core/modules/SpeedAdjustments'
 import React from 'react'
 
+const UPTIME_TARGET = 98
+
 export class AlwaysBeCasting extends Analyser {
 	static override handle = 'abc'
 	static override debug = false
@@ -108,12 +110,14 @@ export class AlwaysBeCasting extends Analyser {
 				mistakes while keeping the GCD rolling than it is to perform the correct
 				rotation slowly.
 			</Trans>,
+			displayOrder: -1,
 			requirements: [
 				new Requirement({
 					name: <Trans id="core.always-cast.gcd-uptime">GCD Uptime</Trans>,
 					percent: this.getUptimePercent(),
 				}),
 			],
+			target: UPTIME_TARGET,
 		}))
 	}
 }


### PR DESCRIPTION
Possibly pending some wording changes. Ideally we'd force this to be expanded, but the checklist system doesn't currently allow for overrides and it's less than trivial to update it to handle this. `-1` for the display order was chosen arbitrarily, but should remain negative to ensure it's always above job-specific checklists.