### PR TITLE
BLU: Overheal report should not consider Devour a heal

### DIFF
--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-05-14'),
+		Changes: () => <>BLU's Overheal report no longer counts Devour as a heal</>,
+		contributors: [CONTRIBUTORS.HUGMEIR],
+	},
+	{
 		date: new Date('2023-05-08'),
 		Changes: () => <>Support for BLU for 6.0 - 6.4</>,
 		contributors: [CONTRIBUTORS.HUGMEIR],

--- a/src/parser/jobs/blu/modules/Overheal.tsx
+++ b/src/parser/jobs/blu/modules/Overheal.tsx
@@ -1,6 +1,6 @@
 import {Trans} from '@lingui/react'
 import ACTIONS from 'data/ACTIONS'
-import {Event} from 'event'
+import {Event, Events} from 'event'
 import {filter} from 'parser/core/filter'
 import {Overheal, SuggestedColors} from 'parser/core/modules/Overheal'
 import React from 'react'
@@ -44,6 +44,15 @@ export class BLUOverheal extends Overheal {
 		this.addEventHook(filter<Event>().type('complete'), this.onCompleteExtra)
 		super.initialise()
 		this.addEventHook(filter<Event>().type('complete'), this.onCompleteExtra)
+	}
+
+	override considerHeal(event: Events['heal'], _pet: boolean = false): boolean {
+		// Filter out Devour; it's going to be used on cooldown by tanks, and either
+		// as a DPS button or occasionally as a mechanic button (e.g. A8S Gavel)
+		if (event.cause.type === 'action') {
+			return event.cause.action !== this.data.actions.DEVOUR.id
+		}
+		return true
 	}
 
 	private onCompleteExtra() {


### PR DESCRIPTION
Devour is a 250 potency GCD that works roughly like WAR's Thrill of Battle -- it gives a buff that temporarily increases your max HP, and heals for the amount increased.

BLU tanks essentially pop this on cooldown.  BLU DPSes don't normally carry it, but if they do, they either use it on cooldown for a minor potency gain (30 or 40 potency vs our filler GCD) or hold it for specific mechanics (A8S Gavel).

BLU's Overheal report is special in that it only appears if the person used any non-White Wind heals, and the heal from Devour was causing a false positive.