### PR TITLE
[DRG] Fix issue with solo Dragon Sight suggestion appearing all the time

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -409,7 +409,7 @@
   "drg.buffs.suggestions.life-surge.content": "<0/> should be used on <1/>, your highest potency ability, as much as possible. In order to keep <2/> on cooldown, it may sometimes be necessary to use it on a 5th combo hit. In multi-target scenarios, <3/> can be used on <4/> if you hit at least three targets.",
   "drg.buffs.suggestions.life-surge.why": "You used {0} on a non-optimal GCD {1, plural, one {# time} other {# times}}.",
   "drg.buffs.suggestions.solo-ds.content": "Although it doesn't impact your personal DPS, try to always use <0/> on a partner in group content so that someone else can benefit from the damage bonus too.",
-  "drg.buffs.suggestions.solo-ds.why": "At least 1 of your Dragon Sight casts didn't have a tether partner.",
+  "drg.buffs.suggestions.solo-ds.why": "{0} of your Dragon Sight casts didn't have a tether partner.",
   "drg.buffs.title": "Buffs",
   "drg.debuffs.checklist.description": "<0/> provides a potent DoT which should be maintained at all times.",
   "drg.debuffs.checklist.name": "Keep your debuffs up",

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -19,6 +19,11 @@ export const DRAGOON = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-09-20'),
+			Changes: () => <>Corrected an issue that was causing the suggestion for using Dragon Sight on a partner to appear even when it was used on a partner.</>,
+			contributors: [CONTRIBUTORS.FALINDRITH],
+		},
+		{
 			date: new Date('2022-04-24'),
 			Changes: () => <>As of 6.1, weaving any jump (except for Stardiver) is no longer a weaving error. Because of this, we now expect both Spineshatter Dive charges to be used with Dragon Sight windows.</>,
 			contributors: [CONTRIBUTORS.FALINDRITH],

--- a/src/parser/jobs/drg/modules/Buffs.tsx
+++ b/src/parser/jobs/drg/modules/Buffs.tsx
@@ -1,6 +1,6 @@
 import {t} from '@lingui/macro'
 import {Trans, Plural} from '@lingui/react'
-import {ActionLink, StatusLink} from 'components/ui/DbLink'
+import {DataLink} from 'components/ui/DbLink'
 import {ActionKey} from 'data/ACTIONS'
 import {Cause, Event, Events} from 'event'
 import {Analyser} from 'parser/core/Analyser'
@@ -12,7 +12,7 @@ import {Data} from 'parser/core/modules/Data'
 import {Invulnerability} from 'parser/core/modules/Invulnerability'
 import {PieChartStatistic, Statistics} from 'parser/core/modules/Statistics'
 import {Statuses} from 'parser/core/modules/Statuses'
-import Suggestions, {Suggestion, TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
+import Suggestions, {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
@@ -144,12 +144,12 @@ export default class Buffs extends Analyser {
 		this.checklist.add(new Rule({
 			name: <Trans id="drg.buffs.checklist.name">Keep {this.data.statuses.POWER_SURGE.name} up</Trans>,
 			description: <Trans id="drg.buffs.checklist.description">
-				<ActionLink {...this.data.actions.DISEMBOWEL}/> and <ActionLink action="COERTHAN_TORMENT" /> grant <StatusLink status="POWER_SURGE" /> which provides a 10% boost to your personal damage and should always be kept up.
+				<DataLink action="DISEMBOWEL"/> and <DataLink action="COERTHAN_TORMENT" /> grant <DataLink status="POWER_SURGE" /> which provides a 10% boost to your personal damage and should always be kept up.
 			</Trans>,
 			displayOrder: DISPLAY_ORDER.DISEMBOWEL,
 			requirements: [
 				new Requirement({
-					name: <Trans id="drg.buffs.checklist.requirement.name"><StatusLink {...this.data.statuses.POWER_SURGE}/> uptime</Trans>,
+					name: <Trans id="drg.buffs.checklist.requirement.name"><DataLink status="POWER_SURGE" /> uptime</Trans>,
 					percent: () => this.getPowerSurgeUptimePercent(),
 				}),
 			],
@@ -158,7 +158,7 @@ export default class Buffs extends Analyser {
 		this.suggestions.add(new TieredSuggestion({
 			icon: this.data.actions.LIFE_SURGE.icon,
 			content: <Trans id="drg.buffs.suggestions.life-surge.content">
-				<ActionLink {...this.data.actions.LIFE_SURGE}/> should be used on <ActionLink {...this.data.actions.HEAVENS_THRUST}/>, your highest potency ability, as much as possible. In order to keep <ActionLink {...this.data.actions.LIFE_SURGE} /> on cooldown, it may sometimes be necessary to use it on a 5th combo hit. In multi-target scenarios, <ActionLink {...this.data.actions.LIFE_SURGE} /> can be used on <ActionLink {...this.data.actions.COERTHAN_TORMENT} /> if you hit at least three targets.
+				<DataLink action="LIFE_SURGE"/> should be used on <DataLink action="HEAVENS_THRUST"/>, your highest potency ability, as much as possible. In order to keep <DataLink action="LIFE_SURGE" /> on cooldown, it may sometimes be necessary to use it on a 5th combo hit. In multi-target scenarios, <DataLink action="LIFE_SURGE" /> can be used on <DataLink action="COERTHAN_TORMENT" /> if you hit at least three targets.
 			</Trans>,
 			tiers: {
 				1: SEVERITY.MINOR,
@@ -171,18 +171,19 @@ export default class Buffs extends Analyser {
 			</Trans>,
 		}))
 
-		if (this.soloDragonSightCount > 0) {
-			this.suggestions.add(new Suggestion({
-				icon: this.data.actions.DRAGON_SIGHT.icon,
-				content: <Trans id="drg.buffs.suggestions.solo-ds.content">
-					Although it doesn't impact your personal DPS, try to always use <ActionLink {...this.data.actions.DRAGON_SIGHT} /> on a partner in group content so that someone else can benefit from the damage bonus too.
-				</Trans>,
-				severity: SEVERITY.MINOR,
-				why: <Trans id="drg.buffs.suggestions.solo-ds.why">
-					{this.soloDragonSightCount} of your Dragon Sight casts didn't have a tether partner.
-				</Trans>,
-			}))
-		}
+		this.suggestions.add(new TieredSuggestion({
+			icon: this.data.actions.DRAGON_SIGHT.icon,
+			content: <Trans id="drg.buffs.suggestions.solo-ds.content">
+				Although it doesn't impact your personal DPS, try to always use <DataLink action="DRAGON_SIGHT" /> on a partner in group content so that someone else can benefit from the damage bonus too.
+			</Trans>,
+			tiers: {
+				1: SEVERITY.MINOR,
+			},
+			value: this.soloDragonSightCount,
+			why: <Trans id="drg.buffs.suggestions.solo-ds.why">
+				{this.soloDragonSightCount} of your Dragon Sight casts didn't have a tether partner.
+			</Trans>,
+		}))
 
 		// make a lil graph of life surge uses
 		// get total LS casts

--- a/src/parser/jobs/drg/modules/Buffs.tsx
+++ b/src/parser/jobs/drg/modules/Buffs.tsx
@@ -78,7 +78,7 @@ export default class Buffs extends Analyser {
 		const playerFilter = filter<Event>().source(this.parser.actor.id)
 		this.addEventHook(playerFilter.type('action'), this.onCast)
 
-		this.addEventHook(filter<Event>().source(this.parser.actor.id).action(this.data.actions.DRAGON_SIGHT.id), this.onDragonSight)
+		this.addEventHook(playerFilter.action(this.data.actions.DRAGON_SIGHT.id), this.onDragonSight)
 
 		this.addEventHook(playerFilter.type('damage').cause(filter<Cause>().action(this.data.actions.COERTHAN_TORMENT.id)), this.onCot)
 		this.addEventHook('complete', this.onComplete)

--- a/src/parser/jobs/drg/modules/Buffs.tsx
+++ b/src/parser/jobs/drg/modules/Buffs.tsx
@@ -79,7 +79,6 @@ export default class Buffs extends Analyser {
 		this.addEventHook(playerFilter.type('action'), this.onCast)
 
 		this.addEventHook(playerFilter.action(this.data.actions.DRAGON_SIGHT.id), this.onDragonSight)
-
 		this.addEventHook(playerFilter.type('damage').cause(filter<Cause>().action(this.data.actions.COERTHAN_TORMENT.id)), this.onCot)
 		this.addEventHook('complete', this.onComplete)
 
@@ -144,7 +143,7 @@ export default class Buffs extends Analyser {
 		this.checklist.add(new Rule({
 			name: <Trans id="drg.buffs.checklist.name">Keep {this.data.statuses.POWER_SURGE.name} up</Trans>,
 			description: <Trans id="drg.buffs.checklist.description">
-				<DataLink action="DISEMBOWEL"/> and <DataLink action="COERTHAN_TORMENT" /> grant <DataLink status="POWER_SURGE" /> which provides a 10% boost to your personal damage and should always be kept up.
+				<DataLink action="DISEMBOWEL"/> and <DataLink action="SONIC_THRUST" /> grant <DataLink status="POWER_SURGE" /> which provides a 10% boost to your personal damage and should always be kept up.
 			</Trans>,
 			displayOrder: DISPLAY_ORDER.DISEMBOWEL,
 			requirements: [

--- a/src/parser/jobs/drg/modules/Buffs.tsx
+++ b/src/parser/jobs/drg/modules/Buffs.tsx
@@ -78,7 +78,7 @@ export default class Buffs extends Analyser {
 		const playerFilter = filter<Event>().source(this.parser.actor.id)
 		this.addEventHook(playerFilter.type('action'), this.onCast)
 
-		this.addEventHook(filter<Event>().source(this.parser.actor.id).action(this.data.actions.DRAGON_SIGHT.id), this.onDs)
+		this.addEventHook(filter<Event>().source(this.parser.actor.id).action(this.data.actions.DRAGON_SIGHT.id), this.onDragonSight)
 
 		this.addEventHook(playerFilter.type('damage').cause(filter<Cause>().action(this.data.actions.COERTHAN_TORMENT.id)), this.onCot)
 		this.addEventHook('complete', this.onComplete)
@@ -114,7 +114,7 @@ export default class Buffs extends Analyser {
 		}
 	}
 
-	private onDs(event: Events['action']) {
+	private onDragonSight(event: Events['action']) {
 		// self cast
 		if (event.source === event.target) {
 			this.soloDragonSightCount += 1


### PR DESCRIPTION
The suggestion to use Dragon Sight on a partner was showing up constantly due to SE changing the IDs used for Right Eye, presumably after ~~patch 6.08 when they took the visual away from us~~ they fixed the bug where dragon sight goes away when your partner dies in the 6.21 hotfix. This PR fixes it so we're not checking for an ID, but instead are checking to see if we used DS on ourselves and displaying the suggestion accordingly. This works back through patch 6.0.