### PR TITLE
Fix Devilment timing check for 6.4+

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -77,4 +77,9 @@ export const changelog = [
 		Changes: () => <>Fix a bug where fights with unavoidable downtime could report Standard Step uptime as a negative percentage.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2023-05-27'),
+		Changes: () => <>Adjust Devilment timing check to account for changed Technical Finish status application timing after 6.4.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -79,9 +79,15 @@ export class Technicalities extends Analyser {
 			.filter(actor => actor.playerControlled)
 			.map(actor => actor.id)
 
+		// 6.4 changed the status application time from the players own finish to not always happen at the same time as the executing action
+		// Hook both the player's finish actions and status applications targeting the player
 		this.addEventHook(
 			techFinishFilter
 				.target(this.parser.actor.id),
+			this.tryOpenWindow)
+		this.addEventHook(
+			filter<Event>().type('action').action(oneOf(this.technicalFinishIds))
+				.source(this.parser.actor.id),
 			this.tryOpenWindow)
 
 		this.addEventHook(
@@ -112,7 +118,7 @@ export class Technicalities extends Analyser {
 		}
 	}
 
-	private tryOpenWindow(event: Events['statusApply']): TechnicalWindow {
+	private tryOpenWindow(event: Events['statusApply'] | Events['action']): TechnicalWindow {
 		const lastWindow: TechnicalWindow | undefined = _.last(this.history)
 
 		// Handle multiple dancer's buffs overwriting each other, we'll have a remove then an apply with the same timestamp
@@ -225,7 +231,9 @@ export class Technicalities extends Analyser {
 
 		lastWindow.usedDevilment = true
 
-		if (lastWindow.gcdCount === 0) {
+		// If the player hits devilment within a GCD of another DNC's Finish going up, or immediately following their own Technical Finish, it is considered to be on time
+		if (lastWindow.gcdCount <= 1 ||
+			this.technicalFinishIds.includes(lastWindow.rotation[lastWindow.rotation.length-1].action)) {
 			lastWindow.timelyDevilment = true
 		}
 	}

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -220,12 +220,9 @@ export class Technicalities extends Analyser {
 
 	/** Check to see if Devilment was used at the proper time. In Endwalker, it should immediately follow Technical Finish */
 	private handleDevilment(lastWindow: TechnicalWindow | undefined) {
-		if (!this.actors.current.hasStatus(this.data.statuses.TECHNICAL_FINISH.id)) {
-			this.badDevilments++
-		}
-
-		// If we don't have a window for some reason, bail
+		// If we're not currently in an active Technical Window, mark the Devilment use as bad
 		if (lastWindow == null || lastWindow.end) {
+			this.badDevilments++
 			return
 		}
 


### PR DESCRIPTION
A knock-on effect of the buff radius changes made in 6.4 was that Technical Finish no longer immediately applies to the source Dancer upon action execution. This opened up the possibility for Devilment to be executed between the execution of the Technical Finish, and the application of its status, which was causing the "Was Devilment used on time?" check to fail incorrectly.

Updated to hook the player dancer's Technical Finish actions as well as Technical Finish status applications for the purpose of opening a new window, and adjusted the check to determine whether Devilment was used on time accordingly.