### PR TITLE
Fix 6.1 Raid Buffs in Timeline

### DIFF
--- a/src/data/ACTIONS/layers/patch6.1.ts
+++ b/src/data/ACTIONS/layers/patch6.1.ts
@@ -4,6 +4,10 @@ import {ActionRoot} from '../root'
 export const patch610: Layer<ActionRoot> = {
 	patch: '6.1',
 	data: {
+		// NIN 6.1 raid buff changes
+		TRICK_ATTACK: {statusesApplied: []},
+		MUG: {statusesApplied: ['MUG_VULNERABILITY_UP']},
+
 		// Tank 6.1 cooldown changes
 		DEFIANCE: {cooldown: 3000},
 		GRIT: {cooldown: 3000},

--- a/src/data/STATUSES/layers/patch6.1.ts
+++ b/src/data/STATUSES/layers/patch6.1.ts
@@ -1,16 +1,18 @@
 import {Layer} from 'data/layer'
 import {StatusRoot} from '../root'
+import {SHARED} from '../root/SHARED'
 
 export const patch610: Layer<StatusRoot> = {
 	patch: '6.1',
 	data: {
 		// NIN 6.1 buff changes
-		MUG: {
-			id: 3183,
-			name: 'Mug',
-			icon: 'https://xivapi.com/i/014000/014942.png',
+		MUG_VULNERABILITY_UP: {
+			id: 638,
+			name: 'Vulnerability Up',
+			icon: 'https://xivapi.com/i/015000/015020.png',
 			duration: 20000,
 		},
+		TRICK_ATTACK_VULNERABILITY_UP: SHARED.UNKNOWN,
 
 		// SCH 6.1 duration changes
 		EXPEDIENCE: {duration: 10000},

--- a/src/data/STATUSES/root/NIN.ts
+++ b/src/data/STATUSES/root/NIN.ts
@@ -9,7 +9,7 @@ export const NIN = ensureStatuses({
 		duration: 15000,
 	},
 
-	MUG: SHARED.UNKNOWN,
+	MUG_VULNERABILITY_UP: SHARED.UNKNOWN,
 
 	KASSATSU: {
 		id: 497,

--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,12 +10,18 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2022-04-20'),
+		Changes: () => <>Update core raid buffs to use the correct NIN buff name in timeline.</>,
+		contributors: [CONTRIBUTORS.AY],
+	},
+	{
 		date: new Date('2022-03-29'),
 		Changes: () => <>
 			Update Always Be Casting to target 98% and show at top of checklist.
 		</>,
 		contributors: [CONTRIBUTORS.AY],
-	},	{
+	},
+	{
 		date: new Date('2022-02-17'),
 		Changes: () => <>
 			Allow core procs to hide the timeline row. This was previously enforced, jobs can now hide it.
@@ -26,7 +32,7 @@ export const changelog: ChangelogEntry[] = [
 	{
 		date: new Date('2022-02-11'),
 		Changes: () => <>
-		Fix Swiftcast end of fight forgiveness. It was increasing the number of expected GCDs to 2 instead of reducing it to 0.
+			Fix Swiftcast end of fight forgiveness. It was increasing the number of expected GCDs to 2 instead of reducing it to 0.
 		</>,
 		contributors: [CONTRIBUTORS.DEAN],
 	},

--- a/src/parser/core/modules/RaidBuffs.ts
+++ b/src/parser/core/modules/RaidBuffs.ts
@@ -63,7 +63,10 @@ export class RaidBuffs extends Analyser {
 				{key: 'TRICK_ATTACK_VULNERABILITY_UP', name: 'Trick Attack'}
 			)
 		} else {
-			this.settings.set(this.data.statuses.MUG.id, {key: 'MUG'})
+			this.settings.set(
+				this.data.statuses.MUG_VULNERABILITY_UP.id,
+				{key: 'MUG_VULNERABILITY_UP', name: 'Mug'}
+			)
 		}
 
 		// Event hooks


### PR DESCRIPTION
First attempt at this used incorrect statuses, now that we've got logs to verify this PR fixes the status IDs/names and ensures the data config is still valid. Other data changes for NIN are in the scope of the NIN 6.1 PR.