### PR TITLE
Sage updates for 6.1

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -853,8 +853,6 @@
   "sge.actiontimeline.addersgall": "",
   "sge.cooldownDowntime.defense-cd-metric": "",
   "sge.cooldownDowntime.ogcd-cd-metric": "",
-  "sge.cooldowns.pepsis.why": "",
-  "sge.cooldowns.suggestions.pepsis.content": "",
   "sge.dots.requirement.uptime.name": "Gesamtanwendungszeit von <0/>",
   "sge.dots.rule.description": "",
   "sge.dots.rule.name": "Halte deinen DoT aufrecht",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -853,8 +853,6 @@
   "sge.actiontimeline.addersgall": "Addersgall",
   "sge.cooldownDowntime.defense-cd-metric": "Using your mitigation and healing cooldowns allows you to help keep the party healthy while continuing to deal damage and healing to your <0/> target. While you shouldn't waste these actions, you should try to plan out when to use them to maximize their utility.",
   "sge.cooldownDowntime.ogcd-cd-metric": "<0/> is stronger than <1/>. Try not to lose out on using it by sitting on both charges for too long.",
-  "sge.cooldowns.pepsis.why": "You didn't use <0/>",
-  "sge.cooldowns.suggestions.pepsis.content": "<0/> allows you to convert unused <1/> or <2/> shields into healing. If your party has a shield that will wear off before more damage hits, you can use <3/> to help top them up and keep the shield from going to waste.",
   "sge.dots.requirement.uptime.name": "<0/> uptime",
   "sge.dots.rule.description": "<0/> makes up a good portion of your damage. Aim to keep this DoT up at all times. It can also be used to weave your Addersgall abilities or other cooldowns, or maneuver around without dropping GCD uptime.",
   "sge.dots.rule.name": "Keep your DoT up",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -853,8 +853,6 @@
   "sge.actiontimeline.addersgall": "Bile de vipère",
   "sge.cooldownDowntime.defense-cd-metric": "",
   "sge.cooldownDowntime.ogcd-cd-metric": "",
-  "sge.cooldowns.pepsis.why": "Vous n'avez pas utilisé <0/>",
-  "sge.cooldowns.suggestions.pepsis.content": "",
   "sge.dots.requirement.uptime.name": "Temps total d'application de <0/>",
   "sge.dots.rule.description": "",
   "sge.dots.rule.name": "Vérifiez que vos DoTs soient bien appliqués à votre cible en permanence",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -853,8 +853,6 @@
   "sge.actiontimeline.addersgall": "アダーガル",
   "sge.cooldownDowntime.defense-cd-metric": "軽減と回復のクールダウンを使えば <0/> の対象にダメージと回復を与え続けながら、パーティのHP維持に貢献することが出来ます。これらのアクションは無駄にはなりませんが、その有用性を最大化するために使用するタイミングを計画的に行うようにしましょう。",
   "sge.cooldownDowntime.ogcd-cd-metric": "<0/> は <1/> よりも強いです。 両方のチャージを長くして使い損なわないようにしましょう。",
-  "sge.cooldowns.pepsis.why": "あなたは <0/> を使用しませんでした。",
-  "sge.cooldowns.suggestions.pepsis.content": "<0/> を使うと、 使用していない <1/> や <2/> のバリアを回復に変換することが出来ます。パーティのバリアがダメージを受ける前に切れてしまう場合、 <3/> を使うことでバリアを無駄にならないようにすることが出来ます。",
   "sge.dots.requirement.uptime.name": "アクティブ率: <0/>",
   "sge.dots.rule.description": "<0/>は、ダメージの大部分を占めます。このDoTを常に維持することを目指してください。また、アダーガルのアビリティや他のクールダウンを挟むことで、GCDの稼働時間を落とさずに操作することができます。",
   "sge.dots.rule.name": "DoTを切らさないようにしましょう",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -853,8 +853,6 @@
   "sge.actiontimeline.addersgall": "",
   "sge.cooldownDowntime.defense-cd-metric": "",
   "sge.cooldownDowntime.ogcd-cd-metric": "",
