### PR TITLE
Updated sentences 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The parser is the meat of xivanalysis. Its primary job is to orchestrate modules
 
 The modules are split into a number of groups:
 
-- `core`: Unsurprisingly, the core system modules. These provide commonly-used functionality (see the section on dependency below), as well as job-agnostic modules such as "Don't die".
-- `jobs/[job]`: Each supported job has its own group of modules, that provide specialised analysis/information for that job.
-- `bosses/[boss]`: Like jobs, some bosses have groups of modules, usually used to analyse unique fight mechanics, or provide concrete implementations that fflogs does not currently provide itself.
+- `core`:These provide commonly-used functionality (see the section on dependency below), as well as job-agnostic modules such as "Don't die".
+- `jobs/[job]`: Each supported job has its own group of modules. These provide specialised analysis/information for that job.
+- `bosses/[boss]`: Some bosses have groups of modules. They usually used to analyse unique fight mechanics, or provide concrete implementations that fflogs does not provide.
 
 Modules from `core` are loaded first, followed by bosses, then jobs.
 

--- a/docs/patch-checklist.md
+++ b/docs/patch-checklist.md
@@ -33,7 +33,7 @@ Make sure to sanity check the function results, as the underlying algorithm may 
 
 ## Adding encounter overrides
 
-While we generally avoid adding per-boss handling, as it generates increased maintenance burden for the site as a whole, some modules such as `invulnerability` can't account for all possible variations, and occasionally need to be configured.
+Boss handing generates increased maintenance burnen for the site. Some modules such as `invulnerability` can't account for all possible variations, and occasionally need to be configured.
 
 To start, you'll need to add an entry to `src/data/ENCOUNTERS` for the boss - don't feel the need to populate it with _every_ new boss, only the ones we're explicitly adding overrides for. Use community shorthand for the keys, i.e. `P1S` for Erichthonios.
 


### PR DESCRIPTION
Revision 1 

- `core`: Unsurprisingly, the core system modules. These provide commonly-used functionality (see the section on dependency below), as well as job-agnostic modules such as "Don't die".
- `jobs/[job]`: Each supported job has its own group of modules, that provide specialised analysis/information for that job.
- `bosses/[boss]`: Like jobs, some bosses have groups of modules, usually used to analyse unique fight mechanics, or provide concrete implementations that fflogs does not currently provide itself.

Changes 1

- `core`:These provide commonly-used functionality (see the section on dependency below), as well as job-agnostic modules such as "Don't die".
- `jobs/[job]`: Each supported job has its own group of modules. These provide specialised analysis/information for that job.
- `bosses/[boss]`: Some bosses have groups of modules. They usually used to analyse unique fight mechanics, or provide concrete implementations that fflogs does not provide.

URL: https://github.com/Jep4/xivanalysis/blob/endwalker/README.md 

Revision 2
## Adding encounter overrides

While we generally avoid adding per-boss handling, as it generates increased maintenance burden for the site as a whole, some modules such as `invulnerability` can't account for all possible variations, and occasionally need to be configured.


Changes 2

Boss handing generates increased maintenance burnen for the site. Some modules such as `invulnerability` can't account for all possible variations, and occasionally need to be configured.


URL: https://github.com/Jep4/xivanalysis/blob/endwalker/docs/patch-checklist.md 


