### PR TITLE
BLU: Final Sting handling

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -185,6 +185,7 @@
   "blu.coldfog.dropped_casts.why": "",
   "blu.coldfog.ineffective.content": "",
   "blu.coldfog.ineffective.why": "",
+  "blu.deaths.why": "",
   "blu.dots.requirement.uptime-bleed.name": "Gesamtanwendungszeit von <0/>",
   "blu.dots.rule.description": "",
   "blu.dots.rule.name": "Halte deine DoTs aufrecht",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -185,6 +185,7 @@
   "blu.coldfog.dropped_casts.why": "{droppedWhiteDeathCasts, plural, one {# Cold Fog use} other {# Cold Fog uses}} cast <0/> less than 6 times.",
   "blu.coldfog.ineffective.content": "For <0/> to be effective, you need to cast <1/>at least two times while under <2/>.",
   "blu.coldfog.ineffective.why": "{ineffectiveColdFog, plural, one {# Cold Fog use} other {# Cold Fog uses}} were a DPS loss due to not using <0/> enough times",
+  "blu.deaths.why": "{0, plural, =1 {# death} other {# deaths}}.  That number does not include the {actorStings, plural, =1 {# death} other {# deaths}} from using <0/>",
   "blu.dots.requirement.uptime-bleed.name": "<0/> uptime",
   "blu.dots.rule.description": "The <0/> effect from Nightbloom and SoT is a solid 15% of your total damage.",
   "blu.dots.rule.name": "Keep your DoTs up",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -185,7 +185,7 @@
   "blu.coldfog.dropped_casts.why": "{droppedWhiteDeathCasts, plural, one {# Cold Fog use} other {# Cold Fog uses}} cast <0/> less than 6 times.",
   "blu.coldfog.ineffective.content": "For <0/> to be effective, you need to cast <1/>at least two times while under <2/>.",
   "blu.coldfog.ineffective.why": "{ineffectiveColdFog, plural, one {# Cold Fog use} other {# Cold Fog uses}} were a DPS loss due to not using <0/> enough times",
-  "blu.deaths.why": "{0, plural, =1 {# death} other {# deaths}}.  That number does not include the {actorStings, plural, =1 {# death} other {# deaths}} from using <0/>",
+  "blu.deaths.why": "{0, plural, =1 {# death} other {# deaths}}, not counting {actorStings, plural, =1 {# death} other {# deaths}} from using <0/>.",
   "blu.dots.requirement.uptime-bleed.name": "<0/> uptime",
   "blu.dots.rule.description": "The <0/> effect from Nightbloom and SoT is a solid 15% of your total damage.",
   "blu.dots.rule.name": "Keep your DoTs up",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -185,6 +185,7 @@
   "blu.coldfog.dropped_casts.why": "",
   "blu.coldfog.ineffective.content": "",
   "blu.coldfog.ineffective.why": "",
+  "blu.deaths.why": "",
   "blu.dots.requirement.uptime-bleed.name": "Temps total d'application de <0/>",
   "blu.dots.rule.description": "",
   "blu.dots.rule.name": "Vérifiez bien que vos DoTs sont bien appliqués à votre cible",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -185,6 +185,7 @@
   "blu.coldfog.dropped_casts.why": "",
   "blu.coldfog.ineffective.content": "",
   "blu.coldfog.ineffective.why": "",
+  "blu.deaths.why": "",
   "blu.dots.requirement.uptime-bleed.name": "アクティブ率: <0/>",
   "blu.dots.rule.description": "",
   "blu.dots.rule.name": "常にDoTを切らさないようにしてください。",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -185,6 +185,7 @@
   "blu.coldfog.dropped_casts.why": "",
   "blu.coldfog.ineffective.content": "",
   "blu.coldfog.ineffective.why": "",
+  "blu.deaths.why": "",
   "blu.dots.requirement.uptime-bleed.name": "적용시간 <0/>",
   "blu.dots.rule.description": "",
   "blu.dots.rule.name": "항상 도트가 유지되도록 하십시오.",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -185,6 +185,7 @@
   "blu.coldfog.dropped_casts.why": "{droppedWhiteDeathCasts, plural, other {# 次彻骨雾寒}} 中打出 <0/> 少于6次。",
   "blu.coldfog.ineffective.content": "要让 <0/> 有正收益，你至少要使用2次 <1/> 于 <2/> 期间。",
   "blu.coldfog.ineffective.why": "{ineffectiveColdFog, plural, other {# 次彻骨雾寒}} 由于没有使用足够次数的 <0/> 而亏损了DPS。",
