### PR TITLE
MCH Gauge: yarn lint wanted less whitespace

### DIFF
--- a/src/parser/jobs/mch/modules/Gauge.tsx
+++ b/src/parser/jobs/mch/modules/Gauge.tsx
@@ -8,7 +8,7 @@ import {dependency} from 'parser/core/Injectable'
 import {CounterGauge, Gauge as CoreGauge} from 'parser/core/modules/Gauge'
 import Suggestions, {SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
 import React from 'react'
-import { isSuccessfulHit } from 'utilities'
+import {isSuccessfulHit} from 'utilities'
 
 const OVERCAP_SEVERITY = {
 	HEAT: {


### PR DESCRIPTION
`yarn lint --fix` automagically does this change on the current head commit.  Was patching something unrelated and this kept cropping up.