### PR TITLE
fix: incorrect null check for twin snakes windows

### DIFF
--- a/src/data/ACTIONS/index.ts
+++ b/src/data/ACTIONS/index.ts
@@ -3,7 +3,7 @@ import {Patch} from 'data/PATCHES'
 import {Report} from 'report'
 import {layers} from './layers'
 import {ActionRoot, ITEM_ID_OFFSET, root} from './root'
-import {Action} from './type'
+import {Action, BonusModifier, BaseModifier} from './type'
 
 const DEFAULT_GCD_CASTTIME = 0
 const DEFAULT_GCD_COOLDOWN = 2500
@@ -43,6 +43,18 @@ export type {Action}
 export function getActions(report: Report) {
 	const patch = new Patch(report.edition, report.timestamp / 1000)
 	return getAppliedData({root, layers, state: {patch: patch}})
+}
+
+export function getBasePotency(action: Action): number {
+	return getPotencyWithMods(action, [], [])
+}
+
+export function getPotencyWithMods(action: Action, bonusModifiers: BonusModifier[], baseModifiers: BaseModifier[]) {
+	return action.potencies?.find(
+		potency =>
+			JSON.stringify(potency.bonusModifiers.sort()) === JSON.stringify(bonusModifiers.sort()) &&
+			JSON.stringify(potency.baseModifiers ? potency.baseModifiers.sort() : []) === JSON.stringify(baseModifiers.sort())
+	)?.value || 0
 }
 
 // Everything below here is temp back compat

--- a/src/data/ACTIONS/layers/patch6.1.ts
+++ b/src/data/ACTIONS/layers/patch6.1.ts
@@ -1,6 +1,7 @@
 import {Layer} from 'data/layer'
 import {ActionRoot} from '../root'
 import {SHARED} from '../root/SHARED'
