### PR TITLE
[SMN] Add level 70/80 skills for better Ultimate analysis

### DIFF
--- a/src/data/ACTIONS/layers/patch6.1.ts
+++ b/src/data/ACTIONS/layers/patch6.1.ts
@@ -94,6 +94,12 @@ export const patch610: Layer<ActionRoot> = {
 			icon: 'https://xivapi.com/i/002000/002780.png',
 			statusesApplied: ['SEARING_LIGHT'],
 		},
+		RUBY_RUIN_III: {
+			gcdRecast: 3000,
+		},
+		RUBY_OUTBURST: {
+			gcdRecast: 3000,
+		},
 		RUBY_RITE: {
 			gcdRecast: 3000,
 		},

--- a/src/data/ACTIONS/root/SMN.ts
+++ b/src/data/ACTIONS/root/SMN.ts
@@ -157,10 +157,28 @@ export const SMN = ensureActions({
 		cooldown: 20000,
 	},
 
+	RUBY_RUIN_III: {
+		id: 25817,
+		name: 'Ruby Ruin III',
+		icon: 'https://xivapi.com/i/002000/002682.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+		castTime: 2800,
+	},
+
 	RUBY_RITE: {
 		id: 25823,
 		name: 'Ruby Rite',
 		icon: 'https://xivapi.com/i/002000/002760.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+		castTime: 2800,
+	},
+
+	TOPAZ_RUIN_III: {
+		id: 25818,
+		name: 'Topaz Ruin III',
+		icon: 'https://xivapi.com/i/002000/002682.png',
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 		castTime: 2800,
@@ -172,6 +190,15 @@ export const SMN = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002761.png',
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
+	},
+
+	EMERALD_RUIN_III: {
+		id: 25819,
+		name: 'Emerald Ruin III',
+		icon: 'https://xivapi.com/i/002000/002682.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+		castTime: 2800,
 	},
 
 	EMERALD_RITE: {
@@ -293,6 +320,14 @@ export const SMN = ensureActions({
 		statusesApplied: ['SLIPSTREAM'],
 	},
 
+	SUMMON_IFRIT: {
+		id: 25805,
+		name: 'Summon Ifrit',
+		icon: 'https://xivapi.com/i/002000/002680.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+	},
+
 	SUMMON_IFRIT_II: {
 		id: 25838,
 		name: 'Summon Ifrit II',
@@ -301,10 +336,26 @@ export const SMN = ensureActions({
 		speedAttribute: Attribute.SPELL_SPEED,
 	},
 
+	SUMMON_TITAN: {
+		id: 25806,
+		name: 'Summon Titan',
+		icon: 'https://xivapi.com/i/002000/002755.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+	},
+
 	SUMMON_TITAN_II: {
 		id: 25839,
 		name: 'Summon Titan II',
 		icon: 'https://xivapi.com/i/002000/002773.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+	},
+
+	SUMMON_GARUDA: {
+		id: 25807,
+		name: 'Summon Garuda',
+		icon: 'https://xivapi.com/i/002000/002756.png',
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
 	},

--- a/src/data/ACTIONS/root/SMN.ts
+++ b/src/data/ACTIONS/root/SMN.ts
@@ -181,7 +181,6 @@ export const SMN = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002682.png',
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
-		castTime: 2800,
 	},
 
 	TOPAZ_RITE: {
@@ -198,7 +197,7 @@ export const SMN = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002682.png',
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
-		castTime: 2800,
+		cooldown: 1500,
 	},
 
 	EMERALD_RITE: {
@@ -261,6 +260,15 @@ export const SMN = ensureActions({
 		statusesApplied: ['REKINDLE', 'UNDYING_FLAME'],
 	},
 
+	RUBY_OUTBURST: {
+		id: 25814,
+		name: 'Ruby Outburst',
+		icon: 'https://xivapi.com/i/002000/002698.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+		castTime: 2800,
+	},
+
 	RUBY_CATASTROPHE: {
 		id: 25832,
 		name: 'Ruby Catastrophe',
@@ -270,12 +278,28 @@ export const SMN = ensureActions({
 		castTime: 2800,
 	},
 
+	TOPAZ_OUTBURST: {
+		id: 25815,
+		name: 'Topaz Outburst',
+		icon: 'https://xivapi.com/i/002000/002698.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+	},
+
 	TOPAZ_CATASTROPHE: {
 		id: 25833,
 		name: 'Topaz Catastrophe',
 		icon: 'https://xivapi.com/i/002000/002767.png',
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,
+	},
+
+	EMERALD_OUTBURST: {
+		id: 25816,
+		name: 'Emerald Outburst',
+		icon: 'https://xivapi.com/i/002000/002698.png',
+		onGcd: true,
+		cooldown: 1500,
 	},
 
 	EMERALD_CATASTROPHE: {

--- a/src/parser/jobs/smn/modules/Summons.tsx
+++ b/src/parser/jobs/smn/modules/Summons.tsx
@@ -142,6 +142,7 @@ export class Summons extends Analyser {
 			current.data.ifritSummon = event
 			break
 		case this.data.actions.RUBY_RUIN_III.id:
+		case this.data.actions.RUBY_OUTBURST.id:
 		case this.data.actions.RUBY_RITE.id:
 		case this.data.actions.RUBY_CATASTROPHE.id:
 			current.data.rubyGcds += 1
@@ -158,6 +159,7 @@ export class Summons extends Analyser {
 			current.data.titanSummon = event
 			break
 		case this.data.actions.TOPAZ_RUIN_III.id:
+		case this.data.actions.TOPAZ_OUTBURST.id:
 		case this.data.actions.TOPAZ_RITE.id:
 		case this.data.actions.TOPAZ_CATASTROPHE.id:
 			current.data.topazGcds += 1
@@ -171,6 +173,7 @@ export class Summons extends Analyser {
 			current.data.garudaSummon = event
 			break
 		case this.data.actions.EMERALD_RUIN_III.id:
+		case this.data.actions.EMERALD_OUTBURST.id:
 		case this.data.actions.EMERALD_RITE.id:
 		case this.data.actions.EMERALD_CATASTROPHE.id:
 			current.data.emeraldGcds += 1

--- a/src/parser/jobs/smn/modules/Summons.tsx
+++ b/src/parser/jobs/smn/modules/Summons.tsx
@@ -137,9 +137,11 @@ export class Summons extends Analyser {
 			current.data.enkindle += 1
 			break
 
+//		case this.data.actions.SUMMON_IFRIT.id:
 		case this.data.actions.SUMMON_IFRIT_II.id:
 			current.data.ifritSummon = event
 			break
+//		case this.data.actions.RUBY_RUIN_III.id:
 		case this.data.actions.RUBY_RITE.id:
 		case this.data.actions.RUBY_CATASTROPHE.id:
 			current.data.rubyGcds += 1
@@ -151,9 +153,11 @@ export class Summons extends Analyser {
 			current.data.crimsonStrike += 1
 			break
 
+//		case this.data.actions.SUMMON_TITAN.id:
 		case this.data.actions.SUMMON_TITAN_II.id:
 			current.data.titanSummon = event
 			break
+//		case this.data.actions.TOPAZ_RUIN_III.id:
 		case this.data.actions.TOPAZ_RITE.id:
 		case this.data.actions.TOPAZ_CATASTROPHE.id:
 			current.data.topazGcds += 1
@@ -162,9 +166,11 @@ export class Summons extends Analyser {
 			current.data.mountainBusters += 1
 			break
 
+//		case this.data.actions.SUMMON_GARUDA.id:
 		case this.data.actions.SUMMON_GARUDA_II.id:
 			current.data.garudaSummon = event
 			break
+//		case this.data.actions.EMERALD_RUIN_III.id:
 		case this.data.actions.EMERALD_RITE.id:
 		case this.data.actions.EMERALD_CATASTROPHE.id:
 			current.data.emeraldGcds += 1

--- a/src/parser/jobs/smn/modules/Summons.tsx
+++ b/src/parser/jobs/smn/modules/Summons.tsx
@@ -137,11 +137,11 @@ export class Summons extends Analyser {
 			current.data.enkindle += 1
 			break
 
-//		case this.data.actions.SUMMON_IFRIT.id:
+		case this.data.actions.SUMMON_IFRIT.id:
 		case this.data.actions.SUMMON_IFRIT_II.id:
 			current.data.ifritSummon = event
 			break
-//		case this.data.actions.RUBY_RUIN_III.id:
+		case this.data.actions.RUBY_RUIN_III.id:
 		case this.data.actions.RUBY_RITE.id:
 		case this.data.actions.RUBY_CATASTROPHE.id:
 			current.data.rubyGcds += 1
@@ -153,11 +153,11 @@ export class Summons extends Analyser {
 			current.data.crimsonStrike += 1
 			break
 
-//		case this.data.actions.SUMMON_TITAN.id:
+		case this.data.actions.SUMMON_TITAN.id:
 		case this.data.actions.SUMMON_TITAN_II.id:
 			current.data.titanSummon = event
 			break
-//		case this.data.actions.TOPAZ_RUIN_III.id:
+		case this.data.actions.TOPAZ_RUIN_III.id:
 		case this.data.actions.TOPAZ_RITE.id:
 		case this.data.actions.TOPAZ_CATASTROPHE.id:
 			current.data.topazGcds += 1
@@ -166,11 +166,11 @@ export class Summons extends Analyser {
 			current.data.mountainBusters += 1
 			break
 
-//		case this.data.actions.SUMMON_GARUDA.id:
+		case this.data.actions.SUMMON_GARUDA.id:
 		case this.data.actions.SUMMON_GARUDA_II.id:
 			current.data.garudaSummon = event
 			break
-//		case this.data.actions.EMERALD_RUIN_III.id:
+		case this.data.actions.EMERALD_RUIN_III.id:
 		case this.data.actions.EMERALD_RITE.id:
 		case this.data.actions.EMERALD_CATASTROPHE.id:
 			current.data.emeraldGcds += 1


### PR DESCRIPTION
**Issue:**
A level 70/80 smn log like https://xivanalysis.com/fflogs/kaPYJ28j61NHL9Ky/7/4 will show large gaps in the timeline and various modules because Titan/Garuda/Ifrit summon actions are not present.

**Fix:**
Add Summon Titan, Summon Garuda, Summon Ifrit, Topaz Ruin III, Emerald Ruin III, Ruby Ruin III, Topaz Outburst, Emerald Outburst, and Ruby Outburst. This is enough to fix the timeline module.

**Extra Notes:**
I'm specifically avoiding additional changes even though we could support things like the summons module, because as discussed that could cause complications long term. We're not really trying to support 70/80 content here, just trying to make the timeline useable.

I used these logs for testing:
https://www.fflogs.com/reports/v8WVxQzgKYrcB7J1#fight=4 - level 90 smn parse
https://www.fflogs.com/reports/Hzf2bRYdCgKFphQ1#fight=153 - level 90 smn parse
https://www.fflogs.com/reports/kaPYJ28j61NHL9Ky#fight=7 - level 70 smn parse on UWU
https://www.fflogs.com/reports/hTkHrMvzqVagpnNc#fight=5 - level 80 smn parse on TEA

**Before** ABC / summons module / timeline:
![image](https://github.com/xivanalysis/xivanalysis/assets/31753748/0cbbcce8-601d-4610-a605-5bad47ba9f1d)

**After** ABC / summons module / timeline:
![image](https://github.com/xivanalysis/xivanalysis/assets/31753748/40315edb-ce72-4ead-a1bb-29713a005a44)

