### PR TITLE
Fix NIN positionals analyser for pre-6.1 patches

### DIFF
--- a/src/parser/jobs/nin/modules/Positionals.ts
+++ b/src/parser/jobs/nin/modules/Positionals.ts
@@ -9,7 +9,7 @@ export class Positionals extends CorePositionals {
 				modifiers: [],
 			},
 			{
-				value: 360,
+				value: this.parser.patch.before('6.1') ? 340 : 360,
 				modifiers: [PotencyModifier.COMBO],
 			},
 		],
@@ -25,7 +25,7 @@ export class Positionals extends CorePositionals {
 				modifiers: [],
 			},
 			{
-				value: 380,
+				value: this.parser.patch.before('6.1') ? 360 : 380,
 				modifiers: [PotencyModifier.COMBO],
 			},
 		],


### PR DESCRIPTION
Important since Korea just got Endwalker and I assume they'd like to analyse NIN at some point. No changelog since this is just a fix to the change with a changelog added half an hour ago. We went from 6.0 -> 6.1 -> 6.0-6.1 between these PRs.