### PR TITLE
Bump NIN support to 6.2

### DIFF
--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -69,6 +69,11 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 			[GameEdition.CHINESE]: 1660032000, // 09/08/22 08:00:00 GMT
 		},
 	},
+	'6.2': {
+		date: {
+			[GameEdition.GLOBAL]: 1661248800, // 23/08/22 10:00:00 GMT
+		},
+	},
 })
 
 export type PatchNumber = keyof typeof PATCHES

--- a/src/parser/jobs/nin/index.tsx
+++ b/src/parser/jobs/nin/index.tsx
@@ -14,7 +14,7 @@ export const NINJA = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.05',
-		to: '6.1',
+		to: '6.2',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},

--- a/src/parser/jobs/rdm/index.tsx
+++ b/src/parser/jobs/rdm/index.tsx
@@ -21,7 +21,7 @@ export const RED_MAGE = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.1',
+		to: '6.2',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.LAILLE, role: ROLES.DEVELOPER},


### PR DESCRIPTION
No changelog because there are no changes. NIN was untouched in the 6.2 patch notes so I'm just bumping the version. RDM bump is included as well at Leylia's request since it had no combat changes.