### PR TITLE
Bugfix - Improve accuracy of 'expected finish' check

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -54,7 +54,7 @@ export const changelog = [
 	},
 	{
 		date: new Date('2022-02-16'),
-		Changes: () => <>Improved accuracy of Esprit gauge generation simulation</>,
+		Changes: () => <>Improved accuracy of Esprit gauge generation simulation.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 	{
@@ -65,6 +65,11 @@ export const changelog = [
 	{
 		date: new Date('2022-09-08'),
 		Changes: () => <>Fix a bug preventing missed steps from registering as an error.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2022-09-30'),
+		Changes: () => <>Fix a bug that could improperly mark Quadruple Technical Finish as wrong if Technical Step was started before the pull.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 ]

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -43,15 +43,24 @@ class Dance {
 
 	public get expectedFinishId(): number {
 		const actualFinish = _.last(this.rotation)
-		let expectedFinish = -1
-		if (actualFinish) {
-			if (this.initiatingStep.action === this.data.actions.TECHNICAL_STEP.id) {
-				expectedFinish =  this.data.actions.QUADRUPLE_TECHNICAL_FINISH.id
-			} else if (this.initiatingStep.action === this.data.actions.STANDARD_STEP.id) {
-				expectedFinish = this.data.actions.DOUBLE_STANDARD_FINISH.id
-			}
+
+		// Bail if something's wrong
+		if (actualFinish == null) { return -1 }
+
+		// If the player actually finished with one of the two expected finishes, just return that
+		if (actualFinish.action === this.data.actions.QUADRUPLE_TECHNICAL_FINISH.id ||
+			actualFinish.action === this.data.actions.DOUBLE_STANDARD_FINISH.id) {
+			return actualFinish.action
 		}
-		return expectedFinish
+
+		// If the player messed up Standard Step, return Double Standard Finish
+		if (actualFinish.action === this.data.actions.STANDARD_FINISH.id ||
+			actualFinish.action === this.data.actions.SINGLE_STANDARD_FINISH.id) {
+			return this.data.actions.DOUBLE_STANDARD_FINISH.id
+		}
+
+		// Process of elimination, they messed up Technical so return Quadruple Technical Finish
+		return this.data.actions.QUADRUPLE_TECHNICAL_FINISH.id
 	}
 
 	public get expectedEndTime(): number {


### PR DESCRIPTION
Bug was reported that a Quadruple Technical Finish was being flagged as having the wrong number of steps:
https://xivanalysis.com/fflogs/qzJ9Wvrny14xAXmH/1/9

In this case the log was started late, but this could technically (har) apply to any pre-pull Technical Finish. The check that figures out what finish was expected went off the action that opened the window, which is expected to be the Step, but in this case was also Quadruple Technical Finish since it was the first action in the log.

Fixing the getter to just return the actual finisher if it's the Double Standard or Quad Technical, and to determine the proper finisher based on the actual finisher, instead of the assumed starter.