-  "sge.cooldowns.pepsis.why": "",
-  "sge.cooldowns.suggestions.pepsis.content": "",
   "sge.dots.requirement.uptime.name": "적용시간 <0/>",
   "sge.dots.rule.description": "",
   "sge.dots.rule.name": "항상 도트 데미지가 유지되도록 하십시오.",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -853,8 +853,6 @@
   "sge.actiontimeline.addersgall": "蛇胆量谱",
   "sge.cooldownDowntime.defense-cd-metric": "使用减伤和治疗能力技可以帮助你维持团队血线，这样你就能继续造成伤害并治疗<0/>目标。你不应该浪费这些技能，你应该试着寻找有效的使用时机。",
   "sge.cooldownDowntime.ogcd-cd-metric": "<0/> 比 <1/> 强，避免因为觉得它们充能太慢就不用。",
-  "sge.cooldowns.pepsis.why": "你没有使用<0/>",
-  "sge.cooldowns.suggestions.pepsis.content": "<0/> 可以将未消耗的 <1/> 和 <2/> 提供的护盾转化为治疗，如果队里有护盾即将超时且接下来没有Boss伤害，则可以使用 <3/> 将他们回满从而避免护盾浪费。",
   "sge.dots.requirement.uptime.name": "<0/> 覆盖率",
   "sge.dots.rule.description": "<0/>的总威力很大，请尽量保持此DoT的常驻。另外，它产生的GCD空档的时间也可以用来插入能力技或其他技能。",
   "sge.dots.rule.name": "保持你的 DoT 常驻",

--- a/src/data/STATUSES/layers/patch6.1.ts
+++ b/src/data/STATUSES/layers/patch6.1.ts
@@ -14,5 +14,8 @@ export const patch610: Layer<StatusRoot> = {
 
 		// SCH 6.1 duration changes
 		EXPEDIENCE: {duration: 10000},
+
+		// SGE 6.1 changes
+		SOTERIA: {stacksApplied: 4},
 	},
 }

--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -47,4 +47,9 @@ export const changelog = [
 		Changes: () => <>Fixed an issue with Addersting stacks not counting correctly on some logs in 6.05+</>,
 		contributors: [CONTRIBUTORS.AZARIAH],
 	},