+import {BonusModifier} from '../type'
 
 export const patch610: Layer<ActionRoot> = {
 	patch: '6.1',
@@ -8,6 +9,36 @@ export const patch610: Layer<ActionRoot> = {
 		// NIN 6.1 raid buff changes
 		TRICK_ATTACK: {statusesApplied: ['TRICK_ATTACK']},
 		MUG: {statusesApplied: ['MUG_VULNERABILITY_UP']},
+		ARMOR_CRUSH: {
+			potencies: [{
+				value: 140,
+				bonusModifiers: [],
+			}, {
+				value: 200,
+				bonusModifiers: [BonusModifier.POSITIONAL],
+			}, {
+				value: 360,
+				bonusModifiers: [BonusModifier.COMBO],
+			}, {
+				value: 420,
+				bonusModifiers: [BonusModifier.POSITIONAL, BonusModifier.COMBO],
+			}],
+		},
+		AEOLIAN_EDGE: {
+			potencies: [{
+				value: 140,
+				bonusModifiers: [],
+			}, {
+				value: 200,
+				bonusModifiers: [BonusModifier.POSITIONAL],
+			}, {
+				value: 380,
+				bonusModifiers: [BonusModifier.COMBO],
+			}, {
+				value: 440,
+				bonusModifiers: [BonusModifier.POSITIONAL, BonusModifier.COMBO],
+			}],
+		},
 
 		// Tank 6.1 cooldown changes
 		DEFIANCE: {cooldown: 3000},
@@ -19,10 +50,34 @@ export const patch610: Layer<ActionRoot> = {
 		HISSATSU_KAITEN: SHARED.UNKNOWN, //Kaiten was removed. But is job critical for pre-6.1 analysis.
 		// Potency buffs, very important, breaks postionals without them.
 		GEKKO: {
-			potency: 330,
+			potencies: [{
+				value: 120,
+				bonusModifiers: [],
+			}, {
+				value: 170,
+				bonusModifiers: [BonusModifier.POSITIONAL],
+			}, {
+				value: 330,
+				bonusModifiers: [BonusModifier.COMBO],
+			}, {
+				value: 370,
+				bonusModifiers: [BonusModifier.POSITIONAL, BonusModifier.COMBO],
+			}],
 		},
 		KASHA: {
-			potency: 330,
+			potencies: [{
+				value: 120,
+				bonusModifiers: [],
+			}, {
+				value: 170,
+				bonusModifiers: [BonusModifier.POSITIONAL],
+			}, {
+				value: 330,
+				bonusModifiers: [BonusModifier.COMBO],
+			}, {
+				value: 380,
+				bonusModifiers: [BonusModifier.POSITIONAL, BonusModifier.COMBO],
+			}],
 		},
 		// DNC 6.1 changes
 		FLOURISH: {

--- a/src/data/ACTIONS/root/DRG.ts
+++ b/src/data/ACTIONS/root/DRG.ts
@@ -1,5 +1,5 @@
 import {Attribute} from 'event'
-import {ensureActions} from '../type'
+import {ensureActions, BonusModifier, PotencySpecialCase} from '../type'
 
 export const DRG = ensureActions({
 	// -----
@@ -95,6 +95,19 @@ export const DRG = ensureActions({
 			from: 87,
 			end: true,
 		},
+		potencies: [{
+			value: 100,
+			bonusModifiers: [],
+		}, {
+			value: 140,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+		}, {
+			value: 260,
+			bonusModifiers: [BonusModifier.COMBO],
+		}, {
+			value: 300,
+			bonusModifiers: [BonusModifier.COMBO, BonusModifier.POSITIONAL],
+		}],
 		statusesApplied: ['CHAOTIC_SPRING'],
 	},
 
@@ -126,6 +139,24 @@ export const DRG = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002582.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
+		potencies: [{
+			value: 260,
+			bonusModifiers: [],
+			baseModifiers: [],
+		}, {
+			value: 300,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: [],
+		}, {
+			// Lance Mastery increases the potency of the 5th hit by 100
+			value: 360,
+			bonusModifiers: [],
+			baseModifiers: [PotencySpecialCase.DRG_LANCE_MASTERY],
+		}, {
+			value: 400,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: [PotencySpecialCase.DRG_LANCE_MASTERY],
+		}],
 	},
 
 	WHEELING_THRUST: {
@@ -134,6 +165,24 @@ export const DRG = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002584.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
+		potencies: [{
+			value: 260,
+			bonusModifiers: [],
+			baseModifiers: [],
+		}, {
+			value: 300,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: [],
+		}, {
+			// Lance Mastery increases the potency of the 5th hit by 100
+			value: 360,
+			bonusModifiers: [],
+			baseModifiers: [PotencySpecialCase.DRG_LANCE_MASTERY],
+		}, {
+			value: 400,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: [PotencySpecialCase.DRG_LANCE_MASTERY],
+		}],
 	},
 
 	RAIDEN_THRUST: {

--- a/src/data/ACTIONS/root/MNK.ts
+++ b/src/data/ACTIONS/root/MNK.ts
@@ -1,5 +1,5 @@
 import {Attribute} from 'event'
-import {ensureActions} from '../type'
+import {ensureActions, BonusModifier} from '../type'
 
 export const MNK = ensureActions({
 	// -----
@@ -12,6 +12,14 @@ export const MNK = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000208.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
+		potencies: [{
+			value: 210,
+			bonusModifiers: [],
+		}, {
+			value: 310,
+			bonusModifiers: [],
+			baseModifiers: ['LEADEN_FIST'],
+		}],
 	},
 
 	TRUE_STRIKE: {
@@ -20,7 +28,10 @@ export const MNK = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000209.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
-		potency: 300,
+		potencies: [{
+			value: 300,
+			bonusModifiers: [],
+		}],
 	},
 
 	SNAP_PUNCH: {
@@ -29,6 +40,13 @@ export const MNK = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000210.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
+		potencies: [{
+			value: 250,
+			bonusModifiers: [],
+		}, {
+			value: 310,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+		}],
 	},
 
 	TWIN_SNAKES: {
@@ -37,8 +55,11 @@ export const MNK = ensureActions({
 		icon: 'https://xivapi.com/i/000000/000213.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
-		potency: 280,
 		statusesApplied: ['DISCIPLINED_FIST'],
+		potencies: [{
+			value: 280,
+			bonusModifiers: [],
+		}],
 	},
 
 	SHADOW_OF_THE_DESTROYER: {
@@ -56,6 +77,13 @@ export const MNK = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
 		statusesApplied: ['DEMOLISH'],
+		potencies: [{
+			value: 70,
+			bonusModifiers: [],
+		}, {
+			value: 130,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+		}],
 	},
 
 	ROCKBREAKER: {
@@ -127,7 +155,10 @@ export const MNK = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
 		statusesApplied: ['FORMLESS_FIST'],
-		potency: 600,
+		potencies: [{
+			value: 600,
+			bonusModifiers: [],
+		}],
 	},
 
 	CELESTIAL_REVOLUTION: {
@@ -137,7 +168,10 @@ export const MNK = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
 		statusesApplied: ['FORMLESS_FIST'],
-		potency: 450,
+		potencies: [{
+			value: 450,
+			bonusModifiers: [],
+		}],
 	},
 
 	RISING_PHOENIX: {
@@ -147,7 +181,10 @@ export const MNK = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
 		statusesApplied: ['FORMLESS_FIST'],
-		potency: 700,
+		potencies: [{
+			value: 700,
+			bonusModifiers: [],
+		}],
 	},
 
 	PHANTOM_RUSH: {

--- a/src/data/ACTIONS/root/NIN.ts
+++ b/src/data/ACTIONS/root/NIN.ts
@@ -1,5 +1,5 @@
 import {Attribute} from 'event'
-import {ensureActions} from '../type'
+import {ensureActions, BonusModifier} from '../type'
 
 export const NIN = ensureActions({
 	// -----
@@ -39,6 +39,19 @@ export const NIN = ensureActions({
 			from: 2242,
 			end: true,
 		},
+		potencies: [{
+			value: 140,
+			bonusModifiers: [],
+		}, {
+			value: 200,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+		}, {
+			value: 360,
+			bonusModifiers: [BonusModifier.COMBO],
+		}, {
+			value: 420,
+			bonusModifiers: [BonusModifier.POSITIONAL, BonusModifier.COMBO],
+		}],
 	},
 
 	DEATH_BLOSSOM: {
@@ -71,6 +84,19 @@ export const NIN = ensureActions({
 			from: 2242,
 			end: true,
 		},
+		potencies: [{
+			value: 140,
+			bonusModifiers: [],
+		}, {
+			value: 200,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+		}, {
+			value: 340,
+			bonusModifiers: [BonusModifier.COMBO],
+		}, {
+			value: 400,
+			bonusModifiers: [BonusModifier.POSITIONAL, BonusModifier.COMBO],
+		}],
 	},
 
 	HAKKE_MUJINSATSU: {
@@ -375,6 +401,13 @@ export const NIN = ensureActions({
 		onGcd: false,
 		cooldown: 60000,
 		statusesApplied: ['TRICK_ATTACK_VULNERABILITY_UP'],
+		potencies: [{
+			value: 300,
+			bonusModifiers: [],
+		}, {
+			value: 400,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+		}],
 	},
 
 	SHADE_SHIFT: {

--- a/src/data/ACTIONS/root/RPR.ts
+++ b/src/data/ACTIONS/root/RPR.ts
@@ -1,5 +1,5 @@
 import {Attribute} from 'event'
-import {ensureActions} from '../type'
+import {ensureActions, BonusModifier} from '../type'
 
 export const RPR = ensureActions({
 	// -----
@@ -166,6 +166,23 @@ export const RPR = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
 		statusesApplied: ['ENHANCED_GIBBET'],
+		potencies: [{
+			value: 400,
+			bonusModifiers: [],
+			baseModifiers: [],
+		}, {
+			value: 460,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: [],
+		}, {
+			value: 460,
+			bonusModifiers: [],
+			baseModifiers: ['ENHANCED_GALLOWS'],
+		}, {
+			value: 520,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: ['ENHANCED_GALLOWS'],
+		}],
 	},
 
 	GIBBET: {
@@ -175,6 +192,23 @@ export const RPR = ensureActions({
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
 		statusesApplied: ['ENHANCED_GALLOWS'],
+		potencies: [{
+			value: 400,
+			bonusModifiers: [],
+			baseModifiers: [],
+		}, {
+			value: 460,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: [],
+		}, {
+			value: 460,
+			bonusModifiers: [],
+			baseModifiers: ['ENHANCED_GIBBET'],
+		}, {
+			value: 520,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: ['ENHANCED_GIBBET'],
+		}],
 	},
 
 	GUILLOTINE: {

--- a/src/data/ACTIONS/root/SAM.ts
+++ b/src/data/ACTIONS/root/SAM.ts
@@ -1,5 +1,5 @@
 import {Attribute} from 'event'
-import {ensureActions} from '../type'
+import {ensureActions, BonusModifier} from '../type'
 
 // Samurai Actions
 
@@ -82,7 +82,19 @@ export const SAM = ensureActions({
 		icon: 'https://xivapi.com/i/003000/003158.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
-		potency: 320,
+		potencies: [{
+			value: 100,
+			bonusModifiers: [],
+		}, {
+			value: 150,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+		}, {
+			value: 320,
+			bonusModifiers: [BonusModifier.COMBO],
+		}, {
+			value: 370,
+			bonusModifiers: [BonusModifier.POSITIONAL, BonusModifier.COMBO],
+		}],
 		combo: {
 			from: 7478,
 			end: true,
@@ -117,7 +129,19 @@ export const SAM = ensureActions({
 		icon: 'https://xivapi.com/i/003000/003164.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
-		potency: 320,
+		potencies: [{
+			value: 100,
+			bonusModifiers: [],
+		}, {
+			value: 150,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+		}, {
+			value: 320,
+			bonusModifiers: [BonusModifier.COMBO],
+		}, {
+			value: 370,
+			bonusModifiers: [BonusModifier.POSITIONAL, BonusModifier.COMBO],
+		}],
 		combo: {
 			from: 7479,
 			end: true,

--- a/src/data/ACTIONS/type.ts
+++ b/src/data/ACTIONS/type.ts
@@ -1,3 +1,4 @@
+import {StatusKey} from 'data/STATUSES'
 import {StatusRoot} from 'data/STATUSES/root'
 import {Attribute} from 'event'
 import {ensureRecord} from 'utilities/typescript'
@@ -8,6 +9,34 @@ export type ActionCombo =
 		| {from: number | number[], start?: never}
 	)
 	& {end?: true}
+
+// Currently whether it's rear or flank doesn't matter.
+export enum BonusModifier {
+	COMBO,
+	POSITIONAL,
+}
+
+// DRG lance mastery is a special case hidden field that
+// augments the potency of the 5th hit.
+export enum PotencySpecialCase {
+	DRG_LANCE_MASTERY,
+}
+
+// When calculating the bonusPercent that the game uses to display
+// combo and positional success, BonusModifiers are the modifiers that
+// will increase the percent. Statuses from jobs like RPR and DRG
+// modify the base.
+export type BaseModifier = PotencySpecialCase | StatusKey
+
+// Potency is modeled this way because any single potency number
+// can have a combination of states that apply to it, see all
+// of the commented out PotencyModifiers. An empty modifier
+// list means it's the base potency.
+export interface Potency {
+	value: number,
+	baseModifiers?: BaseModifier[]
+	bonusModifiers: BonusModifier[]
+}
 
 export interface Action {
 	id: number
@@ -26,6 +55,7 @@ export interface Action {
 	mpCost?: number
 	/** Indicate whether this action's recast is adjusted by skill speed or spell speed.  Should be set for any onGCD skill or gcd-like skill that has a reduced recast based on speed stats */
 	speedAttribute?: Attribute.SKILL_SPEED | Attribute.SPELL_SPEED
+	potencies?: Potency[]
 	// TODO: Do I need this still?
 	// [key: string]: unknown
 }

--- a/src/parser/core/modules/Positionals.tsx
+++ b/src/parser/core/modules/Positionals.tsx
@@ -1,7 +1,8 @@
 import {t} from '@lingui/macro'
 import {Trans} from '@lingui/react'
 import {ActionLink, DataLink} from 'components/ui/DbLink'
-import {Action} from 'data/ACTIONS'
+import {Action, getPotencyWithMods, getBasePotency} from 'data/ACTIONS'
+import {BonusModifier} from 'data/ACTIONS/type'
 import {Event, Events} from 'event'
 import {filter} from 'parser/core/filter'
 import {dependency} from 'parser/core/Injectable'
@@ -14,38 +15,9 @@ import {Analyser} from '../Analyser'
 import {Data} from './Data'
 
 export interface PositionalResult {
-	positional: Positional,
+	positional: Action,
 	hits: Array<Events['damage']>,
 	misses: Array<Events['damage']>
-}
-
-// The commented out enums are unused because only plain combo actions
-// are required for the positional checking to work for now.
-// "NONE" or "BASE" was considered as a modifier, but it could result in
-// invalid states like [NONE, COMBO] that need to be checked.
-export enum PotencyModifier {
-	COMBO,
-	// POSITIONAL,
-	// DRG_LANCE_MASTERY,
-	// RPR_ENHANCED_REAVE,
-}
-
-// Potency is modeled this way because any single potency number
-// can have a combination of states that apply to it, see all
-// of the commented out PotencyModifiers. An empty modifier
-// list means it's the base potency.
-interface Potency {
-	value: number,
-	modifiers: PotencyModifier[]
-}
-
-// The absence of potencies current means that it does NOT have combo actions,
-// because in order to detect positionals, checking combo non-positional
-// potencies is sufficient. For full potency modeling, potencies
-// should not be optional.
-interface Positional {
-	action: Action,
-	potencies?: Potency[]
 }
 
 const NO_BONUS_PERCENT = 0
@@ -63,13 +35,16 @@ export abstract class Positionals extends Analyser {
 
 	/**
 	 * Jobs MUST provide a list of their positional actions
+	 *
+	 * TODO: This should just be a filter on all actions for the job for
+	 * any actions they have with positional potencies.
 	 */
-	protected abstract positionals: Positional[]
+	protected abstract positionals: Action[]
 
 	override initialise() {
 		this.addEventHook(
 			filter<Event>().source(this.parser.actor.id).type('damage')
-				.cause(this.data.matchCauseActionId(this.positionals.map(positional => positional.action.id))), this.onCast)
+				.cause(this.data.matchCauseActionId(this.positionals.map(positional => positional.id))), this.onCast)
 		this.addEventHook('complete', this.onComplete)
 	}
 
@@ -81,7 +56,7 @@ export abstract class Positionals extends Analyser {
 		if (action == null) {
 			return
 		}
-		const positional = this.positionals.find(positional => positional.action === action)
+		const positional = this.positionals.find(positional => positional === action)
 		if (positional == null) {
 			return
 		}
@@ -97,7 +72,7 @@ export abstract class Positionals extends Analyser {
 		}
 	}
 
-	private getOrCreatePositionalResult(positional: Positional) {
+	private getOrCreatePositionalResult(positional: Action) {
 		let positionalResult = this.positionalResults.find(result => result.positional === positional)
 		if (positionalResult == null) {
 			positionalResult = {
@@ -114,24 +89,17 @@ export abstract class Positionals extends Analyser {
 	// things such as DRG's 5th hit combo buff and RPR's reaver buff.
 	// Luckily, assessing misses is easy and sufficient for the purposes
 	// of detecting positional hits.
-	private missedPositionalBonusPercents(action: Positional) {
+	private missedPositionalBonusPercents(action: Action) {
 		const missed_positional_combo_bonus_percent = this.calculateBonusPercent(
-			this.getPotencyWithMods(action, []),
-			this.getPotencyWithMods(action, [PotencyModifier.COMBO]))
+			getBasePotency(action),
+			getPotencyWithMods(action, [BonusModifier.COMBO], []))
 		return [...new Set([NO_BONUS_PERCENT, missed_positional_combo_bonus_percent])]
 	}
 
 	// Currently just checks that you didn't miss. Checking for hits would
 	// otherwise be more complex.
-	private positionalHit(action: Positional, bonusPercent: number) {
+	private positionalHit(action: Action, bonusPercent: number) {
 		return !this.missedPositionalBonusPercents(action).includes(bonusPercent)
-	}
-
-	private getPotencyWithMods(action: Positional, modifiers: PotencyModifier[]) {
-		return action.potencies?.find(
-			potency =>
-				JSON.stringify(potency.modifiers.sort()) === JSON.stringify(modifiers.sort())
-		)?.value || NO_BONUS_PERCENT
 	}
 
 	// The bonusPercent is based on the final potency number.
@@ -179,7 +147,7 @@ export abstract class Positionals extends Analyser {
 			percent = Math.min(percent, 100)
 		}
 		return new Requirement({
-			name: <ActionLink {...result.positional.action}/>,
+			name: <ActionLink {...result.positional}/>,
 			percent: percent,
 			weight: expected,
 			overrideDisplay: `${actual} / ${expected} (${percent.toFixed(2)}%)`,
@@ -211,9 +179,9 @@ export abstract class Positionals extends Analyser {
 						const numHits = result.hits.length
 						const numMisses = result.misses.length
 						const success = numMisses === 0
-						return <Table.Row key={result.positional.action.id}>
+						return <Table.Row key={result.positional.id}>
 							<Table.Cell style={{whiteSpace: 'nowrap'}}>
-								<ActionLink {...result.positional.action} showName={false} />
+								<ActionLink {...result.positional} showName={false} />
 							</Table.Cell>
 							<Table.Cell
 								textAlign="center"

--- a/src/parser/jobs/drg/modules/Positionals.ts
+++ b/src/parser/jobs/drg/modules/Positionals.ts
@@ -1,25 +1,9 @@
-import {PotencyModifier, Positionals as CorePositionals} from 'parser/core/modules/Positionals'
+import {Positionals as CorePositionals} from 'parser/core/modules/Positionals'
 
 export class Positionals extends CorePositionals {
-	positionals = [{
-		action: this.data.actions.CHAOTIC_SPRING,
-		potencies: [
-			{
-				value: 100,
-				modifiers: [],
-			},
-			{
-				value: 260,
-				modifiers: [PotencyModifier.COMBO],
-			},
-		],
-
-	},
-	{
-		action: this.data.actions.WHEELING_THRUST,
-	},
-	{
-		action: this.data.actions.FANG_AND_CLAW,
-	},
+	positionals = [
+		this.data.actions.CHAOTIC_SPRING,
+		this.data.actions.FANG_AND_CLAW,
+		this.data.actions.WHEELING_THRUST,
 	]
 }

--- a/src/parser/jobs/mnk/modules/Positionals.ts
+++ b/src/parser/jobs/mnk/modules/Positionals.ts
@@ -1,11 +1,8 @@
 import {Positionals as CorePositionals} from 'parser/core/modules/Positionals'
 
 export class Positionals extends CorePositionals {
-	positionals = [{
-		action: this.data.actions.DEMOLISH,
-	},
-	{
-		action: this.data.actions.SNAP_PUNCH,
-	},
+	positionals = [
+		this.data.actions.DEMOLISH,
+		this.data.actions.SNAP_PUNCH,
 	]
 }

--- a/src/parser/jobs/mnk/modules/Revolution.tsx
+++ b/src/parser/jobs/mnk/modules/Revolution.tsx
@@ -1,5 +1,6 @@
 import {Plural, Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
+import {getBasePotency} from 'data/ACTIONS'
 import {Event} from 'event'
 import {Analyser} from 'parser/core/Analyser'
 import {filter} from 'parser/core/filter'
@@ -28,8 +29,8 @@ export class Revolution extends Analyser {
 
 	private onComplete(): void {
 		if (this.revolutions > 0) {
-			const lowerBound = this.revolutions * (this.data.actions.ELIXIR_FIELD.potency - this.data.actions.CELESTIAL_REVOLUTION.potency)
-			const upperBound = this.revolutions * (this.data.actions.RISING_PHOENIX.potency - this.data.actions.CELESTIAL_REVOLUTION.potency)
+			const lowerBound = this.revolutions * (getBasePotency(this.data.actions.ELIXIR_FIELD) - getBasePotency(this.data.actions.CELESTIAL_REVOLUTION))
+			const upperBound = this.revolutions * (getBasePotency(this.data.actions.RISING_PHOENIX) - getBasePotency(this.data.actions.CELESTIAL_REVOLUTION))
 			this.suggestions.add(new Suggestion({
 				icon: this.data.actions.CELESTIAL_REVOLUTION.icon,
 				content: <Trans id="mnk.cr.suggestions.content">

--- a/src/parser/jobs/mnk/modules/Steppies.tsx
+++ b/src/parser/jobs/mnk/modules/Steppies.tsx
@@ -1,5 +1,6 @@
 import {Plural, Trans} from '@lingui/react'
 import {DataLink} from 'components/ui/DbLink'
+import {getBasePotency, getPotencyWithMods} from 'data/ACTIONS'
 import {Cause, Event, Events, SourceModifier} from 'event'
 import {Analyser} from 'parser/core/Analyser'
 import {filter} from 'parser/core/filter'
@@ -10,9 +11,6 @@ import {Data} from 'parser/core/modules/Data'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import React from 'react'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
-
-const LITE_BOOT_POTENCY = 210
-const LEAD_BOOT_POTENCY = 310
 
 const SUGGESTION_TIERS = {
 	// Typically a player with lag can derp positional in opener, this usually happens 2 times per fight.
@@ -49,6 +47,9 @@ export class Steppies extends Analyser {
 	@dependency private checklist!: Checklist
 	@dependency private data!: Data
 	@dependency private suggestions!: Suggestions
+
+	private liteBootPotency = getBasePotency(this.data.actions.BOOTSHINE)
+	private leadBootPotency = getPotencyWithMods(this.data.actions.BOOTSHINE, [], ['LEADEN_FIST'])
 
 	private steppies: Boot[] = []
 
@@ -97,7 +98,7 @@ export class Steppies extends Analyser {
 				Avoid unbuffed <DataLink action="BOOTSHINE"/> by using <DataLink action="DRAGON_KICK" /> before it.
 			</Trans>,
 			why: <Trans id="mnk.steppies.suggestions.dragon_kick.why">
-				{this.getUnbuffedCount(this.steppies) * (LEAD_BOOT_POTENCY - LITE_BOOT_POTENCY)} potency lost to missing <DataLink status="LEADEN_FIST"/> buff {this.getUnbuffedCount(this.steppies)} times.
+				{this.getUnbuffedCount(this.steppies) * (this.leadBootPotency - this.liteBootPotency)} potency lost to missing <DataLink status="LEADEN_FIST"/> buff {this.getUnbuffedCount(this.steppies)} times.
 			</Trans>,
 			tiers: SUGGESTION_TIERS.WEAK,
 			value: this.getUnbuffedCount(this.steppies),

--- a/src/parser/jobs/mnk/modules/TwinSnakes.tsx
+++ b/src/parser/jobs/mnk/modules/TwinSnakes.tsx
@@ -1,6 +1,6 @@
 import {Plural, Trans} from '@lingui/react'
 import {DataLink} from 'components/ui/DbLink'
-import {Action, ActionKey} from 'data/ACTIONS'
+import {Action, ActionKey, getBasePotency} from 'data/ACTIONS'
 import {Status} from 'data/STATUSES'
 import {Event, Events} from 'event'
 import {Analyser} from 'parser/core/Analyser'
@@ -144,7 +144,7 @@ export class TwinSnakes extends Analyser {
 		this.stopAndSave(this.parser.pull.timestamp + this.parser.pull.duration)
 
 		// Calculate derped potency to early refreshes
-		const lostTruePotency = this.earlySnakes * (this.data.actions.TRUE_STRIKE.potency - this.data.actions.TWIN_SNAKES.potency)
+		const lostTruePotency = this.earlySnakes * (getBasePotency(this.data.actions.TRUE_STRIKE) - getBasePotency(this.data.actions.TWIN_SNAKES))
 
 		this.checklist.add(new Rule({
 			name: <Trans id="mnk.twinsnakes.checklist.name">Keep <DataLink status="DISCIPLINED_FIST" showIcon={false}/> up</Trans>,

--- a/src/parser/jobs/mnk/modules/TwinSnakes.tsx
+++ b/src/parser/jobs/mnk/modules/TwinSnakes.tsx
@@ -88,7 +88,7 @@ export class TwinSnakes extends Analyser {
 		}
 
 		// Verify the window isn't closed, and count the GCDs:
-		if (this.twinSnake.end != null) {
+		if (this.twinSnake.end == null) {
 			// We still count TS in the GCD list of the window, just flag if it's early
 			if (action.id === this.data.actions.TWIN_SNAKES.id) {
 				const expected = this.data.statuses.DISCIPLINED_FIST.duration - TWIN_SNAKES_BUFFER

--- a/src/parser/jobs/nin/modules/Positionals.ts
+++ b/src/parser/jobs/nin/modules/Positionals.ts
@@ -1,39 +1,9 @@
-import {PotencyModifier, Positionals as CorePositionals} from 'parser/core/modules/Positionals'
-
-const ARMOR_CRUSH_COMBO_POTENCY_6_0 = 340
-const ARMOR_CRUSH_COMBO_POTENCY_6_1 = 360
-const AEOLIAN_EDGE_COMBO_POTENCY_6_0 = 360
-const AEOLIAN_EDGE_COMBO_POTENCY_6_1 = 380
+import {Positionals as CorePositionals} from 'parser/core/modules/Positionals'
 
 export class Positionals extends CorePositionals {
-	positionals = [{
-		action: this.data.actions.ARMOR_CRUSH,
-		potencies: [
-			{
-				value: this.data.actions.ARMOR_CRUSH.potency,
-				modifiers: [],
-			},
-			{
-				value: this.parser.patch.before('6.1') ? ARMOR_CRUSH_COMBO_POTENCY_6_0 : ARMOR_CRUSH_COMBO_POTENCY_6_1,
-				modifiers: [PotencyModifier.COMBO],
-			},
-		],
-	},
-	{
-		action: this.data.actions.TRICK_ATTACK,
-	},
-	{
-		action: this.data.actions.AEOLIAN_EDGE,
-		potencies: [
-			{
-				value: this.data.actions.AEOLIAN_EDGE.potency,
-				modifiers: [],
-			},
-			{
-				value: this.parser.patch.before('6.1') ? AEOLIAN_EDGE_COMBO_POTENCY_6_0 : AEOLIAN_EDGE_COMBO_POTENCY_6_1,
-				modifiers: [PotencyModifier.COMBO],
-			},
-		],
-	},
+	positionals = [
+		this.data.actions.ARMOR_CRUSH,
+		this.data.actions.TRICK_ATTACK,
+		this.data.actions.AEOLIAN_EDGE,
 	]
 }

--- a/src/parser/jobs/rpr/modules/Positionals.ts
+++ b/src/parser/jobs/rpr/modules/Positionals.ts
@@ -4,11 +4,8 @@ import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 export class Positionals extends CorePositionals {
 	static override displayOrder = DISPLAY_ORDER.POSITIONALS
 
-	positionals = [{
-		action: this.data.actions.GIBBET,
-	},
-	{
-		action: this.data.actions.GALLOWS,
-	},
+	positionals = [
+		this.data.actions.GIBBET,
+		this.data.actions.GALLOWS,
 	]
 }

--- a/src/parser/jobs/sam/modules/Positionals.ts
+++ b/src/parser/jobs/sam/modules/Positionals.ts
@@ -1,33 +1,8 @@
-import {PotencyModifier, Positionals as CorePositionals} from 'parser/core/modules/Positionals'
+import {Positionals as CorePositionals} from 'parser/core/modules/Positionals'
 
-const POTENCY_600 = 100
-const POTENCY_610 = 120
 export class Positionals extends CorePositionals {
-	positionals = [{
-		action: this.data.actions.GEKKO,
-		potencies: [
-			{
-				value: this.parser.patch.before('6.1') ? POTENCY_600 : POTENCY_610,
-				modifiers: [],
-			},
-			{
-				value: this.data.actions.GEKKO.potency,
-				modifiers: [PotencyModifier.COMBO],
-			},
-		],
-	},
-	{
-		action: this.data.actions.KASHA,
-		potencies: [
-			{
-				value: this.parser.patch.before('6.1') ? POTENCY_600 : POTENCY_610,
-				modifiers: [],
-			},
-			{
-				value: this.data.actions.KASHA.potency,
-				modifiers: [PotencyModifier.COMBO],
-			},
-		],
-	},
+	positionals = [
+		this.data.actions.GEKKO,
+		this.data.actions.KASHA,
 	]
 }


### PR DESCRIPTION
Found this while I was reviewing #1684 - the existing Twin Snakes module was not correctly checking for early refreshes because this check was never finding an open Twin Snakes window.

Can validate the change with this log, created with multiple intentional early TS refreshes: https://www.fflogs.com/reports/bj316mFGkAafVxgc#fight=1&type=damage-done&source=3