### PR TITLE
Flag patch 6.3 support for tanks

### DIFF
--- a/src/data/ACTIONS/layers/patch6.3.ts
+++ b/src/data/ACTIONS/layers/patch6.3.ts
@@ -60,5 +60,34 @@ export const patch630: Layer<ActionRoot> = {
 
 		// WAR 6.3 new statuses from actions
 		SHAKE_IT_OFF: {statusesApplied: ['SHAKE_IT_OFF', 'SHAKE_IT_OFF_OVER_TIME']},
+
+		// Tank stance changes
+		DEFIANCE: {cooldown: 2000},
+		GRIT: {cooldown: 2000},
+		ROYAL_GUARD: {cooldown: 2000},
+
+		RELEASE_DEFIANCE: {
+			id: 32066,
+			name: 'Release Defiance',
+			icon: 'https://xivapi.com/i/002000/002572.png',
+			onGcd: false,
+			cooldown: 1000,
+		},
+
+		RELEASE_GRIT: {
+			id: 32067,
+			name: 'Release Grit',
+			icon: 'https://xivapi.com/i/003000/003092.png',
+			onGcd: false,
+			cooldown: 1000,
+		},
+
+		RELEASE_ROYAL_GUARD: {
+			id: 32068,
+			name: 'Release Royal Guard',
+			icon: 'https://xivapi.com/i/003000/003433.png',
+			onGcd: false,
+			cooldown: 1000,
+		},
 	},
 }

--- a/src/data/ACTIONS/layers/patch6.3.ts
+++ b/src/data/ACTIONS/layers/patch6.3.ts
@@ -57,5 +57,8 @@ export const patch630: Layer<ActionRoot> = {
 		PHLEGMA: {cooldown: 40000},
 		PHLEGMA_II: {cooldown: 40000},
 		PHLEGMA_III: {cooldown: 40000},
+
+		// WAR 6.3 new statuses from actions
+		SHAKE_IT_OFF: {statusesApplied: ['SHAKE_IT_OFF', 'SHAKE_IT_OFF_OVER_TIME']},
 	},
 }

--- a/src/data/ACTIONS/root/DRK.ts
+++ b/src/data/ACTIONS/root/DRK.ts
@@ -1,5 +1,6 @@
 import {Attribute} from 'event'
 import {ensureActions} from '../type'
