### PR TITLE
DRG: 6.4 support

### DIFF
--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -12,7 +12,7 @@ export const DRAGOON = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.FALINDRITH, role: ROLES.MAINTAINER},


### PR DESCRIPTION
DRG is the same*

*but with added positional buffs. Since Dragon Sight is still primarily used for damage, it'll typically be used on CD and not for optimizing positionals (and if you're doing that we're going to assume you know what you're doing). This is a lot of words to say there are no plans for additional analysis of DS.