### PR TITLE
Improved API error handling

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -245,7 +245,7 @@
   "core.defensives.title": "",
   "core.dummy.broken-log": "",
   "core.dummy.title": "Trainingspuppe",
-  "core.error.generic": "Sieht aus, als ob etwas falsch gelaufen ist. Unser hoch motiviertes Team von Programmierern wurde benachrichtigt.",
+  "core.error.unknown": "",
   "core.gauge.title": "Balken",
   "core.gcd.estimate-help.fflogs": "",
   "core.gcd.estimated-gcd": "Geschätzte globale Abklingzeit",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -245,7 +245,7 @@
   "core.defensives.title": "Defensives",
   "core.dummy.broken-log": "One or more actors in this pull appear to be striking dummies. The behaviour of dummy health pools breaks a number of assumptions made by xivanalysis, which can lead to subtly incorrect results.",
   "core.dummy.title": "Striking Dummy",
-  "core.error.generic": "Looks like something has gone wrong. The code monkies have been notified.",
+  "core.error.unknown": "xivanalysis encountered an unknown error. If this issue persists, let us know on Discord.",
   "core.gauge.title": "Gauge",
   "core.gcd.estimate-help.fflogs": "Precise attribute values are only available from FF Logs for the player who logged the report in ACT.",
   "core.gcd.estimated-gcd": "Estimated GCD",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -245,7 +245,7 @@
   "core.defensives.title": "Défensives",
   "core.dummy.broken-log": "Un ou plusieurs acteurs dans ce pull semblent être des mannequins d'entraînement. Le comportement de la jauge de vie des mannequins va à l'encontre d'un certain nombre d'hypothèses sur lesquelles repose xivanalysis, ce qui peut engendrer des résultats subtilement incorrects.",
   "core.dummy.title": "Mannequin d'entraînement",
-  "core.error.generic": "On dirait que quelque ne tourne pas rond. Notre équipe de développeurs hautement qualifiée en a été notifiée.",
+  "core.error.unknown": "",
   "core.gauge.title": "Jauge",
   "core.gcd.estimate-help.fflogs": "Les valeurs précises des attributs ne sont disponibles depuis FFLog que pour le joueur qui a enregistré le rapport de combat dans ACT.",
   "core.gcd.estimated-gcd": "Estimation du GCD",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -245,7 +245,7 @@
   "core.defensives.title": "",
   "core.dummy.broken-log": "レポートに一つかそれ以上のターゲットは木人らしいです。木人のHPはxivanalysisの仮定ルールと一致していませんので、計算は間違う可能性があります。",
   "core.dummy.title": "木人",
-  "core.error.generic": "おや、何か大変なことになりましたね。すでに開発者にアラートを送りましたのでご安心ください。",
+  "core.error.unknown": "",
   "core.gauge.title": "ゲージ",
   "core.gcd.estimate-help.fflogs": "",
   "core.gcd.estimated-gcd": "推定GCD",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -245,7 +245,7 @@
   "core.defensives.title": "경감",
   "core.dummy.broken-log": "전투 기록에 나무인형이 하나 이상 포함되어 있습니다. 나무인형의 체력 동작은 xivanalysis에서 가정한 수치와 다르기에 결과가 일부 잘못되었을 수 있습니다.",
   "core.dummy.title": "나무인형",
-  "core.error.generic": "무언가 잘못되었습니다. 코드 깎는 노인들에게 알림이 갔습니다.",
+  "core.error.unknown": "",
   "core.gauge.title": "게이지",
   "core.gcd.estimate-help.fflogs": "정확한 속성 값은 ACT로 리포트를 기록하여 FF Logs에 업로드한 플레이어만 알 수 있습니다.",
   "core.gcd.estimated-gcd": "예상 글로벌 쿨타임 시간",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -245,7 +245,7 @@
   "core.defensives.title": "防御性技能",
   "core.dummy.broken-log": "这场战斗中的一个或多个目标似乎是木人。木人血量槽的表现与xivanalysis做出的一些假设不符，这可能会导致错误的分析结果。",
   "core.dummy.title": "木人",
-  "core.error.generic": "好像出了点问题。程序猿已经接到报警。",
+  "core.error.unknown": "",
   "core.gauge.title": "职业量谱",
   "core.gcd.estimate-help.fflogs": "只有在 ACT 中记录报告的玩家才能从 FFlogs 中获得精确的属性值。",
   "core.gcd.estimated-gcd": "预估GCD复唱时间",

--- a/src/components/ui/ErrorMessage.js
+++ b/src/components/ui/ErrorMessage.js
@@ -20,7 +20,9 @@ const ErrorMessage = ({error}) => <Message
 	{...(ERROR_PROPS[error.severity || SEVERITY.ERROR])}
 	header={error.message || error.toString()}
 	content={<p>
-		{error.detail || <Trans id="core.error.generic">Looks like something has gone wrong. The code monkies have been notified.</Trans>}
+		{error.detail || (
+			<Trans id="core.error.unknown">xivanalysis encountered an unknown error. If this issue persists, let us know on Discord.</Trans>
+		)}
 	</p>}
 />
 

--- a/src/components/ui/ErrorMessage.js
+++ b/src/components/ui/ErrorMessage.js
@@ -23,6 +23,7 @@ const ErrorMessage = ({error}) => <Message
 		{error.detail || (
 			<Trans id="core.error.unknown">xivanalysis encountered an unknown error. If this issue persists, let us know on Discord.</Trans>
 		)}
