### PR TITLE
Mark patch 6.1 support for DRK

### DIFF
--- a/src/data/ACTIONS/root/DRK.ts
+++ b/src/data/ACTIONS/root/DRK.ts
@@ -83,7 +83,7 @@ export const DRK = ensureActions({
 	},
 	CARVE_AND_SPIT: {
 		id: 3643,
-		name: 'Carve And Spit',
+		name: 'Carve and Spit',
 		icon: 'https://xivapi.com/i/003000/003058.png',
 		cooldown: 60000,
 		cooldownGroup: 14,

--- a/src/data/STATUSES/layers/patch6.1.ts
+++ b/src/data/STATUSES/layers/patch6.1.ts
@@ -14,7 +14,7 @@ export const patch610: Layer<StatusRoot> = {
 		// Duration varies by the remaining duration on Walking Dead when it was cleansed
 		UNDEAD_REBIRTH: {
 			id: 3255,
-			name: 'Undeath Rebirth',
+			name: 'Undead Rebirth',
 			icon: 'https://xivapi.com/i/013000/013124.png',
 		},
 

--- a/src/data/STATUSES/layers/patch6.1.ts
+++ b/src/data/STATUSES/layers/patch6.1.ts
@@ -5,6 +5,19 @@ import {SHARED} from '../root/SHARED'
 export const patch610: Layer<StatusRoot> = {
 	patch: '6.1',
 	data: {
+		// DRK 6.1 buff changes
+		BLOOD_WEAPON: {
+			duration: 15000,
+			stacksApplied: 5,
+		},
+
+		// Duration varies by the remaining duration on Walking Dead when it was cleansed
+		UNDEAD_REBIRTH: {
+			id: 3255,
+			name: 'Undeath Rebirth',
+			icon: 'https://xivapi.com/i/013000/013124.png',
+		},
+
 		// NIN 6.1 buff changes
 		MUG_VULNERABILITY_UP: {
 			id: 638,

--- a/src/data/STATUSES/root/DRK.ts
+++ b/src/data/STATUSES/root/DRK.ts
@@ -1,4 +1,5 @@
 import {ensureStatuses} from '../type'
+import {SHARED} from './SHARED'
 
 export const DRK = ensureStatuses({
 	GRIT: {
@@ -41,6 +42,9 @@ export const DRK = ensureStatuses({
 		icon: 'https://xivapi.com/i/013000/013116.png',
 		duration: 10000,
 	},
+
+	UNDEAD_REBIRTH: SHARED.UNKNOWN,
+
 	DARK_MIND: {
 		id: 746,
 		name: 'Dark Mind',

--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -22,8 +22,14 @@ export const DARK_KNIGHT = new Meta({
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AZARIAH, role: ROLES.MAINTAINER},
+		{user: CONTRIBUTORS.AY, role: ROLES.DEVELOPER},
 	],
 	changelog: [
+		{
+			date: new Date('2022-04-24'),
+			Changes: () => <>Update timeline for 6.1 changes to <DataLink action="LIVING_DEAD"/>, and combine <DataLink action="SALTED_EARTH"/> with <DataLink action="SALT_AND_DARKNESS"/>.</>,
+			contributors: [CONTRIBUTORS.AY],
+		},
 		{
 			date: new Date('2022-01-18'),
 			Changes: () => <>Fixed Oblation timeline display</>,

--- a/src/parser/jobs/drk/modules/ActionTimeline.tsx
+++ b/src/parser/jobs/drk/modules/ActionTimeline.tsx
@@ -15,8 +15,7 @@ export class ActionTimeline extends CoreActionTimeline {
 		'CARVE_AND_SPIT',
 		'ABYSSAL_DRAIN',
 		'PLUNGE',
-		'SALTED_EARTH',
-		'SALT_AND_DARKNESS',
+		['SALTED_EARTH', 'SALT_AND_DARKNESS'],
 		// Personal Mitigation
 		'LIVING_DEAD',
 		'SHADOW_WALL',

--- a/src/parser/jobs/drk/modules/StatusTimeline.ts
+++ b/src/parser/jobs/drk/modules/StatusTimeline.ts
@@ -4,5 +4,6 @@ import {StatusTimeline as CoreStatusTimeline} from 'parser/core/modules/StatusTi
 export class StatusTimeline extends CoreStatusTimeline {
 	static override statusesStackMapping = {
 		[STATUSES.WALKING_DEAD.id]: STATUSES.LIVING_DEAD.id,
+		[STATUSES.UNDEAD_REBIRTH.id]: STATUSES.LIVING_DEAD.id,
 	}
 }


### PR DESCRIPTION
Additionally, fixed some code legibility issues in Blood gauge and a skill name in data. Main thing was the timeline status changes, both the new status and combining Salted Earth with Salt and Darkness.

Blood gauge change was to prevent the bug where Blood numbers show super high as it previously tracked each stack as a separate application, changing to the action is basically Good Enough™. Blood Weapon itself needs no logical changes as core BuffWindow checks if there's an open window already and safely handles the stacks.