### PR TITLE
Fix Broil III into Broil IV in SCH/interrupts.js

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -841,7 +841,7 @@
   "sch.faeriegauge.overcap.content": "",
   "sch.faeriegauge.overcap.why": "",
   "sch.gauge.title": "",
-  "sch.interrupts.suggestion.content": "Wenn möglich, versuche dich noch vor dem Auftreten von Mechaniken zu positionieren, so dass du dich während dieser möglichst wenig bewegen musst. Durch Slidecasting wirst du seltener <0/> einsetzen müssen um dich sofort umzupositionieren oder seltener deine <1/>-Wirkungen unterbrechen müssen",
+  "sch.interrupts.suggestion.content": "Wenn möglich, versuche dich noch vor dem Auftreten von Mechaniken zu positionieren, so dass du dich während dieser möglichst wenig bewegen musst. Durch Slidecasting wirst du seltener <0/> einsetzen müssen um dich sofort umzupositionieren oder seltener deine <1/>-Wirkungen unterbrechen müssen.",
   "sch.overheal.hot.name": "Geweihte Erde",
   "sch.overheal.pet.name": "Fee",
   "sch.overheal.pethot.name": "Fee Heilung über Zeit",

--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -841,7 +841,7 @@
   "sch.faeriegauge.overcap.content": "",
   "sch.faeriegauge.overcap.why": "",
   "sch.gauge.title": "",
-  "sch.interrupts.suggestion.content": "Wenn möglich, versuche dich noch vor dem Auftreten von Mechaniken zu positionieren, so dass du dich während dieser möglichst wenig bewegen musst. Durch Slidecasting wirst du seltener <0/> einsetzen müssen um dich sofort umzupositionieren oder seltener deine Vernichtende Bravade-Wirkungen unterbrechen müssen",
+  "sch.interrupts.suggestion.content": "Wenn möglich, versuche dich noch vor dem Auftreten von Mechaniken zu positionieren, so dass du dich während dieser möglichst wenig bewegen musst. Durch Slidecasting wirst du seltener <0/> einsetzen müssen um dich sofort umzupositionieren oder seltener deine <1/>-Wirkungen unterbrechen müssen",
   "sch.overheal.hot.name": "Geweihte Erde",
   "sch.overheal.pet.name": "Fee",
   "sch.overheal.pethot.name": "Fee Heilung über Zeit",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -841,7 +841,7 @@
   "sch.faeriegauge.overcap.content": "Use <0/> when your Faerie Gauge is high to spend gauge and avoid using Aetherflow abilities when your Faerie Gauge is full.",
   "sch.faeriegauge.overcap.why": "You lost a total of {0} Faerie Gauge over the course of the fight due to overcapping.",
   "sch.gauge.title": "Faerie Gauge Usage",
-  "sch.interrupts.suggestion.content": "If you can, try to preposition yourself so you don't have to move during mechanics as much as possible. Utilizing slidecasting will lower the need to use <0/> to instantly relocate or interrupt your current Broil III cast",
+  "sch.interrupts.suggestion.content": "If you can, try to preposition yourself so you don't have to move during mechanics as much as possible. Utilizing slidecasting will lower the need to use <0/> to instantly relocate or interrupt your current <1/> cast.",
   "sch.overheal.hot.name": "Sacred Soil",
   "sch.overheal.pet.name": "Fairy",
   "sch.overheal.pethot.name": "Fairy HoTs",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -841,7 +841,7 @@
   "sch.faeriegauge.overcap.content": "",
   "sch.faeriegauge.overcap.why": "",
   "sch.gauge.title": "Usage de la jauge d'éther féerique",
-  "sch.interrupts.suggestion.content": "Si vous le pouvez, essayez de vous prépositionner de façon à ne pas avoir à vous déplacer autant pendant la mécanique. L'utilisation de slidecasting(L'acte d'attendre que le sort lancé soit presque terminé et de commencer le mouvement, sans que le serveur n'interrompe le lancer. Ceci est possible, si le temps restant sur le cast est inférieur à la latence entre le serveur et le client.) réduit le besoin d'utiliser <0/> pour déplacer ou interrompre instantanément votre Loi de l'ébullition III",
+  "sch.interrupts.suggestion.content": "Si vous le pouvez, essayez de vous prépositionner de façon à ne pas avoir à vous déplacer autant pendant la mécanique. L'utilisation de slidecasting(L'acte d'attendre que le sort lancé soit presque terminé et de commencer le mouvement, sans que le serveur n'interrompe le lancer. Ceci est possible, si le temps restant sur le cast est inférieur à la latence entre le serveur et le client.) réduit le besoin d'utiliser <0/> pour déplacer ou interrompre instantanément votre <1/>.",
   "sch.overheal.hot.name": "Dogme de survie",
   "sch.overheal.pet.name": "Fée",
   "sch.overheal.pethot.name": "Soins sur la durée de la fée",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -841,7 +841,7 @@
   "sch.faeriegauge.overcap.content": "",
   "sch.faeriegauge.overcap.why": "",
   "sch.gauge.title": "フェイエーテル",
