### PR TITLE
Bump WHM to 6.4

### DIFF
--- a/src/parser/jobs/whm/index.tsx
+++ b/src/parser/jobs/whm/index.tsx
@@ -21,7 +21,7 @@ export const WHITE_MAGE = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.3',
+		to: '6.4',
 	},
 	contributors: [
 		// {user: CONTRIBUTORS.YOU, role: ROLES.DEVELOPER},
@@ -32,7 +32,7 @@ export const WHITE_MAGE = new Meta({
 		// {
 		// 	date: new Date('2021-11-19'),
 		// 	Changes: () => <>The changes you made</>,
-		// 	contrubutors: [CONTRIBUTORS.YOU],
+		// 	contributors: [CONTRIBUTORS.YOU],
 		// },
 		{
 			date: new Date('2021-12-30'),


### PR DESCRIPTION
Nothing effective changed, DoT potency and AoE radii aren't neccessary to keep track of. WHM is good for 6.4. (Also fixed a comment typo.)