### PR TITLE
[Core] defensive cooldowns prepull fix

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,13 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2023-07-09'),
+		Changes: () => <>
+			Fixed prepull actions for defensive cooldowns module.
+		</>,
+		contributors: [CONTRIBUTORS.OTOCEPHALY],
+	},
+	{
 		date: new Date('2023-05-24'),
 		Changes: () => <>
 			Overhaul defensive cooldown analysis for all jobs, including role actions by default.

--- a/src/parser/core/modules/Defensives.tsx
+++ b/src/parser/core/modules/Defensives.tsx
@@ -144,9 +144,14 @@ export class Defensives extends Analyser {
 			currentCharges = chargesAvailableEvent?.current || 0
 		}
 
+		const prepullBoolean: boolean = this.getUses(defensive).find(historyEntry => historyEntry.start === this.parser.pull.timestamp)?.start != null
 		const cooldown = defensive.cooldown || this.parser.pull.duration
 		const nextEntry = this.getUses(defensive).find(historyEntry => historyEntry.start > timestamp)
 		const useByTimestamp = nextEntry != null ? (nextEntry.start - cooldown) : (this.parser.pull.timestamp + this.parser.pull.duration)
+
+		//need to consider whether there is a prepull action as it will shift every subsequent event for this analysis. assumption is that it was actioned right at pull since no timestamp available for prepull so cooldown is used
+		availableTimestamp = availableTimestamp
+			+ (prepullBoolean && availableTimestamp !== (this.parser.pull.duration + this.parser.pull.timestamp) ? cooldown : 0)
 
 		if (useByTimestamp <= availableTimestamp) {
 			return {chargesBeforeNextUse: 0, availableTimestamp, useByTimestamp}


### PR DESCRIPTION
if someone used an action prior to the pull, there was an issue with the timestamps

Here are the before and after screenshots using this log
https://www.fflogs.com/reports/a:bgxRam2h8M6pqTr4#fight=16

Before (AST / SCH):
![image](https://github.com/xivanalysis/xivanalysis/assets/89435408/332acd77-0fb6-4a07-9b71-dab7e1f1628e)
![image](https://github.com/xivanalysis/xivanalysis/assets/89435408/8e608307-7776-4774-94a8-7b436ca9ad3f)

After (AST / SCH):
![image](https://github.com/xivanalysis/xivanalysis/assets/89435408/48873e91-f398-4245-b145-55846697dda3)
![image](https://github.com/xivanalysis/xivanalysis/assets/89435408/e05a3f91-99d1-454e-a28d-15fd6ec9a668)
