### PR TITLE
Add overcap tracking to core timer gauge

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,11 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2022-04-26'),
+		Changes: () => <>Add overcap tracking to core timer gauge.</>,
+		contributors: [CONTRIBUTORS.AY],
+	},
+	{
 		date: new Date('2022-04-20'),
 		Changes: () => <>Update core raid buffs to use the correct NIN buff name in timeline.</>,
 		contributors: [CONTRIBUTORS.AY],

--- a/src/parser/core/modules/Gauge/TimerGauge.ts
+++ b/src/parser/core/modules/Gauge/TimerGauge.ts
@@ -37,6 +37,7 @@ export class TimerGauge extends AbstractGauge {
 	// Just in case I ever have to change it lmao
 	private readonly minimum = 0
 	private readonly maximum: number
+	overCap: number = 0
 	private readonly expirationCallback?: TimestampHookCallback
 	private readonly graphOptions?: GaugeGraphOptions
 
@@ -157,6 +158,10 @@ export class TimerGauge extends AbstractGauge {
 			remaining: this.remaining,
 			paused: this.paused,
 		})
+
+		if (duration > this.maximum) {
+			this.overCap += duration - this.maximum
+		}
 
 		const remaining = Math.max(this.minimum, Math.min(duration, this.maximum))
 


### PR DESCRIPTION
Kinda niche, useful for things like getting wasted time for statuses that are memed by the timer gauge, and possibly DRK if anyone decides we care about Darkside overcap outside of burst windows but there are other better ways to track that.