### PR TITLE
DNC - 6.3 bump and bugfix

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -72,4 +72,9 @@ export const changelog = [
 		Changes: () => <>Fix a bug that could improperly mark Quadruple Technical Finish as wrong if Technical Step was started before the pull.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2023-01-15'),
+		Changes: () => <>Fix a bug where fights with unavoidable downtime could report Standard Step uptime as a negative percentage.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/dnc/index.tsx
+++ b/src/parser/jobs/dnc/index.tsx
@@ -25,7 +25,7 @@ export const DANCER = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.2',
+		to: '6.3',
 	},
 
 	contributors: [

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -214,8 +214,8 @@ export class DirtyDancing extends Analyser {
 
 	private getStatusUptimePercent(statusKey: StatusKey): number {
 		// Exclude downtime from both the status time and expected uptime
-		const statusTime = this.statuses.getUptime(statusKey, this.actors.friends) - this.downtime.getDowntime()
-		const uptime = this.parser.currentDuration - this.downtime.getDowntime()
+		const statusTime = Math.max(this.statuses.getUptime(statusKey, this.actors.friends) - this.downtime.getDowntime(), 0)
+		const uptime = Math.max(this.parser.currentDuration - this.downtime.getDowntime(), 0)
 
 		return (statusTime / uptime) * 100
 	}


### PR DESCRIPTION
DNC had no notable changes to analysis
Technically we got new icons for some (all?) of the proc statuses, but they reside at the same xivapi URLs as they did before, so no change needed.

Also fixing a bug where fights with downtime would show the uptime percentage for Standard Finish and/or Closed Position as negative if the uptime was less than the total downtime of the fight.