### PR TITLE
Add local machine caching for fflogs requests

### DIFF
--- a/src/reportSources/legacyFflogs/fflogsApi.ts
+++ b/src/reportSources/legacyFflogs/fflogsApi.ts
@@ -1,7 +1,9 @@
 import {ReportProcessingError} from 'errors'
-import ky, {Options} from 'ky'
+import ky, {Options, Hooks} from 'ky'
 import {Fight,  ReportEventsQuery, ReportEventsResponse} from './eventTypes'
 import {Report} from './legacyStore'
+
+const FROM_CACHE_HEADER = '__from-cache'
 
 const options: Options = {
 	prefixUrl: process.env.REACT_APP_FFLOGS_V1_BASE_URL,
@@ -18,21 +20,55 @@ if (process.env.REACT_APP_FFLOGS_V1_API_KEY) {
 // Core API via ky
 export const fflogsApi = ky.create(options)
 
-function fetchEvents(code: string, searchParams: Record<string, string | number | boolean>) {
+function createCacheHooks(cache: Cache): Hooks {
+	return {
+		// Before sending a request, try to fetch it from the cache.
+		beforeRequest: [
+			async request => {
+				const cachedResponse = await cache.match(request)
+				// If we got a cached response, mark it so we don't try to re-cache it later.
+				cachedResponse?.headers.append(FROM_CACHE_HEADER, 'true')
+				return cachedResponse
+			},
+		],
+
+		afterResponse: [
+			(request, _options, response) => {
+				// If the respone was fetched from cache, don't need to do anything.
+				if (response.headers.has(FROM_CACHE_HEADER)) {
+					return
+				}
+
+				// Save successful responses to the cache
+				if (response.ok) {
+					cache.put(request, response)
+				}
+			},
+		],
+	}
+}
+
+function fetchEvents(
+	code: string,
+	searchParams: Record<string, string | number | boolean>,
+	cache: Cache
+) {
 	return fflogsApi.get(
 		`report/events/${code}`,
-		{searchParams},
+		{searchParams, hooks: createCacheHooks(cache)},
 	).json<ReportEventsResponse>()
 }
 
 async function requestEvents(
 	code: string,
 	query: ReportEventsQuery,
+	cache: Cache
 ) {
 	const searchParams = query as Record<string, string | number | boolean>
 	let response = await fetchEvents(
 		code,
 		searchParams,
+		cache
 	)
 
 	// If it's blank, try again, bypassing the cache
@@ -40,6 +76,7 @@ async function requestEvents(
 		response = await fetchEvents(
 			code,
 			{...searchParams, bypassCache: 'true'},
+			cache
 		)
 	}
 
@@ -63,6 +100,9 @@ export async function getFflogsEvents(
 ) {
 	const {code} = report
 
+	// Grab the cache storage we'll be using for requests
+	const cache = await getCache(report)
+
 	// Base parameters
 	const searchParams: ReportEventsQuery = {
 		start: fight.start_time,
@@ -71,16 +111,39 @@ export async function getFflogsEvents(
 	}
 
 	// Initial data request
-	let data = await requestEvents(code, searchParams)
+	let data = await requestEvents(code, searchParams, cache)
 	const events = data.events
 
 	// Handle pagination
 	while (data.nextPageTimestamp && data.events.length > 0) {
 		searchParams.start = data.nextPageTimestamp
-		data = await requestEvents(code, searchParams)
+		data = await requestEvents(code, searchParams, cache)
 		events.push(...data.events)
 	}
 
 	// And done
 	return events
+}
+
+async function getCache(report: Report) {
+	// This is currently bucketing an entire report at a time. Keep an eye on behavior,
+	// it's relatively easy to tweak this key to increase/decrease bucket size.
+	const key = report.code
+
+	// Grab all the current cache names, as well as the cache we actually want
+	const [keys, cache] = await Promise.all([
+		caches.keys(),
+		caches.open(key),
+	])
+
+	// Delete any caches that aren't the one we requested.
+	for (const cacheKey of keys) {
+		if (cacheKey === key) {
+			continue
+		}
+
+		caches.delete(cacheKey)
+	}
+
+	return cache
 }

--- a/src/reportSources/legacyFflogs/fflogsApi.ts
+++ b/src/reportSources/legacyFflogs/fflogsApi.ts
@@ -22,7 +22,7 @@ if (process.env.REACT_APP_FFLOGS_V1_API_KEY) {
 // Core API via ky
 export const fflogsApi = ky.create(options)
 
-function createCacheHooks(cache: Cache, behavior: CacheBehavior): Hooks {
+export function createCacheHooks(cache: Cache, behavior: CacheBehavior): Hooks {
 	return {
 		// If bypassing the cache, disable beforeRequest to prevent reading from it
 		// - we still want to cache responses.
@@ -114,7 +114,7 @@ export async function getFflogsEvents(
 	const {code} = report
 
 	// Grab the cache storage we'll be using for requests
-	const cache = await getCache(report)
+	const cache = await getCache(report.code)
 
 	// Base parameters
 	const searchParams: ReportEventsQuery = {
@@ -138,10 +138,12 @@ export async function getFflogsEvents(
 	return events
 }
 
-async function getCache(report: Report) {
+export async function getCache(code: Report['code']) {
 	// This is currently bucketing an entire report at a time. Keep an eye on behavior,
 	// it's relatively easy to tweak this key to increase/decrease bucket size.
-	const key = report.code
+	// NOTE: Decreasing size of bucket will require splitting reports into their
+	// own bucket, which will in turn require more nuanced bucket deletion logic.
+	const key = code
 
 	// Grab all the current cache names, as well as the cache we actually want
 	const [keys, cache] = await Promise.all([

--- a/src/reportSources/legacyFflogs/fflogsApi.ts
+++ b/src/reportSources/legacyFflogs/fflogsApi.ts
@@ -38,7 +38,7 @@ export function createCacheHooks(cache: Cache, behavior: CacheBehavior): Hooks {
 
 		afterResponse: [
 			(request, _options, response) => {
-				// If the respone was fetched from cache, don't need to do anything.
+				// If the response was fetched from cache, don't need to do anything.
 				if (response.headers.has(FROM_CACHE_HEADER)) {
 					return
 				}

--- a/src/reportSources/legacyFflogs/legacyStore.ts
+++ b/src/reportSources/legacyFflogs/legacyStore.ts
@@ -5,7 +5,7 @@ import {action, observable, runInAction} from 'mobx'
 import {globalErrorStore} from 'store/globalError'
 import {settingsStore} from 'store/settings'
 import {ProcessedReportFightsResponse, ReportFightsQuery, ReportFightsResponse} from './eventTypes'
-import {fflogsApi} from './fflogsApi'
+import {createCacheHooks, fflogsApi, getCache} from './fflogsApi'
 
 interface UnloadedReport {
 	loading: true
@@ -39,12 +39,14 @@ export class ReportStore {
 
 		let response: ReportFightsResponse
 		try {
+			const cache = await getCache(code)
 			response = await fflogsApi.get(`report/fights/${code}`, {
 				searchParams: {
 					translate: 'true',
 					..._.omitBy(params, _.isNil),
 					...(bypassCache? {bypassCache: 'true'} : {}),
 				},
+				hooks: createCacheHooks(cache, bypassCache ? 'bypass' : 'read'),
 			}).json<ReportFightsResponse>()
 		} catch (e) {
 			// Something's gone wrong, clear report status then dispatch an error

--- a/src/reportSources/legacyFflogs/store.ts
+++ b/src/reportSources/legacyFflogs/store.ts
@@ -67,8 +67,6 @@ export class LegacyFflogsReportStore extends ReportStore {
 		const legacyEvents = await getFflogsEvents(
 			legacyReport,
 			legacyFight,
-			{/* actorid: parseInt(actorId, 10) */},
-			true,
 		)
 
 		return adaptEvents(report, pull, legacyEvents)


### PR DESCRIPTION
title. this pr leverages the browser cache api to store requests related to the currently accessed report. as a result, navigating between actors of a pull will not fire any additional requests, and reports are only loaded once. this is stored between page loads, so refreshing at any point should result in no additional requests, either.

while primarily written in an attempt to help mitigate peak loads on the backend, i imagine this will also _dramatically_ improve developer experience, as auto-reload will no longer risk frustrating 429s.