### PR TITLE
legacyFflogs/eventTypes.ts: silence a linter warning

### DIFF
--- a/src/reportSources/legacyFflogs/eventTypes.ts
+++ b/src/reportSources/legacyFflogs/eventTypes.ts
@@ -332,7 +332,7 @@ export interface HeadMarkerEvent extends AbilityEventFields {
 	type: 'headmarker',
 	markerID: number,
 	markerDuration?: number,
-	markerType?: 'stack' | 'circle' | 'donut' | `dice${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8}`,
+	markerType?: 'stack' | 'circle' | 'donut' | `dice${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8}`, // eslint-disable-line @typescript-eslint/no-magic-numbers
 }
 
 export interface TetherEvent extends AbilityEventFields {


### PR DESCRIPTION
The linter issue was introduced a couple of months back in 3e5fe8eb5794e1bad with the "skip ci" tag, but now it's causing random PRs to fail, so this just silences the linter for the one line that has issues.

This is what's causing the CI failure in https://github.com/xivanalysis/xivanalysis/pull/1794