### PR TITLE
BLM 6.4 adjustments

### DIFF
--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -72,4 +72,9 @@ export const changelog = [
 		Changes: () => <>Fixed a bug with the Not Casting check that was giving incorrect results for fight downtime and end-of-fight casts.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2023-05-24'),
+		Changes: () => <>Foul now requires 3 targets to outperform Xenoglossy due to 6.4 potency increase.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/blm/index.tsx
+++ b/src/parser/jobs/blm/index.tsx
@@ -14,7 +14,7 @@ export const BLACK_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/blm/modules/AoEUsages.ts
+++ b/src/parser/jobs/blm/modules/AoEUsages.ts
@@ -7,7 +7,8 @@ export class AoEUsages extends CoreAoE {
 		{
 			aoeAction: this.data.actions.FOUL,
 			stActions: [this.data.actions.XENOGLOSSY],
-			minTargets: 2,
+			// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+			minTargets: this.parser.patch.before('6.4') ? 2 : 3,
 		},
 		{
 			aoeAction: this.data.actions.FLARE,


### PR DESCRIPTION
Xenoglossy's potency increase now causes it to outperform a 2-target Foul. Updated the AoEUsages minTargets count for parses uploaded in 6.4 and after