### PR TITLE
Bugfix: DNC missed steps

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -62,4 +62,9 @@ export const changelog = [
 		Changes: () => <>Update proc analysis to handle the separate Flourish and combo-sourced procs.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2022-09-08'),
+		Changes: () => <>Fix a bug preventing missed steps from registering as an error.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -175,7 +175,7 @@ export class DirtyDancing extends Analyser {
 		// Count dance as dirty if we didn't get the expected finisher, and the fight wouldn't have ended or been in an invuln window before we could have
 		if (finisher.action !== dance.expectedFinishId && dance.expectedEndTime <= this.parser.pull.timestamp + this.parser.pull.duration) {
 			this.addTimestampHook(dance.expectedEndTime, ({timestamp}) => {
-				dance.dirty = this.invulnerability.isActive({
+				dance.dirty = !this.invulnerability.isActive({
 					timestamp,
 					types: ['invulnerable'],
 				})


### PR DESCRIPTION
Missed a 'not' when checking whether a dance should be marked dirty based on whether the boss was invulnerable when the dance _should_ have finished if they'd done all the expected steps.