### PR TITLE
6.1 support for Core

### DIFF
--- a/src/data/ACTIONS/layers/patch6.1.ts
+++ b/src/data/ACTIONS/layers/patch6.1.ts
@@ -4,6 +4,10 @@ import {ActionRoot} from '../root'
 export const patch610: Layer<ActionRoot> = {
 	patch: '6.1',
 	data: {
-		//...
+		// Tank 6.1 cooldown changes
+		DEFIANCE: {cooldown: 3000},
+		GRIT: {cooldown: 3000},
+		IRON_WILL: {cooldown: 3000},
+		ROYAL_GUARD: {cooldown: 3000},
 	},
 }

--- a/src/data/STATUSES/layers/patch6.1.ts
+++ b/src/data/STATUSES/layers/patch6.1.ts
@@ -5,6 +5,6 @@ export const patch610: Layer<StatusRoot> = {
 	patch: '6.1',
 	data: {
 		// SCH 6.1 duration changes
-		EXPEDIENCE: { duration: 10000 },
+		EXPEDIENCE: {duration: 10000},
 	},
 }

--- a/src/data/STATUSES/layers/patch6.1.ts
+++ b/src/data/STATUSES/layers/patch6.1.ts
@@ -1,6 +1,5 @@
 import {Layer} from 'data/layer'
 import {StatusRoot} from '../root'
-import {SHARED} from '../root/SHARED'
 
 export const patch610: Layer<StatusRoot> = {
 	patch: '6.1',
@@ -12,7 +11,6 @@ export const patch610: Layer<StatusRoot> = {
 			icon: 'https://xivapi.com/i/014000/014942.png',
 			duration: 20000,
 		},
-		TRICK_ATTACK_VULNERABILITY_UP: SHARED.UNKNOWN,
 
 		// SCH 6.1 duration changes
 		EXPEDIENCE: {duration: 10000},

--- a/src/data/STATUSES/layers/patch6.1.ts
+++ b/src/data/STATUSES/layers/patch6.1.ts
@@ -1,9 +1,19 @@
 import {Layer} from 'data/layer'
 import {StatusRoot} from '../root'
+import {SHARED} from '../root/SHARED'
 
 export const patch610: Layer<StatusRoot> = {
 	patch: '6.1',
 	data: {
+		// NIN 6.1 buff changes
+		MUG: {
+			id: 3183,
+			name: 'Mug',
+			icon: 'https://xivapi.com/i/014000/014942.png',
+			duration: 20000,
+		},
+		TRICK_ATTACK_VULNERABILITY_UP: SHARED.UNKNOWN,
+
 		// SCH 6.1 duration changes
 		EXPEDIENCE: {duration: 10000},
 	},

--- a/src/data/STATUSES/root/NIN.ts
+++ b/src/data/STATUSES/root/NIN.ts
@@ -1,4 +1,5 @@
 import {ensureStatuses} from '../type'
+import {SHARED} from './SHARED'
 
 export const NIN = ensureStatuses({
 	TRICK_ATTACK_VULNERABILITY_UP: {
@@ -7,6 +8,8 @@ export const NIN = ensureStatuses({
 		icon: 'https://xivapi.com/i/015000/015020.png',
 		duration: 15000,
 	},
+
+	MUG_VULNERABILITY_UP: SHARED.UNKNOWN,
 
 	KASSATSU: {
 		id: 497,

--- a/src/data/STATUSES/root/NIN.ts
+++ b/src/data/STATUSES/root/NIN.ts
@@ -9,7 +9,7 @@ export const NIN = ensureStatuses({
 		duration: 15000,
 	},
 
-	MUG_VULNERABILITY_UP: SHARED.UNKNOWN,
+	MUG: SHARED.UNKNOWN,
 
 	KASSATSU: {
 		id: 497,

--- a/src/parser/core/index.tsx
+++ b/src/parser/core/index.tsx
@@ -15,7 +15,7 @@ export const CORE = new Meta({
 	// Read `docs/patch-checklist.md` before editing the following values.
 	supportedPatches: {
 		from: '6.0',
-		to: '6.08',
+		to: '6.1',
 	},
 })
 

--- a/src/parser/core/modules/RaidBuffs.ts
+++ b/src/parser/core/modules/RaidBuffs.ts
@@ -63,10 +63,7 @@ export class RaidBuffs extends Analyser {
 				{key: 'TRICK_ATTACK_VULNERABILITY_UP', name: 'Trick Attack'}
 			)
 		} else {
-			this.settings.set(
-				this.data.statuses.MUG_VULNERABILITY_UP.id,
-				{key: 'MUG_VULNERABILITY_UP', name: 'Mug'}
-			)
+			this.settings.set(this.data.statuses.MUG.id, {key: 'MUG'})
 		}
 
 		// Event hooks

--- a/src/parser/core/modules/RaidBuffs.ts
+++ b/src/parser/core/modules/RaidBuffs.ts
@@ -32,7 +32,6 @@ const TRACKED_STATUSES: StatusConfig[] = [
 	{key: 'EMBOLDEN_SELF'}, // tracking the self buff so it appears on the RDM's perspective
 	{key: 'EMBOLDEN_PARTY'},
 	{key: 'LEFT_EYE', exclude: ['DRAGOON']}, // notDRG
-	{key: 'TRICK_ATTACK_VULNERABILITY_UP', name: 'Trick Attack'},
 	{key: 'TECHNICAL_FINISH'},
 	{key: 'STANDARD_FINISH_PARTNER'},
 	{key: 'DEVILMENT'},
@@ -57,6 +56,19 @@ export class RaidBuffs extends Analyser {
 	)
 
 	override initialise() {
+		// Patch-specific raid buff additions
+		if (this.parser.patch.before('6.1')) {
+			this.settings.set(
+				this.data.statuses.TRICK_ATTACK_VULNERABILITY_UP.id,
+				{key: 'TRICK_ATTACK_VULNERABILITY_UP', name: 'Trick Attack'}
+			)
+		} else {
+			this.settings.set(
+				this.data.statuses.MUG_VULNERABILITY_UP.id,
+				{key: 'MUG_VULNERABILITY_UP', name: 'Mug'}
+			)
+		}
+
 		// Event hooks
 		const statusFilter = filter<Event>()
 			.status(oneOf([...this.settings.keys()]))


### PR DESCRIPTION
This PR marks 6.1 in core support, and fixes the resulting issues in RaidBuffs. I've added the new status for Mug and properly updated the Trick vuln up for it, but not added the new Trick buff. Additional changes are the collective tank changes since they're blanket, and a linter fix for SCH.