+import {SHARED} from './SHARED'
 
 export const DRK = ensureActions({
 	// -----
@@ -10,6 +11,9 @@ export const DRK = ensureActions({
 		name: 'Grit',
 		icon: 'https://xivapi.com/i/003000/003070.png',
 	},
+
+	RELEASE_GRIT: SHARED.UNKNOWN, // Added in patch 6.3 layer
+
 	// -----
 	// Cooldowns
 	// -----

--- a/src/data/ACTIONS/root/GNB.ts
+++ b/src/data/ACTIONS/root/GNB.ts
@@ -1,5 +1,6 @@
 import {Attribute} from 'event'
 import {ensureActions} from '../type'
+import {SHARED} from './SHARED'
 
 export const GNB = ensureActions({
 	// -----
@@ -216,6 +217,9 @@ export const GNB = ensureActions({
 		onGcd: false,
 		cooldown: 10000,
 	},
+
+	RELEASE_ROYAL_GUARD: SHARED.UNKNOWN, // Added in patch 6.3 layer
+
 	AURORA: {
 		id: 16151,
 		name: 'Aurora',

--- a/src/data/ACTIONS/root/WAR.ts
+++ b/src/data/ACTIONS/root/WAR.ts
@@ -1,5 +1,6 @@
 import {Attribute} from 'event'
 import {ensureActions} from '../type'
+import {SHARED} from './SHARED'
 
 export const WAR = ensureActions({
 	// -----
@@ -241,4 +242,6 @@ export const WAR = ensureActions({
 		cooldownGroup: 3,
 		statusesApplied: ['DEFIANCE'],
 	},
+
+	RELEASE_DEFIANCE: SHARED.UNKNOWN, // Added in patch 6.3 layer
 })

--- a/src/data/STATUSES/layers/patch6.3.ts
+++ b/src/data/STATUSES/layers/patch6.3.ts
@@ -37,5 +37,14 @@ export const patch630: Layer<StatusRoot> = {
 			icon: 'https://xivapi.com/i/012000/012520.png',
 			duration: 30000,
 		},
+
+		// WAR 6.3 changes
+		SHAKE_IT_OFF: {duration: 30000},
+		SHAKE_IT_OFF_OVER_TIME: {
+			id: 2108,
+			name: 'Shake It Off (Over Time)',
+			icon: 'https://xivapi.com/i/012000/012567.png',
+			duration: 15000,
+		},
 	},
 }

--- a/src/data/STATUSES/root/WAR.ts
+++ b/src/data/STATUSES/root/WAR.ts
@@ -1,4 +1,5 @@
 import {ensureStatuses} from '../type'
+import {SHARED} from './SHARED'
 
 export const WAR = ensureStatuses({
 	DEFIANCE: {
@@ -83,6 +84,8 @@ export const WAR = ensureStatuses({
 		icon: 'https://xivapi.com/i/012000/012557.png',
 		duration: 15000,
 	},
+
+	SHAKE_IT_OFF_OVER_TIME: SHARED.UNKNOWN, // Added in patch 6.3 layer
 
 	NASCENT_CHAOS: {
 		id: 1897,

--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -18,7 +18,7 @@ export const DARK_KNIGHT = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.2',
+		to: '6.3',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AZARIAH, role: ROLES.MAINTAINER},

--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -19,7 +19,7 @@ export const GUNBREAKER = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.2',
+		to: '6.3',
 	},
 
 	contributors: [

--- a/src/parser/jobs/war/changelog.tsx
+++ b/src/parser/jobs/war/changelog.tsx
@@ -3,6 +3,13 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-01-28'),
+		Changes: () => <>
+			Add new status Shake it Off (Over Time) for patch 6.3, and add Orogeny to timeline.
+		</>,
+		contributors: [CONTRIBUTORS.AY],
+	},
+	{
 		date: new Date('2022-04-12'),
 		Changes: () => <>
 			Add pre-6.1 Inner Release and Beast gauge handling for the reduced set of stack consumers.

--- a/src/parser/jobs/war/index.tsx
+++ b/src/parser/jobs/war/index.tsx
@@ -16,7 +16,7 @@ export const WARRIOR = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.2',
+		to: '6.3',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AY, role: ROLES.MAINTAINER},

--- a/src/parser/jobs/war/modules/ActionTimeline.ts
+++ b/src/parser/jobs/war/modules/ActionTimeline.ts
@@ -7,9 +7,11 @@ export class ActionTimeline extends CoreActionTimeline {
 		// Buffs
 		'INFURIATE',
 		'INNER_RELEASE',
+
 		// oGCD Damage
-		'UPHEAVAL',
+		['UPHEAVAL', 'OROGENY'],
 		'ONSLAUGHT',
+
 		// Personal Mitigation
 		'VENGEANCE',
 		'RAMPART',
@@ -18,14 +20,17 @@ export class ActionTimeline extends CoreActionTimeline {
 		'THRILL_OF_BATTLE',
 		'EQUILIBRIUM',
 		'HOLMGANG',
+
 		// Party Mitigation
 		'SHAKE_IT_OFF',
 		'REPRISAL',
+
 		// Tank Utility
 		'PROVOKE',
 		'SHIRK',
 		// Stance
 		'DEFIANCE',
+
 		// Disrupt Utility
 		'INTERJECT',
 		'LOW_BLOW',


### PR DESCRIPTION
This PR adds 6.3 support to DRK, GNB, and WAR. The first 2 are pretty trivial, WAR needed an additional new status as well as fixing up an oversight in the action timeline. Changelog entry added for the relevant bits.