### PR TITLE
[BugFix] Remove TBN from Defensives analysis

### DIFF
--- a/src/parser/core/modules/Defensives.tsx
+++ b/src/parser/core/modules/Defensives.tsx
@@ -33,6 +33,7 @@ export class Defensives extends Analyser {
 
 	/**
 	 * Implementing modules should provide a list of job-specific defensive actions to track
+	 * These should not be actions which are constrained by either MP or a gauge resource, such as The Blackest Night, Holy Sheltron, or SGE's Addersgall actions
 	 */
 	protected trackedDefensives: Action[] = []
 	/**

--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -27,6 +27,11 @@ export const DARK_KNIGHT = new Meta({
 	],
 	changelog: [
 		{
+			date: new Date('2022-07-06'),
+			Changes: () => <>Removed <DataLink action="THE_BLACKEST_NIGHT" showIcon={false} /> from the Defensives analysis since it's additionally constrained by MP.</>,
+			contributors: [CONTRIBUTORS.AKAIRYU],
+		},
+		{
 			date: new Date('2022-04-24'),
 			Changes: () => <>Update timeline for 6.1 changes to <DataLink action="LIVING_DEAD"/>, and combine <DataLink action="SALTED_EARTH"/> with <DataLink action="SALT_AND_DARKNESS"/>.</>,
 			contributors: [CONTRIBUTORS.AY],

--- a/src/parser/jobs/drk/modules/Defensives.ts
+++ b/src/parser/jobs/drk/modules/Defensives.ts
@@ -4,7 +4,6 @@ export class Defensives extends CoreDefensives {
 	protected override trackedDefensives = [
 		this.data.actions.LIVING_DEAD,
 		this.data.actions.SHADOW_WALL,
-		this.data.actions.THE_BLACKEST_NIGHT,
 		this.data.actions.DARK_MISSIONARY,
 		this.data.actions.OBLATION,
 		this.data.actions.DARK_MIND,


### PR DESCRIPTION
The Defensives analyser doesn't account for secondary resource consumption, so we shouldn't be including actions that require such there. I'd already removed most of them, but apparently overlooked TBN somewhere along the way. Also added a comment to the core module to remind future developers (self included) about that intent.