-  "sch.interrupts.suggestion.content": "可能な限り事前に位置取りをすることでギミック中に動く必要がないようにしてみましょう。すべり撃ちも活用することで死炎法を中断したり<0/>に置き換えたりする必要が少なくなります。",
+  "sch.interrupts.suggestion.content": "可能な限り事前に位置取りをすることでギミック中に動く必要がないようにしてみましょう。すべり撃ちも活用することで<1/>を中断したり<0/>に置き換えたりする必要が少なくなります。",
   "sch.overheal.hot.name": "野戦治療の陣",
   "sch.overheal.pet.name": "フェアリー",
   "sch.overheal.pethot.name": "フェアリー(HoT)",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -841,7 +841,7 @@
   "sch.faeriegauge.overcap.content": "요정 에테르 게이지가 높을 때는 <0/>을 사용하여 게이지를 소비하고 요정 에테르 게이지가 가득 찼을 때는 요정 에테르가 쌓이는 스킬을 사용하지 않도록 하십시오.",
   "sch.faeriegauge.overcap.why": "게이지 초과로 인해 전투 중 총 {0} 의 요정 에테르 게이지를 잃었습니다.",
   "sch.gauge.title": "요정 에테르 사용",
-  "sch.interrupts.suggestion.content": "가능하면 이동을 최소화 할 수 있는 위치를 선점하십시오. 슬라이드 캐스팅을 적극적으로 활용하면 이동시 강제되는 <0/> 사용 혹은 마염법 시전이 취소되는 상황을 피할 수 있습니다.",
+  "sch.interrupts.suggestion.content": "가능하면 이동을 최소화 할 수 있는 위치를 선점하십시오. 슬라이드 캐스팅을 적극적으로 활용하면 이동시 강제되는 <0/> 사용 혹은 <1/> 시전이 취소되는 상황을 피할 수 있습니다.",
   "sch.overheal.hot.name": "야전치유진",
   "sch.overheal.pet.name": "요정",
   "sch.overheal.pethot.name": "요정의 도트힐",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -841,7 +841,7 @@
   "sch.faeriegauge.overcap.content": "当你的异想以太量值过高的时候避使用<0/>来消耗，如果异想以太量值已满避免使用以太让他溢出",
   "sch.faeriegauge.overcap.why": "在战斗过程中由于技能的过度使用，你总共损失了 {0} 异想以太",
   "sch.gauge.title": "异想以太",
-  "sch.interrupts.suggestion.content": "如果可以的话，提前移动到你应该在的位置，这样就不用在处理机制时进行过多移动了。合理利用滑步可以减少为了移动而使用的 <0/> ，避免打断死炎法的咏唱。",
+  "sch.interrupts.suggestion.content": "如果可以的话，提前移动到你应该在的位置，这样就不用在处理机制时进行过多移动了。合理利用滑步可以减少为了移动而使用的 <0/> ，避免打断 <1/> 的咏唱。",
   "sch.overheal.hot.name": "野战治疗阵",
   "sch.overheal.pet.name": "小仙女",
   "sch.overheal.pethot.name": "小仙女的HoT",

--- a/src/parser/jobs/sch/modules/Interrupts.js
+++ b/src/parser/jobs/sch/modules/Interrupts.js
@@ -1,6 +1,5 @@
 import {Trans} from '@lingui/react'
 import {DataLink} from 'components/ui/DbLink'
-import ACTIONS from 'data/ACTIONS'
 import {Interrupts as CoreInterrupts} from 'parser/core/modules/Interrupts'
 import React from 'react'
 

--- a/src/parser/jobs/sch/modules/Interrupts.js
+++ b/src/parser/jobs/sch/modules/Interrupts.js
@@ -1,9 +1,9 @@
 import {Trans} from '@lingui/react'
-import {ActionLink} from 'components/ui/DbLink'
+import {DataLink} from 'components/ui/DbLink'
 import ACTIONS from 'data/ACTIONS'
 import {Interrupts as CoreInterrupts} from 'parser/core/modules/Interrupts'
 import React from 'react'
 
 export default class Interrupts extends CoreInterrupts {
-	suggestionContent = <Trans id="sch.interrupts.suggestion.content">If you can, try to preposition yourself so you don't have to move during mechanics as much as possible. Utilizing slidecasting will lower the need to use <ActionLink {...ACTIONS.SCH_RUIN_II}/> to instantly relocate or interrupt your current Broil III cast</Trans>
+	suggestionContent = <Trans id="sch.interrupts.suggestion.content">If you can, try to preposition yourself so you don't have to move during mechanics as much as possible. Utilizing slidecasting will lower the need to use <DataLink action="SCH_RUIN_II" /> to instantly relocate or interrupt your current <DataLink action="BROIL_IV" /> cast.</Trans>
 }


### PR DESCRIPTION
-Fixed a mention of Broil III while Broil IV has been added with EW
-Turned the raw string into a DataLink 
-Updated the SCH_RUIN_II into a DataLink from an ActionLink
-Added a dot at the end of the sentence on strings which lacked it
-Added i18n strings 

This has been tested locally and should work correctly