### PR TITLE
fix: MP Gauge calculations

### DIFF
--- a/src/parser/jobs/drk/modules/BloodGauge.tsx
+++ b/src/parser/jobs/drk/modules/BloodGauge.tsx
@@ -60,7 +60,7 @@ export class BloodGauge extends CoreGauge {
 		this.addEventHook(playerFilter.type('combo').action(oneOf([...this.onComboModifiers.keys()])), this.onModifier(this.onComboModifiers))
 
 		// We hook the action for BW so we can just ignore stacks entirely
-		this.addEventHook(playerFilter.type('action').action(this.data.actions.BLOOD_WEAPON.id), this.onApplyBloodWeapon)
+		this.addEventHook(playerFilter.type('statusApply').status(this.data.statuses.BLOOD_WEAPON.id), this.onApplyBloodWeapon)
 		this.addEventHook(playerFilter.type('statusRemove').status(this.data.statuses.BLOOD_WEAPON.id), this.onRemoveBloodWeapon)
 
 		this.addEventHook('complete', this.onComplete)

--- a/src/parser/jobs/drk/modules/BloodGauge.tsx
+++ b/src/parser/jobs/drk/modules/BloodGauge.tsx
@@ -75,12 +75,16 @@ export class BloodGauge extends CoreGauge {
 	}
 
 	private onApplyBloodWeapon() {
-		this.activeGcdHook = this.addEventHook(
-			filter<Event>()
-				.source(this.parser.actor.id)
-				.type('damage'),
-			this.onHitUnderBloodWeapon
-		)
+		if (this.activeGcdHook == null) {
+			// Buffs with stacks generate separate apply events for each stack with a single remove at the end.
+			// Make sure we only start hooking for actions effected by Blood Weapon on the first apply event -- no duplicate hooks on the "reapply" events as the stacks go down
+			this.activeGcdHook = this.addEventHook(
+				filter<Event>()
+					.source(this.parser.actor.id)
+					.type('damage'),
+				this.onHitUnderBloodWeapon
+			)
+		}
 	}
 
 	private onRemoveBloodWeapon() {

--- a/src/parser/jobs/drk/modules/MPUsage.tsx
+++ b/src/parser/jobs/drk/modules/MPUsage.tsx
@@ -100,7 +100,8 @@ export class MPUsage extends Analyser {
 	private onApplyBloodWeapon() {
 		if (this.activeBloodWeaponHook == null) {
 			// Buffs with stacks generate separate apply events for each stack with a single remove at the end.
-			// Make sure we only start hooking for actions effected by Blood Weapon on the first apply event -- no duplicate hooks on the "reapply" events as the stacks go down
+			// Make sure we only start hooking for actions effected by Blood Weapon on the first apply event
+			// ie no duplicate hooks on the "reapply" events as the stacks go down
 			this.activeBloodWeaponHook = this.addEventHook(filter<Event>().source(this.parser.actor.id).type('damage'), this.onGenerator(this.bloodWeaponGenerators))
 		}
 	}
@@ -115,7 +116,8 @@ export class MPUsage extends Analyser {
 	private onApplyDelirium() {
 		if (this.activeDeliriumHook == null) {
 			// Buffs with stacks generate separate apply events for each stack with a single remove at the end.
-			// Make sure we only start hooking for actions effected by Blood Weapon on the first apply event -- no duplicate hooks on the "reapply" events as the stacks go down
+			// Make sure we only start hooking for actions effected by Delirium on the first apply event
+			// ie no duplicate hooks on the "reapply" events as the stacks go down
 			this.activeDeliriumHook = this.addEventHook(filter<Event>().source(this.parser.actor.id).type('damage'), this.onGenerator(this.deliriumGenerators))
 		}
 	}


### PR DESCRIPTION
The MP gauge needed changes similar to the ones applied for the Blood gauge, so that it handles the stacks on Blood Weapon correctly.  In reviewing that, found that there were also two pre-existing bugs for the MP gauge that kind of canceled each other out: Delirium wasn't being handled correctly so was counting too much MP generation (same issue as Blood Weapon due to changing to a stack based buff), and the generation from successful combos (Syphon Strike & Stalwart Soul) was not ever being called due to a missing hook.

While working on this fix, determined that doing a null-check to prevent creating duplicate hooks on status apply was a preferred approach to hooking based on the action, changed the Blood Gauge approach to match.