### PR TITLE
Mark Patch 6.4 for remaining melee jobs

### DIFF
--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -18,7 +18,7 @@ export const DARK_KNIGHT = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AZARIAH, role: ROLES.MAINTAINER},

--- a/src/parser/jobs/rpr/index.tsx
+++ b/src/parser/jobs/rpr/index.tsx
@@ -17,7 +17,7 @@ export const REAPER = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sam/index.js
+++ b/src/parser/jobs/sam/index.js
@@ -21,7 +21,7 @@ export const SAMURAI = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/war/index.tsx
+++ b/src/parser/jobs/war/index.tsx
@@ -16,7 +16,7 @@ export const WARRIOR = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AY, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Flag patch 6.4 for all the remaining melee jobs. I noticed some oversights when checking the changes but they're not due to this particular patch. Specifically, SAM doesn't have AoE target checking for Shoha 1 vs 2 which I assume is for a reason, and I have a local change for RPR I can't remember the reason for that adds a `gcdRecast` to Communio.

Actual changes are potency/range only, no need for layer additions here and they're too small to change any AoE target count rules for these jobs.