### PR TITLE
Marked SMN as supported for 6.4

### DIFF
--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -20,7 +20,7 @@ export const SUMMONER = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.KELOS, role: ROLES.MAINTAINER},


### PR DESCRIPTION
It is tempting to remove the players hit check now that the radius is so large, but I'm sure someone will find a way, so no changes for 6.4.