+	{
+		date: new Date('2022-04-12'),
+		Changes: () => <>Updated Addersting gauge initialization for 6.1 and later logs, and cleaned up a few suggestions.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/sge/index.tsx
+++ b/src/parser/jobs/sge/index.tsx
@@ -18,7 +18,7 @@ export const SAGE = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.08',
+		to: '6.1',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sge/modules/CooldownDowntime.tsx
+++ b/src/parser/jobs/sge/modules/CooldownDowntime.tsx
@@ -2,7 +2,7 @@ import {Trans} from '@lingui/react'
 import {DataLink} from 'components/ui/DbLink'
 import {dependency} from 'parser/core/Injectable'
 import {CooldownDowntime as CoreCooldownDowntime} from 'parser/core/modules/CooldownDowntime'
-import Suggestions, {SEVERITY, Suggestion} from 'parser/core/modules/Suggestions'
+import Suggestions from 'parser/core/modules/Suggestions'
 import React from 'react'
 
 const DPS_TARGET_PERCENT = 80
@@ -37,28 +37,4 @@ export class CooldownDowntime extends CoreCooldownDowntime {
 		Using your mitigation and healing cooldowns allows you to help keep the party healthy while continuing to deal damage and healing to your <DataLink showIcon={false} action="KARDIA" /> target.
 		While you shouldn't waste these actions, you should try to plan out when to use them to maximize their utility.
 	</Trans>
-
-	/**
-	 * Keeping track of Pepsis so we can provide a suggestion if they never used it
-	 */
-	override suggestionOnlyCooldowns = [
-		{cooldowns: [this.data.actions.PEPSIS]},
-	]
-
-	override addJobSuggestions() {
-		// Grab the Pepsis cooldown group
-		const cooldownGroup = this.suggestionOnlyCooldowns[0]
-		const uses = this.calculateUsageCount(cooldownGroup)
-
-		// Only bothering with the suggestion if they never used Pepsis
-		if (uses > 0) { return }
-
-		this.suggestions.add(new Suggestion({
-			icon: this.data.actions.PEPSIS.icon,
-			content: <Trans id="sge.cooldowns.suggestions.pepsis.content"><DataLink showIcon={false} action="PEPSIS"/> allows you to convert unused <DataLink status="EUKRASIAN_DIAGNOSIS" /> or <DataLink status="EUKRASIAN_PROGNOSIS" /> shields into healing.
-				If your party has a shield that will wear off before more damage hits, you can use <DataLink showIcon={false} action="PEPSIS" /> to help top them up and keep the shield from going to waste.</Trans>,
-			severity: SEVERITY.MINOR,
-			why: <Trans id="sge.cooldowns.pepsis.why">You didn't use <DataLink showIcon={false} action="PEPSIS" /></Trans>,
-		}))
-	}
 }

--- a/src/parser/jobs/sge/modules/Gauge.tsx
+++ b/src/parser/jobs/sge/modules/Gauge.tsx
@@ -201,18 +201,21 @@ export class Gauge extends CoreGauge {
 		const addersgallExpirationTime = this.addersgallTimer.getExpirationTime(addersgallLeniency, this.parser.currentEpochTimestamp, forceGainUtaWindows, addersgallLeniency)
 		const lostAddersgall = Math.floor(addersgallExpirationTime / ADDERSGALL_TIME_REQUIRED)
 
-		if (lostAddersgall > 0) {
-			this.suggestions.add(new Suggestion({
-				icon: this.data.actions.KERACHOLE.icon,
-				content: <Trans id="sge.gauge.suggestions.lost-addersgall.content">
-					You lost Addersgall due to capping the gauge and letting the timer stop. Your Addersgall actions are your primary healing and mitigation tools, as well as contributing to your MP recovery, so you should try to use another one before regaining your third stack.
-				</Trans>,
-				severity: SEVERITY.MEDIUM,
-				why: <Trans id="sge.gauge.suggestions.lost-addersgall.why">
-					<Plural value={lostAddersgall} one="# Addersgall stack was" other="# Addersgall stacks were"/> lost to timer inactivity.
-				</Trans>,
-			}))
-		}
+		this.suggestions.add(new TieredSuggestion({
+			icon: this.data.actions.KERACHOLE.icon,
+			content: <Trans id="sge.gauge.suggestions.lost-addersgall.content">
+				You lost Addersgall due to capping the gauge and letting the timer stop. Your Addersgall actions are your primary healing and mitigation tools, as well as contributing to your MP recovery, so you should try to use another one before regaining your third stack.
+			</Trans>,
+			tiers: {
+				1: SEVERITY.MINOR,
+				3: SEVERITY.MEDIUM,
+				5: SEVERITY.MAJOR,
+			},
+			value: lostAddersgall,
+			why: <Trans id="sge.gauge.suggestions.lost-addersgall.why">
+				<Plural value={lostAddersgall} one="# Addersgall stack was" other="# Addersgall stacks were"/> lost to timer inactivity.
+			</Trans>,
+		}))
 
 		const rhizomataLostStacks = Math.floor(this.rhizomataLoss / ADDERSGALL_TIME_REQUIRED)
 		if (rhizomataLostStacks > 0) {

--- a/src/parser/jobs/sge/modules/Gauge.tsx
+++ b/src/parser/jobs/sge/modules/Gauge.tsx
@@ -67,6 +67,7 @@ export class Gauge extends CoreGauge {
 
 	private adderstingGauge = this.add(new CounterGauge({
 		maximum: ADDERSTING_MAX_STACKS,
+		initialValue: this.parser.patch.before('6.1') ? 0 : ADDERSTING_MAX_STACKS,
 		graph: {
 			label: <Trans id="sge.gauge.resource.addersting">Addersting</Trans>,
 			color: ADDERSTING_COLOR.fade(GAUGE_FADE),


### PR DESCRIPTION
- Updates 6.1 status layer with Soteria's 4 stacks (ID did not change, thank)
- Updates Addersting gauge initialization to max for 6.1 and later logs
- Convert Addersgall loss suggestion to tiered
- Removed the "You didn't use Pepsis" suggestion