### PR TITLE
Fixed an issue that prevented synthing a pre-cast Searing Light.

### DIFF
--- a/src/data/ACTIONS/layers/patch6.1.ts
+++ b/src/data/ACTIONS/layers/patch6.1.ts
@@ -56,5 +56,9 @@ export const patch610: Layer<ActionRoot> = {
 			icon: 'https://xivapi.com/i/002000/002649.png',
 			cooldown: 1000,
 		},
+
+		PET_SEARING_LIGHT: {
+			statusesApplied: [],
+		},
 	},
 }

--- a/src/data/ACTIONS/layers/patch6.1.ts
+++ b/src/data/ACTIONS/layers/patch6.1.ts
@@ -46,6 +46,10 @@ export const patch610: Layer<ActionRoot> = {
 			gcdRecast: 3000,
 		},
 
+		PET_SEARING_LIGHT: {
+			statusesApplied: [],
+		},
+
 		// WHM 6.1 changes
 		REGEN: {
 			mpCost: 400,
@@ -55,10 +59,6 @@ export const patch610: Layer<ActionRoot> = {
 			name: 'Liturgy of the Bell (Detonate)',
 			icon: 'https://xivapi.com/i/002000/002649.png',
 			cooldown: 1000,
-		},
-
-		PET_SEARING_LIGHT: {
-			statusesApplied: [],
 		},
 	},
 }

--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -28,6 +28,11 @@ export const SUMMONER = new Meta({
 
 	changelog: [
 		{
+			date: new Date('2022-05-04'),
+			Changes: () => <>Fixed an issue that prevented synthing a pre-cast Searing Light.</>,
+			contributors: [CONTRIBUTORS.KELOS],
+		},
+		{
 			date: new Date('2022-04-23'),
 			Changes: () => <>Updated Searing Light to be sourced from the player in patch 6.1.</>,
 			contributors: [CONTRIBUTORS.KELOS],


### PR DESCRIPTION
Addresses part of https://discord.com/channels/441414116914233364/725971074122121246/970095119472689183

The pre-cast Bahamut is harder to account for since it isn't status based, so that half of this feedback will be addressed separately when I figure out where/how to handle it.