### PR TITLE
RPR - Add soul reaver as applied status to appropriate actions

### DIFF
--- a/src/data/ACTIONS/root/RPR.ts
+++ b/src/data/ACTIONS/root/RPR.ts
@@ -297,6 +297,7 @@ export const RPR = ensureActions({
 		name: 'Blood Stalk',
 		icon: 'https://xivapi.com/i/003000/003617.png',
 		cooldown: 1000,
+		statusesApplied: ['SOUL_REAVER'],
 	},
 
 	UNVEILED_GALLOWS: {
@@ -318,5 +319,6 @@ export const RPR = ensureActions({
 		name: 'Grim Swathe',
 		icon: 'https://xivapi.com/i/003000/003620.png',
 		cooldown: 1000,
+		statusesApplied: ['SOUL_REAVER'],
 	},
 })


### PR DESCRIPTION
Fixes a bug where Gluttony gets erroneously synthed prepull. 