### PR TITLE
PLD - Skip tracking defensives with shared gauge resources

### DIFF
--- a/src/parser/jobs/pld/changelog.tsx
+++ b/src/parser/jobs/pld/changelog.tsx
@@ -3,6 +3,13 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-05-27'),
+		Changes: () => <>
+			Removed Intervention, Holy Sheltron, and Cover from defensive analysis since they use a shared gauge resource.
+		</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2023-01-15'),
 		Changes: () => <>
 			Updated Paladin for 6.3 rework.

--- a/src/parser/jobs/pld/modules/Defensives.ts
+++ b/src/parser/jobs/pld/modules/Defensives.ts
@@ -4,11 +4,8 @@ export class Defensives extends CoreDefensives {
 	protected override trackedDefensives = [
 		this.data.actions.HALLOWED_GROUND,
 		this.data.actions.SENTINEL,
-		this.data.actions.HOLY_SHELTRON,
 		this.data.actions.PASSAGE_OF_ARMS,
 		this.data.actions.DIVINE_VEIL,
-		this.data.actions.INTERVENTION,
-		this.data.actions.COVER,
 		this.data.actions.BULWARK,
 	]
 }


### PR DESCRIPTION
Intervention, Holy Sheltron, and Cover all use Oath Gauge, so their usage is more complicated than just the "is the cooldown up?" question. Consequently, they shouldn't be tracked by the Defensives analysis