### PR TITLE
feat(PLD): Atonement no longer breaks combo as of 6.4

### DIFF
--- a/src/data/ACTIONS/layers/index.ts
+++ b/src/data/ACTIONS/layers/index.ts
@@ -3,6 +3,7 @@ import {ActionRoot} from '../root'
 import {patch610} from './patch6.1'
 import {patch620} from './patch6.2'
 import {patch630} from './patch6.3'
+import {patch640} from './patch6.4'
 
 export const layers: Array<Layer<ActionRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -11,4 +12,5 @@ export const layers: Array<Layer<ActionRoot>> = [
 	patch610,
 	patch620,
 	patch630,
+	patch640,
 ]

--- a/src/data/ACTIONS/layers/patch6.4.ts
+++ b/src/data/ACTIONS/layers/patch6.4.ts
@@ -1,0 +1,11 @@
+import {Layer} from 'data/layer'
+import {ActionRoot} from '../root'
+
+export const patch640: Layer<ActionRoot> = {
+	patch: '6.4',
+	data: {
+		ATONEMENT: {
+			breaksCombo: false,
+		},
+	},
+}

--- a/src/data/ACTIONS/root/PLD.ts
+++ b/src/data/ACTIONS/root/PLD.ts
@@ -130,7 +130,7 @@ export const PLD = ensureActions({
 		icon: 'https://xivapi.com/i/002000/002519.png',
 		onGcd: true,
 		speedAttribute: Attribute.SKILL_SPEED,
-		breaksCombo: true,
+		breaksCombo: true as boolean,
 	},
 	CONFITEOR: {
 		id: 16459,

--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -19,7 +19,7 @@ export const PALADIN = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.3',
-		to: '6.3',
+		to: '6.4',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.STYRFIRE, role: ROLES.MAINTAINER},


### PR DESCRIPTION
Fixes the most important part for 6.4 PLD: Atonement no longer breaking combos.

The FoF usage is not optimized but not incorrect either, so it's still the same until it's been decided how to handle the FoF window in the future.