### PR TITLE
bugfix: Fix report loading for Firefox in Private Browsing mode

### DIFF
--- a/src/reportSources/legacyFflogs/legacyStore.ts
+++ b/src/reportSources/legacyFflogs/legacyStore.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser'
 import * as Errors from 'errors'
 import ky from 'ky'
 import _ from 'lodash'
@@ -39,7 +40,13 @@ export class ReportStore {
 
 		let response: ReportFightsResponse
 		try {
-			const cache = await getCache(code)
+			let cache : Cache | undefined
+			try {
+				cache = await getCache(code)
+			} catch (error) {
+				Sentry.captureException(error)
+				cache = undefined
+			}
 			response = await fetchFflogs<ReportFightsResponse>(
 				`report/fights/${code}`,
 				{


### PR DESCRIPTION
Firefox rejects Cache access in private browsing mode with security errors. This causes reports to not load. The cache is used in two places:

* `legacyStore::fetchReport`
* `fflogsApi::getFflogsEvents`

The latter already has a try-catch block for `getCache` throwing an exception, the former does not. Essentially replicates the try-catch block to the former code location.

Alternatively this can be moved into `fflogsApi::getCache` method so that this fix is does not need to be replicated.

For more information about the SecurityError see [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage?retiredLocale=de).