### PR TITLE
DRG: Update Jump-related Rules

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -428,7 +428,7 @@
   "drg.gauge.suggestions.overcapped-fmf.content": "Make sure to use <0/> before <1/> or <2/> when you already have two stacks of Firstminds' Focus to prevent losing uses of <3/> by overcapping.",
   "drg.gauge.suggestions.overcapped-fmf.why": "{fmfOvercap, plural, one {# Firstminds' Focus stack} other {# Firstminds' Focus stacks}} were lost.",
   "drg.lancecharge.title": "Lance Charge",
-  "drg.lc.prepend-message": "<0/> may be held (not used) during a buff window if you are instead able to use both charges during the next window. We do our best in this module to avoid marking windows where <1/> was correctly held as errors. <2/> should be used in every other window.",
+  "drg.lc.prepend-message": "Both charges of <0/> should be used while both <1/> and <2/> are active. Since this is not always possible, we do our best in this module to avoid marking windows where <3/> was correctly held as errors. <4/> should be used in every other window.",
   "drg.lc.suggestions.missedaction.content": "Try to use as many of your oGCDs as possible during <0/>. Remember to keep your abilities on cooldown, when possible, to prevent them from drifting outside of your buff windows.",
   "drg.lc.suggestions.missedgcd.content": "Try to land at least 8 GCDs during every <0/> window.",
   "drg.procs.suggestions.extenders.content": "Avoid interrupting your combos at the <0/> and <1/> stages, as it causes you to lose the procs that allow you to cast them.",

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -11,7 +11,7 @@ export const DRAGOON = new Meta({
 		</Trans>
 	</>,
 	supportedPatches: {
-		from: '6.0',
+		from: '6.1',
 		to: '6.1',
 	},
 	contributors: [

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -11,7 +11,7 @@ export const DRAGOON = new Meta({
 		</Trans>
 	</>,
 	supportedPatches: {
-		from: '6.1',
+		from: '6.0',
 		to: '6.1',
 	},
 	contributors: [

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -19,6 +19,11 @@ export const DRAGOON = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-04-24'),
+			Changes: () => <>As of 6.1, weaving any jump (except for Stardiver) is no longer a weaving error. Because of this, we now expect both Spineshatter Dive charges to be used with Dragon Sight windows.</>,
+			contributors: [CONTRIBUTORS.FALINDRITH],
+		},
+		{
 			date: new Date('2022-04-03'),
 			Changes: () => <>Due to changes in 6.08, Life Surge is no longer expected to be in every Lance Charge window.</>,
 			contributors: [CONTRIBUTORS.FALINDRITH],

--- a/src/parser/jobs/drg/modules/DragonSight.tsx
+++ b/src/parser/jobs/drg/modules/DragonSight.tsx
@@ -101,29 +101,40 @@ export default class DragonSight extends BuffWindow {
 			adjustCount: this.adjustExpectedGcdCount.bind(this),
 		}))
 
+		const expectedActions = [
+			{
+				action: this.data.actions.HIGH_JUMP,
+				expectedPerWindow: 1,
+			},
+			{
+				action: this.data.actions.GEIRSKOGUL,
+				expectedPerWindow: 1,
+			},
+			{
+				action: this.data.actions.MIRAGE_DIVE,
+				expectedPerWindow: 1,
+			},
+			{
+				action: this.data.actions.SPINESHATTER_DIVE,
+				expectedPerWindow: this.parser.patch.before('6.1') ? 1 : 2,
+			},
+			{
+				action: this.data.actions.DRAGONFIRE_DIVE,
+				expectedPerWindow: 1,
+			},
+		]
+
+		// 6.08 changed the potencies such that it's generally better to always use LS on
+		// Heavens' Thrust. Before that, we generally expected one in each two minute window.
+		if (this.parser.patch.before('6.08')) {
+			expectedActions.push({
+				action: this.data.actions.LIFE_SURGE,
+				expectedPerWindow: 1,
+			})
+		}
+
 		this.addEvaluator(new ExpectedActionsEvaluator({
-			expectedActions: [
-				{
-					action: this.data.actions.HIGH_JUMP,
-					expectedPerWindow: 1,
-				},
-				{
-					action: this.data.actions.GEIRSKOGUL,
-					expectedPerWindow: 1,
-				},
-				{
-					action: this.data.actions.MIRAGE_DIVE,
-					expectedPerWindow: 1,
-				},
-				{
-					action: this.data.actions.SPINESHATTER_DIVE,
-					expectedPerWindow: 2,
-				},
-				{
-					action: this.data.actions.DRAGONFIRE_DIVE,
-					expectedPerWindow: 1,
-				},
-			],
+			expectedActions,
 			suggestionIcon,
 			suggestionContent: <Trans id="drg.lc.suggestions.missedaction.content">Try to use as many of your oGCDs as possible during <ActionLink action="DRAGON_SIGHT" />. Remember to keep your abilities on cooldown, when possible, to prevent them from drifting outside of your buff windows.</Trans>,
 			suggestionWindowName,
@@ -137,7 +148,11 @@ export default class DragonSight extends BuffWindow {
 		}))
 
 		this.addEvaluator(new ShortWindowEvaluator(this.buffTargetDied.bind(this)))
-		this.addEvaluator(new DisplayedActionEvaluator([this.data.actions.LIFE_SURGE]))
+
+		// display ordering
+		if (this.parser.patch.after('6.05')) {
+			this.addEvaluator(new DisplayedActionEvaluator([this.data.actions.LIFE_SURGE]))
+		}
 	}
 
 	private onDeath(event: Events['death']) {

--- a/src/parser/jobs/drg/modules/DragonSight.tsx
+++ b/src/parser/jobs/drg/modules/DragonSight.tsx
@@ -6,6 +6,7 @@ import {Events} from 'event'
 import _ from 'lodash'
 import {dependency} from 'parser/core/Injectable'
 import {BuffWindow, calculateExpectedGcdsForTime, EvaluatedAction, EvaluationOutput, ExpectedActionsEvaluator, ExpectedGcdCountEvaluator, WindowEvaluator} from 'parser/core/modules/ActionWindow'
+import {DisplayedActionEvaluator} from 'parser/core/modules/ActionWindow/evaluators/DisplayedActionEvaluator'
 import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
@@ -115,12 +116,8 @@ export default class DragonSight extends BuffWindow {
 					expectedPerWindow: 1,
 				},
 				{
-					action: this.data.actions.LIFE_SURGE,
-					expectedPerWindow: 1,
-				},
-				{
 					action: this.data.actions.SPINESHATTER_DIVE,
-					expectedPerWindow: 1,
+					expectedPerWindow: 2,
 				},
 				{
 					action: this.data.actions.DRAGONFIRE_DIVE,
@@ -140,6 +137,7 @@ export default class DragonSight extends BuffWindow {
 		}))
 
 		this.addEvaluator(new ShortWindowEvaluator(this.buffTargetDied.bind(this)))
+		this.addEvaluator(new DisplayedActionEvaluator([this.data.actions.LIFE_SURGE]))
 	}
 
 	private onDeath(event: Events['death']) {

--- a/src/parser/jobs/drg/modules/LanceCharge.tsx
+++ b/src/parser/jobs/drg/modules/LanceCharge.tsx
@@ -33,7 +33,7 @@ export default class LanceCharge extends BuffWindow {
 	override buffStatus = this.data.statuses.LANCE_CHARGE
 
 	override prependMessages = <Message info>
-		<Trans id="drg.lc.prepend-message"><ActionLink action="SPINESHATTER_DIVE" /> may be held (not used) during a buff window if you are instead able to use both charges during the next window. We do our best in this module to avoid marking windows where <ActionLink action="SPINESHATTER_DIVE" showIcon={false} /> was correctly held as errors. <ActionLink action="DRAGONFIRE_DIVE" /> should be used in every other window.</Trans>
+		<Trans id="drg.lc.prepend-message">Both charges of <ActionLink action="SPINESHATTER_DIVE" /> should be used while both <ActionLink action="LANCE_CHARGE" /> and <ActionLink action="DRAGON_SIGHT" /> are active. Since this is not always possible, we do our best in this module to avoid marking windows where <ActionLink action="SPINESHATTER_DIVE" showIcon={false} /> was correctly held as errors. <ActionLink action="DRAGONFIRE_DIVE" /> should be used in every other window.</Trans>
 	</Message>
 
 	private ssdDelays: SsdDelayTracker[] = []

--- a/src/parser/jobs/drg/modules/Weaving.ts
+++ b/src/parser/jobs/drg/modules/Weaving.ts
@@ -2,11 +2,8 @@ import {ActionKey} from 'data/ACTIONS'
 import {Weaving as CoreWeaving, Weave} from 'parser/core/modules/Weaving'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
+// With the reduced animation lock, it's just stardiver that's the bad weave
 const JUMPS: ActionKey[] = [
-	'JUMP',
-	'HIGH_JUMP',
-	'SPINESHATTER_DIVE',
-	'DRAGONFIRE_DIVE',
 	'STARDIVER',
 ]
 

--- a/src/parser/jobs/drg/modules/Weaving.ts
+++ b/src/parser/jobs/drg/modules/Weaving.ts
@@ -3,17 +3,31 @@ import {Weaving as CoreWeaving, Weave} from 'parser/core/modules/Weaving'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 // With the reduced animation lock, it's just stardiver that's the bad weave
-const JUMPS: ActionKey[] = [
+const JUMPS_ALL: ActionKey[] = [
 	'STARDIVER',
+]
+
+const JUMPS_600: ActionKey[] = [
+	'JUMP',
+	'HIGH_JUMP',
+	'SPINESHATTER_DIVE',
+	'DRAGONFIRE_DIVE',
 ]
 
 export default class Weaving extends CoreWeaving {
 	static override displayOrder = DISPLAY_ORDER.WEAVING
 
-	private jumpIds = JUMPS.map(key => this.data.actions[key].id)
+	private jumpIds = JUMPS_ALL.map(key => this.data.actions[key].id)
+
+	// pre-6.1, all jumps are bad weaves
+	private jump600Ids = [...this.jumpIds, ...JUMPS_600.map(key => this.data.actions[key].id)]
 
 	override getMaxWeaves(weave: Weave) {
-		if (weave.weaves.some(weave => this.jumpIds.includes(weave.action))) {
+		if (this.parser.patch.before('6.1')) {
+			if (weave.weaves.some(weave => this.jump600Ids.includes(weave.action))) {
+				return 1
+			}
+		} else if (weave.weaves.some(weave => this.jumpIds.includes(weave.action))) {
 			return 1
 		}
 

--- a/src/parser/jobs/drg/modules/Weaving.ts
+++ b/src/parser/jobs/drg/modules/Weaving.ts
@@ -17,14 +17,15 @@ const JUMPS_600: ActionKey[] = [
 export default class Weaving extends CoreWeaving {
 	static override displayOrder = DISPLAY_ORDER.WEAVING
 
-	private jumps = JUMPS.map(key => this.data.actions[key].id)
+	private jumpIds = JUMPS.map(key => this.data.actions[key].id)
 
 	override getMaxWeaves(weave: Weave) {
 		if (this.parser.patch.before('6.1')) {
-			this.jumps.push(...JUMPS_600.map(key => this.data.actions[key].id))
+			const jump600Ids = JUMPS_600.map(key => this.data.actions[key].id)
+			this.jumpIds.push(...jump600Ids)
 		}
 
-		if (weave.weaves.some(weave => this.jumps.includes(weave.action))) {
+		if (weave.weaves.some(weave => this.jumpIds.includes(weave.action))) {
 			return 1
 		}
 

--- a/src/parser/jobs/drg/modules/Weaving.ts
+++ b/src/parser/jobs/drg/modules/Weaving.ts
@@ -3,7 +3,7 @@ import {Weaving as CoreWeaving, Weave} from 'parser/core/modules/Weaving'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 // With the reduced animation lock, it's just stardiver that's the bad weave
-const JUMPS_ALL: ActionKey[] = [
+const JUMPS: ActionKey[] = [
 	'STARDIVER',
 ]
 
@@ -17,15 +17,14 @@ const JUMPS_600: ActionKey[] = [
 export default class Weaving extends CoreWeaving {
 	static override displayOrder = DISPLAY_ORDER.WEAVING
 
-	private jumpIds = JUMPS_ALL.map(key => this.data.actions[key].id)
-
-	// pre-6.1, all jumps are bad weaves
-	private jump600Ids = [...this.jumpIds, ...JUMPS_600.map(key => this.data.actions[key].id)]
+	private jumps = JUMPS.map(key => this.data.actions[key].id)
 
 	override getMaxWeaves(weave: Weave) {
-		const jumps = this.parser.patch.before('6.1')	? this.jump600Ids : this.jumpIds
+		if (this.parser.patch.before('6.1')) {
+			this.jumps.push(...JUMPS_600.map(key => this.data.actions[key].id))
+		}
 
-		if (weave.weaves.some(weave => jumps.includes(weave.action))) {
+		if (weave.weaves.some(weave => this.jumps.includes(weave.action))) {
 			return 1
 		}
 

--- a/src/parser/jobs/drg/modules/Weaving.ts
+++ b/src/parser/jobs/drg/modules/Weaving.ts
@@ -23,11 +23,9 @@ export default class Weaving extends CoreWeaving {
 	private jump600Ids = [...this.jumpIds, ...JUMPS_600.map(key => this.data.actions[key].id)]
 
 	override getMaxWeaves(weave: Weave) {
-		if (this.parser.patch.before('6.1')) {
-			if (weave.weaves.some(weave => this.jump600Ids.includes(weave.action))) {
-				return 1
-			}
-		} else if (weave.weaves.some(weave => this.jumpIds.includes(weave.action))) {
+		const jumps = this.parser.patch.before('6.1')	? this.jump600Ids : this.jumpIds
+
+		if (weave.weaves.some(weave => jumps.includes(weave.action))) {
 			return 1
 		}
 


### PR DESCRIPTION
our jumps are fast now, so all jumps except for stardiver are generally ok to weave. This also means that we now expect both SSD charges to be held for Dragon Sight, as it's now feasible to weave within those windows.