### PR TITLE
fflogs event adapter: handle prepull auras as a statusApply

### DIFF
--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -207,6 +207,65 @@ exports[`Event adapter individual events adapts checksummismatch 1`] = `Array []
 exports[`Event adapter individual events adapts combatantinfo 1`] = `
 Array [
   Object {
+    "action": 3540,
+    "source": "15",
+    "status": 1000727,
+    "target": "unknown",
+    "timestamp": 1599999999997,
+    "type": "action",
+  },
+  Object {
+    "action": 7432,
+    "source": "15",
+    "status": 1001218,
+    "target": "unknown",
+    "timestamp": 1599999999997,
+    "type": "action",
+  },
+  Object {
+    "action": 137,
+    "source": "15",
+    "status": 1000158,
+    "target": "unknown",
+    "timestamp": 1599999999997,
+    "type": "action",
+  },
+  Object {
+    "source": "15",
+    "status": 1000743,
+    "target": "unknown",
+    "timestamp": 1600002865189,
+    "type": "statusApply",
+  },
+  Object {
+    "source": "15",
+    "status": 1000297,
+    "target": "unknown",
+    "timestamp": 1600002865189,
+    "type": "statusApply",
+  },
+  Object {
+    "source": "15",
+    "status": 1000727,
+    "target": "unknown",
+    "timestamp": 1600002865189,
+    "type": "statusApply",
+  },
+  Object {
+    "source": "15",
+    "status": 1001218,
+    "target": "unknown",
+    "timestamp": 1600002865189,
+    "type": "statusApply",
+  },
+  Object {
+    "source": "15",
+    "status": 1000158,
+    "target": "unknown",
+    "timestamp": 1600002865189,
+    "type": "statusApply",
+  },
+  Object {
     "actor": "15",
     "attributes": Array [
       Object {

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -376,7 +376,7 @@ export class TranslateAdapterStep extends AdapterStep {
 		}
 	}
 
-	private adaptCombatantInfoEvent(event: CombatantInfoEvent): Array<Events['actorUpdate']> {
+	private adaptCombatantInfoEvent(event: CombatantInfoEvent): Array<Events['actorUpdate'] | Events['statusApply']> {
 		// TODO: Use more info in here. We're currently extracting the speed attribute values for the logging player, but there's also player level, prepull statuses, and more in there.
 
 		const attributeMapping: Array<[number | undefined, Attribute]> = [
@@ -391,20 +391,34 @@ export class TranslateAdapterStep extends AdapterStep {
 			attributes.push({attribute, value, estimated: false})
 		}
 
-		if (attributes.length === 0) {
-			return []
-		}
+		const ourEvents = new Array<Events['actorUpdate'] | Events['statusApply']>()
+		// "Auras" seems to be a holdover from WoW, but over here they mainly cover Stances;
+		// Tank Stance (Grit, etc), as well as the BLU mimickries.
+		// The minimum thing we can do here is just report these as a statusApply at the
+		// start of each pull.
+		event.auras.forEach(aura => {
+			const statusApplyEvent: Events['statusApply'] = {
+				...this.adaptTargetedFields(event),
+				type: 'statusApply',
+				status: resolveStatusId(aura.ability),
+			}
+			ourEvents.push(statusApplyEvent)
+		})
 
-		return [{
-			...this.adaptBaseFields(event),
-			type: 'actorUpdate',
-			attributes,
-			actor: resolveActorId({
-				id: event.sourceID,
-				instance: event.sourceInstance,
-				actor: event.source,
-			}),
-		}]
+		if (attributes.length !== 0) {
+			const actorUpdateEvent: Events['actorUpdate'] = {
+				...this.adaptBaseFields(event),
+				type: 'actorUpdate',
+				attributes,
+				actor: resolveActorId({
+					id: event.sourceID,
+					instance: event.sourceInstance,
+					actor: event.source,
+				}),
+			}
+			ourEvents.push(actorUpdateEvent)
+		}
+		return ourEvents
 	}
 
 	private adaptTargetedFields(event: FflogsEvent) {


### PR DESCRIPTION
Auras seem like a bit of a holdover from WoW, but for us they seem to cover pre-pull statuses, like stances (Grit, Mighty Guard, the BLU mimickries), as well as Well Fed and the Squadron Manual.

This makes those auras show up for us as a statusApply event at pull start.