### PR TITLE
Potential bugfix for weaves that go on after death

### DIFF
--- a/src/parser/core/modules/Weaving.tsx
+++ b/src/parser/core/modules/Weaving.tsx
@@ -71,6 +71,7 @@ export class Weaving extends Analyser {
 		this.addEventHook(playerFilter.type('prepare'), this.onBeginCast)
 		this.addEventHook(playerFilter.type('action'), this.onCast)
 		this.addEventHook(filter<Event>().type('complete'), this.onComplete)
+		this.addEventHook(filter<Event>().type('death'), this.clearWeave)
 	}
 
 	private onBeginCast(event: Events['prepare']) {
@@ -177,6 +178,17 @@ export class Weaving extends Analyser {
 		const recast = ((weave.leadingGcdEvent != null) ? this.castTime.recastForEvent(weave.leadingGcdEvent) : undefined) ?? BASE_GCD
 		// Check the downtime-adjusted GCD time difference for this weave - do not treat multiple weaves during downtime as bad weaves
 		return weave.gcdTimeDiff > recast && weaveCount > this.getMaxWeaves(weave)
+	}
+
+	private clearWeave() {
+		// prompts saving any existing weaves if they're bad, and reset
+		if (this.weaves.length > 0) {
+			this.saveIfBad()
+		}
+
+		// remove existing weaves and pretend the next leadingGcdEvent is like a fresh start (which I guess it is)
+		this.weaves = []
+		this.leadingGcdEvent = undefined
 	}
 
 	/**


### PR DESCRIPTION
...zombie jokes aside, [this](https://www.fflogs.com/reports/a:q64tW7PkHy2VXmDN#fight=4) parse has a death where:

* The MCH did a GCD, then two oGCDs (which is correct)
* Died
* Revived and used two *more* oGCDs (which, in theory, is still correct for whatever reason)
* Used a GCD, which triggers the weaving module to ding them for 24 seconds of weaves

Now, I'm no expert on core weaving, but I think this fixes the issue (or at least opens the door to you judging me harshly until I fix the issue).