### PR TITLE
Add bucketing of heals and a nice "ignore" feature

### DIFF
--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -15,9 +15,11 @@ interface SeverityTiers {
 }
 
 interface TrackedOverhealOpts {
+	bucketId?: number
 	name: JSX.Element,
 	color?: string
 	trackedHealIds?: number[],
+	ignore?: boolean
 }
 
 const REGENERATION_ID: number = 1302
@@ -44,6 +46,8 @@ export const SuggestedColors: string[] = [
 ]
 
 export class TrackedOverheal {
+	bucketId: number = -1
+	ignore: boolean
 	name: JSX.Element
 	color: string = '#fff'
 	protected trackedHealIds: number[]
@@ -54,6 +58,8 @@ export class TrackedOverheal {
 		this.name = opts.name
 		this.color = opts.color || this.color
 		this.trackedHealIds = opts.trackedHealIds || []
+		this.bucketId = opts.bucketId || -1
+		this.ignore = opts.ignore || false
 	}
 
 	/**
@@ -226,6 +232,16 @@ export class Overheal extends Analyser {
 		return <Trans id="core.overheal.rule.description">Avoid healing your party for more than is needed. Cut back on unnecessary heals and coordinate with your co-healer to plan resources efficiently.</Trans>
 	}
 
+	/**
+	 * This method MAY be overriden to force a heal into a specific bucket for whatever reason
+	 * @param _event - the healing event to consider
+	 * @param _petHeal - whether the heal comes from a pet or not; defaults to false
+	 * @returns a number for the bucket to for a heal into. Return -1 to bucket the heal normally
+	 */
+	protected overrideHealBucket(_event: Events['heal'], _petHeal: boolean = false): number {
+		return -1
+	}
+
 	private isRegeneration(event: Events['heal']): boolean {
 		return event.cause.type === 'action' && event.cause.action === REGENERATION_ID
 	}
@@ -235,6 +251,17 @@ export class Overheal extends Analyser {
 
 		const guid = event.cause.type === 'action' ? event.cause.action : event.cause.status
 		const name = event.cause.type === 'action' ? this.data.getAction(guid)?.name : this.data.getStatus(guid)?.name
+
+		const bucketId = this.overrideHealBucket(event, petHeal)
+		if (bucketId >= 0) {
+			for (const trackedHeal of this.trackedOverheals) {
+				if (trackedHeal.bucketId === bucketId) {
+					this.debug(`Heal ${name} (${guid}) at ${event.timestamp} MANUALLY shoved into bucket ${trackedHeal.name.props.default}`)
+					trackedHeal.pushHeal(event)
+				}
+			}
+			return // return here because you might want to set multiple things with an id to match into multiple categories based on some criteria
+		}
 		for (const trackedHeal of this.trackedOverheals) {
 			if (trackedHeal.idIsTracked(guid)) {
 				this.debug(`Heal from ${name} (${guid}) at ${event.timestamp} matched into category ${trackedHeal.name.props.defaults}`)
@@ -259,7 +286,7 @@ export class Overheal extends Analyser {
 		let overhealtotal = this.direct.overheal
 
 		this.trackedOverheals.forEach(x => {
-			if (x.hasData) {
+			if (!x.ignore && x.hasData) {
 				healtotal += x.heal
 				overhealtotal += x.overheal
 			}
@@ -280,7 +307,7 @@ export class Overheal extends Analyser {
 			}]
 
 			for (const trackedHeal of this.trackedOverheals) {
-				if (trackedHeal.hasData) {
+				if (!trackedHeal.ignore && trackedHeal.hasData) {
 					const percentage = this.percentageOf(trackedHeal.overheal, overhealtotal)
 					data.push({
 						value: percentage,
@@ -315,6 +342,8 @@ export class Overheal extends Analyser {
 				}))
 
 				for (const trackedHeal of this.trackedOverheals) {
+					if (trackedHeal.ignore) { continue }
+
 					requirements.push(new InvertedRequirement({
 						name: trackedHeal.name,
 						percent: trackedHeal.percentInverted,

--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -256,7 +256,7 @@ export class Overheal extends Analyser {
 		if (bucketId >= 0) {
 			for (const trackedHeal of this.trackedOverheals) {
 				if (trackedHeal.bucketId === bucketId) {
-					this.debug(`Heal ${name} (${guid}) at ${event.timestamp} MANUALLY shoved into bucket ${trackedHeal.name.props.default}`)
+					this.debug(`Heal ${name} (${guid}) at ${event.timestamp} MANUALLY shoved into bucket ${trackedHeal.name.props.defaults}`)
 					trackedHeal.pushHeal(event)
 				}
 			}


### PR DESCRIPTION
Attempt 2 of #1122, now with a feature to ignore heals in a bucket. I think a combination of this with manual bucketing, ignoring buckets, and considerHeal will allow flexibility in ignoring heals altogether.

Though, I should be convinced to make `debug = true` show ignored heals somewhere.