+		{error.inner && <pre>{error.inner.toString()}</pre>}
 	</p>}
 />
 
@@ -31,6 +32,7 @@ ErrorMessage.propTypes = {
 		severity: PropTypes.oneOf(Object.values(SEVERITY)),
 		message: PropTypes.string,
 		detail: PropTypes.string,
+		inner: PropTypes.instanceOf(Error),
 	}).isRequired,
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -68,6 +68,11 @@ export class DidNotParticipateError extends GlobalError {
 	}
 }
 
+export class TooManyRequestsError extends GlobalError {
+	message = 'Slow down.'
+	detail = 'Too many requests. Please wait a little while before trying again.'
+}
+
 export class UnknownApiError extends GlobalError {
 	message = 'API Error.'
 	detail = 'An error occured while requesting data from FFLogs. If this issue persists, let us know on Discord.'

--- a/src/errors.js
+++ b/src/errors.js
@@ -71,6 +71,12 @@ export class DidNotParticipateError extends GlobalError {
 export class UnknownApiError extends GlobalError {
 	message = 'API Error.'
 	detail = 'An error occured while requesting data from FFLogs. If this issue persists, let us know on Discord.'
+	constructor(options) {
+		super(options)
+
+		/** @type {Error | undefined} */
+		this.inner = options.inner
+	}
 }
 
 export class ModulesNotFoundError extends GlobalError {

--- a/src/reportSources/legacyFflogs/fflogsApi.ts
+++ b/src/reportSources/legacyFflogs/fflogsApi.ts
@@ -7,6 +7,7 @@ import {Report} from './legacyStore'
 type CacheBehavior = 'read' | 'bypass'
 
 const FROM_CACHE_HEADER = '__from-cache'
+const HTTP_TOO_MANY_REQUESTS = 429
 
 const options: Options = {
 	prefixUrl: process.env.REACT_APP_FFLOGS_V1_BASE_URL,
@@ -90,6 +91,10 @@ export async function fetchFflogs<T>(
 			hooks: createCacheHooks(cache, behavior),
 		}).json<T>()
 	} catch (error) {
+		if (error instanceof ky.HTTPError && error.response.status === HTTP_TOO_MANY_REQUESTS) {
+			throw new Errors.TooManyRequestsError()
+		}
+
 		throw new Errors.UnknownApiError({inner: error})
 	}
 }

--- a/src/reportSources/legacyFflogs/legacyStore.ts
+++ b/src/reportSources/legacyFflogs/legacyStore.ts
@@ -5,7 +5,7 @@ import {action, observable, runInAction} from 'mobx'
 import {globalErrorStore} from 'store/globalError'
 import {settingsStore} from 'store/settings'
 import {ProcessedReportFightsResponse, ReportFightsQuery, ReportFightsResponse} from './eventTypes'
-import {createCacheHooks, fflogsApi, getCache} from './fflogsApi'
+import {fetchFflogs, getCache} from './fflogsApi'
 
 interface UnloadedReport {
 	loading: true
@@ -40,14 +40,15 @@ export class ReportStore {
 		let response: ReportFightsResponse
 		try {
 			const cache = await getCache(code)
-			response = await fflogsApi.get(`report/fights/${code}`, {
-				searchParams: {
+			response = await fetchFflogs<ReportFightsResponse>(
+				`report/fights/${code}`,
+				{
 					translate: 'true',
 					..._.omitBy(params, _.isNil),
-					...(bypassCache? {bypassCache: 'true'} : {}),
 				},
-				hooks: createCacheHooks(cache, bypassCache ? 'bypass' : 'read'),
-			}).json<ReportFightsResponse>()
+				cache,
+				bypassCache ? 'bypass' : 'read',
+			)
 		} catch (e) {
 			// Something's gone wrong, clear report status then dispatch an error
 			runInAction(() => {
@@ -55,12 +56,17 @@ export class ReportStore {
 			})
 
 			// TODO: Add more error handling to this if they start cropping up more
-			if (e instanceof ky.HTTPError) {
-				const json: ErrorResponse | undefined = await e.response.json()
+			if (e instanceof Errors.UnknownApiError && e.inner instanceof ky.HTTPError) {
+				const json: ErrorResponse | undefined = await e.inner.response.json().catch(_err => undefined)
 				if (json && json.error === 'This report does not exist or is private.') {
 					globalErrorStore.setGlobalError(new Errors.ReportNotFoundError())
 					return
 				}
+			}
+
+			if (e instanceof Errors.GlobalError) {
+				globalErrorStore.setGlobalError(e)
+				return
 			}
 
 			globalErrorStore.setGlobalError(new Errors.UnknownApiError({inner: e}))

--- a/src/reportSources/legacyFflogs/legacyStore.ts
+++ b/src/reportSources/legacyFflogs/legacyStore.ts
@@ -63,7 +63,7 @@ export class ReportStore {
 				}
 			}
 
-			globalErrorStore.setGlobalError(new Errors.UnknownApiError())
+			globalErrorStore.setGlobalError(new Errors.UnknownApiError({inner: e}))
 			return
 		}
 


### PR DESCRIPTION
All the try/catch.

This PR
- Updates error handling in API code to surface the underlying error when something goes wrong
- Adds explicit handling for 429s so they're not as opaque
- Adds a bunch more error catches around cache-related code because I'm pretty sure 99% of the issues are just cache problems that we don't really care about.
- Updates that atrocious old generic error message that everyone hates