### PR TITLE
Updated Dark Knight to be supported with 6.2

### DIFF
--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -18,11 +18,12 @@ export const DARK_KNIGHT = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.1',
+		to: '6.2',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AZARIAH, role: ROLES.MAINTAINER},
 		{user: CONTRIBUTORS.AY, role: ROLES.DEVELOPER},
+		{user: CONTRIBUTORS.STYRFIRE, role: ROLES.DEVELOPER},
 	],
 	changelog: [
 		{


### PR DESCRIPTION
The only change for 6.2 to Dark Knight was lowering Living Dead's effect duration from 24 to 20 seconds and potency changes. (https://na.finalfantasyxiv.com/lodestone/topics/detail/6eee1ca8a733856669d901d95d2fa9db46a466e6/)