### PR TITLE
Allow unavoidable overhealing to be excluded 

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -961,7 +961,6 @@
   "whm.ogcds.suggestions.temperance.content": "Setze <0/> oft ein, um gruppenweiten Schaden zu mitigieren und die Potenzen deiner Heilungen mit globaler Abklingzeit zu erhöhen. Vermeide für Anwendungen in der Animation gefangen zu sein (/zu clippen).",
   "whm.ogcds.suggestions.why": "Ungefähr {missed} Casts von {maxUses} möglichen Anwendungen verpasst.",
   "whm.overheal.afflatus.name": "",
-  "whm.overheal.assize.name": "Assise",
   "whm.overheal.hot.name": "Heilung über Zeit",
   "whm.overheal.liturgyofthebell.name": "Glockenspiel",
   "whm.swiftcast.missed.suggestion.content": "Wirke Zauber mit <0/> bevor es abläuft. Dadurch kannst du Angriffe mit Anwendungszeit sofort benutzen, wie beispielsweise <1/> für schnelle Wiederbelebungen oder <2/> zwischen Angriffen mit globaler Abklingzeit (zum weaven).",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -961,7 +961,6 @@
   "whm.ogcds.suggestions.temperance.content": "Use <0/> often to mitigate incoming raid damage and boost GCD healing potency. Avoid clipping to apply it.",
   "whm.ogcds.suggestions.why": "You missed about {missed} out of a possible {maxUses} casts.",
   "whm.overheal.afflatus.name": "Afflatus Healing",
-  "whm.overheal.assize.name": "Assize",
   "whm.overheal.hot.name": "Healing Over Time",
   "whm.overheal.liturgyofthebell.name": "Liturgy of the Bell",
   "whm.swiftcast.missed.suggestion.content": "Cast a spell with <0/> before it expires. This allows you to instantly cast spells with a cast times, such as <1/> for a quick revive, or <2/> for weaving.",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -961,7 +961,6 @@
   "whm.ogcds.suggestions.temperance.content": "Utilisez régulièrement <0/> pour atténuer les dommages causés par les attaques ennemies et augmenter la puissance de guérison des GCD. Évitez de clipper pour l'appliquer.",
   "whm.ogcds.suggestions.why": "Vous avez raté environ {missed} utilisations sur {maxUses} .",
   "whm.overheal.afflatus.name": "Soin des Offrandes",
-  "whm.overheal.assize.name": "Assises",
   "whm.overheal.hot.name": "Soins sur la durée",
   "whm.overheal.liturgyofthebell.name": "Tintinnabule",
   "whm.swiftcast.missed.suggestion.content": "Lancez un sort avec <0/> avant qu'il n'expire. Cela vous permet d'utiliser un sort instantanément, comme <1/> pour une résurrection rapide ou <2/> pour weave.",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -961,7 +961,6 @@
   "whm.ogcds.suggestions.temperance.content": "被ダメージの軽減や，回復魔法の回復力を上昇させるために，<0/>を積極的に使用しましょう。",
   "whm.ogcds.suggestions.why": "使用可能だった{maxUses} 回中{missed} 回で使用しませんでした。",
   "whm.overheal.afflatus.name": "",
-  "whm.overheal.assize.name": "アサイズ",
   "whm.overheal.hot.name": "HoT",
   "whm.overheal.liturgyofthebell.name": "",
   "whm.swiftcast.missed.suggestion.content": "<0/>の効果時間が切れる前に魔法を使用してください。これにより、素早く組成するための<1/>や、アビリティを挟むための<2/>など、詠唱時間を持つ魔法を無詠唱で使用することができます。",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -961,7 +961,6 @@
   "whm.ogcds.suggestions.temperance.content": "<0/> 기술을 자주 사용하여 광역 피해를 줄이고 글쿨 치유 기술의 위력을 높이십시오. 단, 글쿨이 밀리지 않도록 하십시오.",
   "whm.ogcds.suggestions.why": "총 시전 가능 횟수 {maxUses} 중 {missed}회 놓쳤습니다.",
   "whm.overheal.afflatus.name": "황홀한 마음 치유",
-  "whm.overheal.assize.name": "심판",
   "whm.overheal.hot.name": "지속 치유",
   "whm.overheal.liturgyofthebell.name": "예배종",
   "whm.swiftcast.missed.suggestion.content": "<0/> 지속 시간이 만료되기 전에 기술을 시전하십시오. <1/> 기술로 빠르게 부활하거나 <2/> 기술로 논글쿨 기술을 끼워넣을 수 있습니다.",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -961,7 +961,6 @@
   "whm.ogcds.suggestions.temperance.content": "多使用<0/>进行减伤以及提高GCD治疗的效率。使用时避免卡GCD。",
   "whm.ogcds.suggestions.why": "最多可用 {maxUses} 次，但你少用了大概 {missed} 次。",
   "whm.overheal.afflatus.name": "安慰之心治疗",
-  "whm.overheal.assize.name": "法令",
   "whm.overheal.hot.name": "HoT",
   "whm.overheal.liturgyofthebell.name": "礼仪之铃",
   "whm.swiftcast.missed.suggestion.content": "在<0/>结束之前放一个法术。这样你就可以用<1/>秒拉人或者<2/>来插入能力技。",

--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -126,7 +126,7 @@ export class Overheal extends Analyser {
 	 */
 	protected trackedHealCategories: TrackedOverhealOpts[] = []
 	/**
-	 * Implementing modules MAY override this to provide a list of heal 'categories' to track
+	 * Implementing modules MAY override this to provide a list of healing ids to exclude from overhealing
 	 */
 	protected excludedOverhealIds: number[] = []
 
@@ -240,12 +240,10 @@ export class Overheal extends Analyser {
 	}
 
 	private onHeal(event: Events['heal'], petHeal: boolean = false) {
-
 		if (this.isRegeneration(event) || ! this.considerHeal(event, petHeal)) { return }
 
 		const guid = event.cause.type === 'action' ? event.cause.action : event.cause.status
 		const name = event.cause.type === 'action' ? this.data.getAction(guid)?.name : this.data.getStatus(guid)?.name
-
 		if (this.excludedOverheal.includes(guid)) { return }
 		for (const trackedHeal of this.trackedOverheals) {
 			if (trackedHeal.idIsTracked(guid)) {

--- a/src/parser/jobs/whm/modules/Overheal.tsx
+++ b/src/parser/jobs/whm/modules/Overheal.tsx
@@ -7,7 +7,7 @@ export class Overheal extends CoreOverheal {
 	override checklistRuleBreakout = true
 	override displayPieChart = true
 	override displaySuggestion = true
-
+	override excludedOverhealIds = [this.data.actions.ASSIZE.id]
 	override trackedHealCategories = [
 		{
 			name: <Trans id="whm.overheal.hot.name">Healing Over Time</Trans>,
@@ -19,11 +19,6 @@ export class Overheal extends CoreOverheal {
 				this.data.actions.ASYLUM.id,
 				this.data.statuses.ASYLUM.id,
 			],
-		},
-		{
-			name: <Trans id="whm.overheal.assize.name">Assize</Trans>,
-			color: '#12ba45',
-			trackedHealIds: [this.data.actions.ASSIZE.id],
 		},
 		{
 			name: <Trans id="whm.overheal.liturgyofthebell.name">Liturgy of the Bell</Trans>,


### PR DESCRIPTION
## Exclude Ids from overhealing

Allow Core overhealing modules to exclude a list of spells based on a job by job basis and followed method of implementing protected -> private from the tracked heals.

Would like assistance in verification/jest testing 

Discord Server Name: KerrisFang


