### PR TITLE
Small bugfixes for NIN

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -617,7 +617,7 @@
   "nin.ninjutsu.suggestions.aoe-doton.why": "You cast an unoptimized Doton cast {badAoes, plural, one {# time} other {# times}}.",
   "nin.ninjutsu.suggestions.hyoton.content": "Avoid using <0/>, as it's the weakest of the mudra combinations and should typically never be used in raid content.",
   "nin.ninjutsu.suggestions.hyoton.why": "You cast Hyoton {0, plural, one {# time} other {# times}}.",
-  "nin.ninjutsu.suggestions.rabbit.content": "Be careful not to flub your mudras, as using <0/> can cost you personal DPS at best and raid DPS at worst by reducing the number of <1/>s you can do during the fight.",
+  "nin.ninjutsu.suggestions.rabbit.content": "Be careful not to flub your mudras, as using <0/> can cost you considerable DPS by reducing the number of <1/>s you can do during the fight.",
   "nin.ninjutsu.suggestions.rabbit.why": "You cast Rabbit Medium {0, plural, one {# time} other {# times}}.",
   "nin.ninjutsu.suggestions.st-doton.content": "Avoid using <0/> on single targets, as it does less damage than <1/> if any ticks miss and uses more mudras, resulting in more GCD delay for no gain.",
   "nin.ninjutsu.suggestions.st-doton.why": "You cast a single-target Doton {badStds, plural, one {# time} other {# times}}.",

--- a/src/parser/core/modules/Positionals.tsx
+++ b/src/parser/core/modules/Positionals.tsx
@@ -181,6 +181,7 @@ export abstract class Positionals extends Analyser {
 		return new Requirement({
 			name: <ActionLink {...result.positional.action}/>,
 			percent: percent,
+			weight: expected,
 			overrideDisplay: `${actual} / ${expected} (${percent.toFixed(2)}%)`,
 		})
 	}

