### PR TITLE
DRG: 6.3 support

### DIFF
--- a/src/data/ACTIONS/layers/patch6.3.ts
+++ b/src/data/ACTIONS/layers/patch6.3.ts
@@ -6,5 +6,7 @@ export const patch630: Layer<ActionRoot> = {
 	data: {
 		//WHM - Assize CD change
 		ASSIZE: {cooldown: 40000},
+		//DRG - Life Surge CD change
+		LIFE_SURGE: {cooldown: 40000},
 	},
 }

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -12,7 +12,7 @@ export const DRAGOON = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.2',
+		to: '6.3',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.FALINDRITH, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Just the life surge cooldown. No analysis changes right now, possible that we'll start enforcing use of life surge during buff windows with the better alignment in the future.