+  "blu.deaths.why": "",
   "blu.dots.requirement.uptime-bleed.name": "<0/> 覆盖率",
   "blu.dots.rule.description": "月下彼岸花和苦闷之歌附加的 <0/> 效果占了总伤害的15%左右。",
   "blu.dots.rule.name": "保持DoT不断",

--- a/src/parser/core/modules/Death.tsx
+++ b/src/parser/core/modules/Death.tsx
@@ -32,7 +32,7 @@ declare module 'event' {
 	}
 }
 
-interface ActorInfo {
+export interface ActorDeathInfo {
 	timestampDeath?: Event['timestamp']
 	timestampTranscendent?: Event['timestamp']
 	count: number
@@ -53,7 +53,7 @@ export class Death extends Analyser {
 		return this.getDuration(this.parser.actor.id)
 	}
 
-	private info = new Map<Actor['id'], ActorInfo>()
+	private info = new Map<Actor['id'], ActorDeathInfo>()
 
 	getCount(actorId: Actor['id']) {
 		return this.getActorInfo(actorId).count
@@ -88,7 +88,7 @@ export class Death extends Analyser {
 		this.addEventHook('complete', this.onComplete)
 	}
 
-	private getActorInfo(actorId: Actor['id']): ActorInfo {
+	private getActorInfo(actorId: Actor['id']): ActorDeathInfo {
 		let actorInfo = this.info.get(actorId)
 		if (actorInfo == null) {
 			actorInfo = {count: 0, duration: 0}
@@ -184,6 +184,15 @@ export class Death extends Analyser {
 		})
 	}
 
+	protected deathSuggestionWhy(_actorId: Actor['id'], playerInfo: ActorDeathInfo): JSX.Element {
+		return <Plural
+			id="core.deaths.why"
+			value={playerInfo.count}
+			_1="# death"
+			other="# deaths"
+		/>
+	}
+
 	private onComplete(event: Events['complete']) {
 		for (const [actorId, actorInfo] of this.info) {
 			// If the actor was dead on completion, and the pull was a wipe, refund the
@@ -209,12 +218,7 @@ export class Death extends Analyser {
 				Don't die. Between downtime, lost gauge resources, and resurrection debuffs, dying is absolutely <em>crippling</em> to damage output.
 			</Trans>,
 			severity: SEVERITY.MORBID,
-			why: <Plural
-				id="core.deaths.why"
-				value={playerInfo.count}
-				_1="# death"
-				other="# deaths"
-			/>,
+			why: this.deathSuggestionWhy(this.parser.actor.id, playerInfo),
 		}))
 	}
 

--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -3,9 +3,18 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-07-12'),
+		Changes: () => <>
+			<ul>
+				<li>Dying to Final Sting and Self-Destruct won't be counted as a death. </li>
+				<li>Moon Flute windows with a Final Sting have no requirements. </li>
+			</ul>
+		</>,
+		contributors: [CONTRIBUTORS.HUGMEIR],
+	},
+	{
 		date: new Date('2023-05-14'),
 		Changes: () => <>BLU's Overheal report no longer counts Devour as a heal</>,
-		Changes: () => <>Dying to Final Sting and Self-Destruct won't be counted as a death</>,
 		contributors: [CONTRIBUTORS.HUGMEIR],
 	},
 	{

--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -5,6 +5,7 @@ export const changelog = [
 	{
 		date: new Date('2023-05-14'),
 		Changes: () => <>BLU's Overheal report no longer counts Devour as a heal</>,
+		Changes: () => <>Dying to Final Sting and Self-Destruct won't be counted as a death</>,
 		contributors: [CONTRIBUTORS.HUGMEIR],
 	},
 	{

--- a/src/parser/jobs/blu/modules/Death.tsx
+++ b/src/parser/jobs/blu/modules/Death.tsx
@@ -1,0 +1,42 @@
+import {Event, Events} from 'event'
+import {filter, oneOf} from 'parser/core/filter'
+import {dependency} from 'parser/core/Injectable'
+import {Data} from 'parser/core/modules/Data'
+import {Death} from 'parser/core/modules/Death'
+
+// Deaths from Final Sting and Self-Destruct should not count for
+// the report.
+// It would be nice to check for early stings here, but that would
+// require comparing how much damage the sting did vs how much health
+// the boss had left, which is too fight-specific.
+
+export class BLUDeath extends Death {
+	@dependency private mydata!: Data
+
+	private isFinalSting = false
+
+	override initialise() {
+		super.initialise()
+		this.addEventHook(filter<Event>().source(this.parser.actor.id).type('action')
+			.action(oneOf([
+				this.mydata.actions.FINAL_STING.id,
+				this.mydata.actions.SELF_DESTRUCT.id,
+			])), this.onFinalSting)
+	}
+
+	private onFinalSting() {
+		this.isFinalSting = true
+	}
+
+	override shouldCountDeath(event: Events['actorUpdate']): boolean {
+		if (event.actor !== this.parser.actor.id) {
+			return true
+		}
+		if (this.isFinalSting) {
+			this.isFinalSting = false
+			return false
+		}
+		return true
+	}
+}
+

--- a/src/parser/jobs/blu/modules/Death.tsx
+++ b/src/parser/jobs/blu/modules/Death.tsx
@@ -49,7 +49,7 @@ export class BLUDeath extends Death {
 	override deathSuggestionWhy(actorId: Actor['id'], playerInfo: ActorDeathInfo): JSX.Element {
 		const actorStings = this.actorStings.get(actorId) ?? 0
 		if (actorStings === 0) {
-			super.deathSuggestionWhy(actorId, playerInfo)
+			return super.deathSuggestionWhy(actorId, playerInfo)
 		}
 
 		return <Trans id="blu.deaths.why">
@@ -57,11 +57,11 @@ export class BLUDeath extends Death {
 				value={playerInfo.count}
 				_1="# death"
 				other="# deaths"
-			/>.  That number does not include the <Plural id="blu.deaths.why.final_stings"
+			/>, not counting <Plural id="blu.deaths.why.final_stings"
 				value={actorStings}
 				_1="# death"
 				other="# deaths"
-			/> from using <DataLink action="FINAL_STING"/>
+			/> from using <DataLink action="FINAL_STING" showIcon={false} />.
 		</Trans>
 	}
 }

--- a/src/parser/jobs/blu/modules/MoonFlute.tsx
+++ b/src/parser/jobs/blu/modules/MoonFlute.tsx
@@ -1,6 +1,7 @@
 import {t} from '@lingui/macro'
 import {Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
+import {RotationTargetOutcome} from 'components/ui/RotationTable'
 import {dependency} from 'parser/core/Injectable'
 import {BuffWindow, ExpectedActionGroupsEvaluator, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
@@ -45,6 +46,9 @@ const EXPECTED_GCD_COUNT = 5
 // ...but for implementation details, Phantom Flurry is marked as a GCD,
 // so even though we technically only do 4 GCDs in the window, we are
 // looking for a pseudo-5th, Phantom Flurry.
+//
+// Also, if they used Final Sting, then we window can be as short as a single
+// GCD!
 
 export class MoonFlute extends BuffWindow {
 	static override handle = 'moonflutes'
@@ -74,6 +78,7 @@ export class MoonFlute extends BuffWindow {
 			suggestionWindowName,
 			severityTiers: SEVERITIES.TOO_FEW_GCDS,
 			hasStacks: false,
+			adjustCount: this.adjustExpectedGcdCount.bind(this),
 		}))
 
 		this.addEvaluator(new ExpectedActionGroupsEvaluator({
@@ -132,7 +137,27 @@ export class MoonFlute extends BuffWindow {
 				are <ActionLink action="NIGHTBLOOM" showIcon={false} />, and finishing the combo with a <ActionLink action="PHANTOM_FLURRY" showIcon={false} />.
 			</Trans>,
 			severityTiers: SEVERITIES.MISSING_EXPECTED_USES,
+			adjustOutcome: this.adjustExpectedActionOutcome.bind(this),
 		}))
+	}
+
+	private adjustExpectedGcdCount(window: HistoryEntry<EvaluatedAction[]>) {
+		const finalStingUsed = window.data.filter(event => (event.action.id === this.data.actions.FINAL_STING.id || event.action.id === this.data.actions.SELF_DESTRUCT.id)).length
+		return finalStingUsed >= 1 ? (-window.data.length+1) : 0
+	}
+
+	private adjustExpectedActionOutcome(window: HistoryEntry<EvaluatedAction[]>, _action: TrackedAction) {
+		const finalStingUsed = window.data.filter(event => (event.action.id === this.data.actions.FINAL_STING.id || event.action.id === this.data.actions.SELF_DESTRUCT.id)).length
+		if (finalStingUsed === 0) {
+			return
+		}
+
+		return (actual: number, expected?: number) => {
+			if (expected !== undefined && actual === expected) {
+				return RotationTargetOutcome.POSITIVE
+			}
+			return RotationTargetOutcome.NEUTRAL
+		}
 	}
 }
 

--- a/src/parser/jobs/blu/modules/MoonFlute.tsx
+++ b/src/parser/jobs/blu/modules/MoonFlute.tsx
@@ -142,13 +142,18 @@ export class MoonFlute extends BuffWindow {
 		}))
 	}
 
-	private adjustExpectedGcdCount(window: HistoryEntry<EvaluatedAction[]>) {
+	private finalStingsUsedInWindow(window: HistoryEntry<EvaluatedAction[]>): number {
 		const finalStingUsed = window.data.filter(event => (event.action.id === this.data.actions.FINAL_STING.id || event.action.id === this.data.actions.SELF_DESTRUCT.id)).length
+		return finalStingUsed
+	}
+
+	private adjustExpectedGcdCount(window: HistoryEntry<EvaluatedAction[]>) {
+		const finalStingUsed = this.finalStingsUsedInWindow(window)
 		return finalStingUsed >= 1 ? (-window.data.length+1) : 0
 	}
 
 	private adjustExpectedActionOutcome(window: HistoryEntry<EvaluatedAction[]>, _action: TrackedActionGroup) {
-		const finalStingUsed = window.data.filter(event => (event.action.id === this.data.actions.FINAL_STING.id || event.action.id === this.data.actions.SELF_DESTRUCT.id)).length
+		const finalStingUsed = this.finalStingsUsedInWindow(window)
 		if (finalStingUsed === 0) {
 			return
 		}

--- a/src/parser/jobs/blu/modules/MoonFlute.tsx
+++ b/src/parser/jobs/blu/modules/MoonFlute.tsx
@@ -3,7 +3,8 @@ import {Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
 import {RotationTargetOutcome} from 'components/ui/RotationTable'
 import {dependency} from 'parser/core/Injectable'
-import {BuffWindow, ExpectedActionGroupsEvaluator, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
+import {BuffWindow, EvaluatedAction, TrackedActionGroup, ExpectedActionGroupsEvaluator, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
+import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
@@ -146,7 +147,7 @@ export class MoonFlute extends BuffWindow {
 		return finalStingUsed >= 1 ? (-window.data.length+1) : 0
 	}
 
-	private adjustExpectedActionOutcome(window: HistoryEntry<EvaluatedAction[]>, _action: TrackedAction) {
+	private adjustExpectedActionOutcome(window: HistoryEntry<EvaluatedAction[]>, _action: TrackedActionGroup) {
 		const finalStingUsed = window.data.filter(event => (event.action.id === this.data.actions.FINAL_STING.id || event.action.id === this.data.actions.SELF_DESTRUCT.id)).length
 		if (finalStingUsed === 0) {
 			return

--- a/src/parser/jobs/blu/modules/index.tsx
+++ b/src/parser/jobs/blu/modules/index.tsx
@@ -2,6 +2,7 @@ import {Tincture} from 'parser/core/modules/Tincture'
 import {AlwaysBeCasting} from './AlwaysBeCasting'
 import {BLURaidBuffs} from './BLURaidBuffs'
 import {ColdFog} from './ColdFog'
+import {BLUDeath} from './Death'
 import {Defensives} from './Defensives'
 import {DoTs} from './DoTs'
 import {DroppedBuffs} from './DroppedBuffs'
@@ -16,6 +17,7 @@ import {BLUWeaving} from './Weaving'
 
 export default [
 	Defensives,
+	BLUDeath,
 	BLUWeaving,
 	AlwaysBeCasting,
 	DoTs,


### PR DESCRIPTION
`Final Sting` is one of BLU's "signature" moves --  At the cost of our lives, we do a significant chunk of damage.

The changes in this MR accomplish two things:

1. Deaths caused by `Final Sting` should not be counted as Deaths at all
2. `Final Sting` is normally buffed by using Moon Flute first; thus buff windows that end in a Final Sting are excempt from most requirements.

Also, note that all of this also applies to `Self-Destruct`.