--- a/src/parser/jobs/nin/index.tsx
+++ b/src/parser/jobs/nin/index.tsx
@@ -21,6 +21,11 @@ export const NINJA = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-09-24'),
+			Changes: () => <>Fixed a bug in the extender-without-Huton suggestion, adjusted severity on the dropped Kassatsu suggestion, corrected text for the Rabbit Medium suggestion.</>,
+			contributors: [CONTRIBUTORS.TOASTDEIB],
+		},
+		{
 			date: new Date('2022-07-19'),
 			Changes: () => <>Updated Mug and Trick Attack for 6.1 changes, adjusted severity on Raiju and Armor Crush suggestions.</>,
 			contributors: [CONTRIBUTORS.TOASTDEIB],

--- a/src/parser/jobs/nin/modules/Huton.tsx
+++ b/src/parser/jobs/nin/modules/Huton.tsx
@@ -97,12 +97,15 @@ export class Huton extends Analyser {
 		this.lastEventTime = event.timestamp
 	}
 
-	private handleHutonExtension(estimate: HutonEstimate, amount: number, elapsedTime: number) {
+	private handleHutonExtension(estimate: HutonEstimate, actionId: number, amount: number, elapsedTime: number) {
 		let newDuration = estimate.current - elapsedTime
 		if (newDuration <= 0) {
 			estimate.current = 0
 			estimate.downtime -= newDuration // Since it's negative, this is basically addition
-			estimate.badAcs++
+			if (actionId === this.data.actions.ARMOR_CRUSH.id) {
+				// Only flag actual Armor Crushes for the badAcs property
+				estimate.badAcs++
+			}
 		} else {
 			newDuration += amount
 			estimate.clipped += Math.max(newDuration - HUTON_MAX_DURATION_MILLIS, 0)
@@ -117,15 +120,16 @@ export class Huton extends Analyser {
 
 		// The .get() should never be undefined but we must appease the ts lint gods
 		const extension = this.hutonExtensionMillis.get(action.id) ?? 0
-		this.handleHutonExtension(this.highEstimate, extension, elapsedTime)
-		this.handleHutonExtension(this.lowEstimate, extension, elapsedTime)
+		this.handleHutonExtension(this.highEstimate, action.id, extension, elapsedTime)
+		this.handleHutonExtension(this.lowEstimate, action.id, extension, elapsedTime)
 		this.lastEventTime = event.timestamp
 	}
 
 	private onKamaitachi(event: Events['damage']) {
 		const elapsedTime = (event.timestamp - this.lastEventTime)
-		this.handleHutonExtension(this.highEstimate, HUTON_EXTENSION_SHORT, elapsedTime)
-		this.handleHutonExtension(this.lowEstimate, HUTON_EXTENSION_SHORT, elapsedTime)
+		const action = this.data.getAction(event.action)
+		this.handleHutonExtension(this.highEstimate, action.id, HUTON_EXTENSION_SHORT, elapsedTime)
+		this.handleHutonExtension(this.lowEstimate, action.id, HUTON_EXTENSION_SHORT, elapsedTime)
 		this.lastEventTime = event.timestamp
 	}
 

--- a/src/parser/jobs/nin/modules/Huton.tsx
+++ b/src/parser/jobs/nin/modules/Huton.tsx
@@ -127,8 +127,8 @@ export class Huton extends Analyser {
 
 	private onKamaitachi(event: Events['damage']) {
 		const elapsedTime = (event.timestamp - this.lastEventTime)
-		this.handleHutonExtension(this.highEstimate, this.data.actions.HURAIJIN.id, HUTON_EXTENSION_SHORT, elapsedTime)
-		this.handleHutonExtension(this.lowEstimate, this.data.actions.HURAIJIN.id, HUTON_EXTENSION_SHORT, elapsedTime)
+		this.handleHutonExtension(this.highEstimate, this.data.actions.PHANTOM_KAMAITACHI_BUNSHIN.id, HUTON_EXTENSION_SHORT, elapsedTime)
+		this.handleHutonExtension(this.lowEstimate, this.data.actions.PHANTOM_KAMAITACHI_BUNSHIN.id, HUTON_EXTENSION_SHORT, elapsedTime)
 		this.lastEventTime = event.timestamp
 	}
 

--- a/src/parser/jobs/nin/modules/Huton.tsx
+++ b/src/parser/jobs/nin/modules/Huton.tsx
@@ -127,9 +127,8 @@ export class Huton extends Analyser {
 
 	private onKamaitachi(event: Events['damage']) {
 		const elapsedTime = (event.timestamp - this.lastEventTime)
-		const action = this.data.getAction(event.action)
-		this.handleHutonExtension(this.highEstimate, action.id, HUTON_EXTENSION_SHORT, elapsedTime)
-		this.handleHutonExtension(this.lowEstimate, action.id, HUTON_EXTENSION_SHORT, elapsedTime)
+		this.handleHutonExtension(this.highEstimate, this.data.actions.HURAIJIN.id, HUTON_EXTENSION_SHORT, elapsedTime)
+		this.handleHutonExtension(this.lowEstimate, this.data.actions.HURAIJIN.id, HUTON_EXTENSION_SHORT, elapsedTime)
 		this.lastEventTime = event.timestamp
 	}
 

--- a/src/parser/jobs/nin/modules/Kassatsu.tsx
+++ b/src/parser/jobs/nin/modules/Kassatsu.tsx
@@ -60,7 +60,7 @@ export class Kassatsu extends Analyser {
 				content: <Trans id="nin.kassatsu.suggestions.waste.content">
 					Be careful not to let <ActionLink action="KASSATSU"/> fall off, as it wastes a 30% potency buff and means that you're delaying your Ninjutsu casts significantly.
 				</Trans>,
-				severity: SEVERITY.MEDIUM,
+				severity: SEVERITY.MAJOR,
 				why: <Trans id="nin.kassatsu.suggestions.waste.why">
 					You allowed Kassatsu to fall off <Plural value={this.kassatsuWastes} one="# time" other="# times"/>.
 				</Trans>,

--- a/src/parser/jobs/nin/modules/Ninjutsu.tsx
+++ b/src/parser/jobs/nin/modules/Ninjutsu.tsx
@@ -106,7 +106,7 @@ export class Ninjutsu extends Analyser {
 		this.suggestions.add(new TieredSuggestion({
 			icon: this.data.actions.RABBIT_MEDIUM.icon,
 			content: <Trans id="nin.ninjutsu.suggestions.rabbit.content">
-				Be careful not to flub your mudras, as using <ActionLink action="RABBIT_MEDIUM"/> can cost you personal DPS at best and raid DPS at worst by reducing the number of <ActionLink action="TRICK_ATTACK"/>s you can do during the fight.
+				Be careful not to flub your mudras, as using <ActionLink action="RABBIT_MEDIUM"/> can cost you considerable DPS by reducing the number of <ActionLink action="TRICK_ATTACK"/>s you can do during the fight.
 			</Trans>,
 			tiers: {
 				1: SEVERITY.MEDIUM, // You were having a bad day, mudra lag, etc.


### PR DESCRIPTION
Fixes include:

- An actual bug in the Huton module that was flagging _any_ Huton extender as Armor Crush if used when Huton wasn't active
- Bumping the severity of dropped Kassatsu from Medium to Major
- Inaccurate text on the Rabbit Medium suggestion that suggested Trick was still a raid buff
- Weighting the calculation in the Positionals module so every action is treated the same, rather than averaging the percents for each individual action