### PR TITLE
GNB bump to 6.4

### DIFF
--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -19,7 +19,7 @@ export const GUNBREAKER = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 
 	contributors: [


### PR DESCRIPTION
just potency changes and range extension on HoL.

No fundamental changes to analysis.