### PR TITLE
Add types and ignore cases for new fflogs events

### DIFF
--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -326,6 +326,12 @@ exports[`Event adapter individual events adapts encounterend 1`] = `Array []`;
 
 exports[`Event adapter individual events adapts encounterstart 1`] = `Array []`;
 
+exports[`Event adapter individual events adapts gaugeupdate 1`] = `Array []`;
+
+exports[`Event adapter individual events adapts headmarker 1`] = `Array []`;
+
+exports[`Event adapter individual events adapts headmarker 2`] = `Array []`;
+
 exports[`Event adapter individual events adapts heal 1`] = `
 Array [
   Object {
@@ -642,6 +648,8 @@ Array [
   },
 ]
 `;
+
+exports[`Event adapter individual events adapts tether 1`] = `Array []`;
 
 exports[`Event adapter individual events adapts unknown 1`] = `Array []`;
 

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -4,7 +4,7 @@ import {Actor, Pull, Report, Team} from 'report'
 import {adaptEvents} from '../eventAdapter'
 import {AdapterStep} from '../eventAdapter/base'
 import {ReassignUnknownActorStep} from '../eventAdapter/reassignUnknownActor'
-import {CastEvent, CombatantInfoAura, DamageEvent, FflogsEvent, HitType, ReportLanguage} from '../eventTypes'
+import {ActorType, CastEvent, CombatantInfoAura, DamageEvent, FflogsEvent, HitType, ReportLanguage} from '../eventTypes'
 
 // "Mock" the reassign unknown actor step with its real implementation. We use this mock handling later
 // to disable the step on a test-by-test basis.
@@ -804,6 +804,74 @@ const fakeEvents: Record<FflogsEvent['type'], FflogsEvent[]> = {
 			facing: -158,
 			absorb: 52,
 		},
+	}],
+	headmarker: [{
+		timestamp: 1794311,
+		type: 'headmarker',
+		sourceID: 106,
+		sourceIsFriendly: true,
+		target: {
+			name: 'Environment',
+			id: -1,
+			guid: 0,
+			type: ActorType.NPC,
+			icon: 'NPC',
+		},
+		targetIsFriendly: false,
+		ability: {
+			name: 'Unknown Ability',
+			guid: 0,
+			type: 0,
+			abilityIcon: '000000-000405.png',
+		},
+		markerID: 328,
+	}, {
+		timestamp: 1456535,
+		type: 'headmarker',
+		sourceID: 107,
+		sourceIsFriendly: true,
+		target: {
+			name: 'Environment',
+			id: -1,
+			guid: 0,
+			type: ActorType.NPC,
+			icon: 'NPC',
+		},
+		targetIsFriendly: false,
+		ability: {
+			name: 'Unknown Ability',
+			guid: 0,
+			type: 0,
+			abilityIcon: '000000-000405.png',
+		},
+		markerID: 86,
+		markerType: 'dice8',
+		markerDuration: 9000,
+	}],
+	tether: [{
+		timestamp: 1822478,
+		type: 'tether',
+		sourceID: 109,
+		sourceIsFriendly: true,
+		targetID: 104,
+		targetIsFriendly: true,
+		ability: {
+			name: 'Unknown Ability',
+			guid: 0,
+			type: 0,
+			abilityIcon: '000000-000405.png',
+		},
+		tetherID: 202,
+	}],
+	gaugeupdate: [{
+		...fakeBaseFields,
+		timestamp: 1800638,
+		type: 'gaugeupdate',
+		gaugeID: '10331D9A',
+		data1: '1C',
+		data2: '50',
+		data3: 'E0000000',
+		data4: '00',
 	}],
 }
 

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -97,6 +97,8 @@ export class TranslateAdapterStep extends AdapterStep {
 			return this.adaptCombatantInfoEvent(baseEvent)
 
 		/* eslint-disable no-fallthrough */
+		// TODO: This could be _really_ useful. Like, combatantinfo tier useful but even more so. But it will require non-trivial consideration around how we want to approach the data itself.
+		case 'gaugeupdate':
 		// Dispels are already modelled by other events, and aren't something we really care about
 		case 'dispel':
 		// FFLogs computed value, could be useful in the future for shield healing analysis.
@@ -118,6 +120,9 @@ export class TranslateAdapterStep extends AdapterStep {
 		// Could be interesting to do something with, but not important for analysis
 		case 'worldmarkerplaced':
 		case 'worldmarkerremoved':
+		// Seem to be representation of mechanics - interesting data, but likely not useful for analysis without in-depth per-fight logic.
+		case 'headmarker':
+		case 'tether':
 		// Not My Problem™️
 		case 'checksummismatch':
 		// New event type from unreleased (as of 2021/04/26) fflogs client. Doesn't contain anything useful.

--- a/src/reportSources/legacyFflogs/eventTypes.ts
+++ b/src/reportSources/legacyFflogs/eventTypes.ts
@@ -270,6 +270,15 @@ export interface WorldMarkerRemovedEvent extends BaseEventFields {
 	icon: number
 }
 
+export interface GaugeUpdateEvent extends BaseEventFields {
+	type: 'gaugeupdate',
+	gaugeID: string,
+	data1: string,
+	data2: string,
+	data3: string,
+	data4: string,
+}
+
 /* End no source/target */
 
 export interface CombatantInfoAura {
@@ -317,6 +326,18 @@ export interface DispelEvent extends AbilityEventFields {
 export interface InterruptEvent extends AbilityEventFields {
 	type: 'interrupt'
 	extraAbility: Ability
+}
+
+export interface HeadMarkerEvent extends AbilityEventFields {
+	type: 'headmarker',
+	markerID: number,
+	markerDuration?: number,
+	markerType?: 'stack' | 'circle' | 'donut' | `dice${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8}`,
+}
+
+export interface TetherEvent extends AbilityEventFields {
+	type: 'tether',
+	tetherID: number
 }
 
 const castEventTypes = [
@@ -413,6 +434,8 @@ export type AbilityEvent =
 	| TargetabilityUpdateEvent
 	| DispelEvent
 	| InterruptEvent
+	| HeadMarkerEvent
+	| TetherEvent
 
 export type FflogsEvent =
 	| EncounterEvent
@@ -425,6 +448,7 @@ export type FflogsEvent =
 	| WipeCalledEvent
 	| WorldMarkerPlacedEvent
 	| WorldMarkerRemovedEvent
+	| GaugeUpdateEvent
 	| MapChangeEvent
 	| CombatantInfoEvent
 	| InstanceSealUpdateEvent


### PR DESCRIPTION
While two of these events are pretty ignoreable for our purposes, `gaugeupdate` is very interesting, and might be worth further research to work out how we want to approach it, and how we can deal with it's absence.

Suffice to say that it acts much the same as the combatant info, only sending data for the logging player.

