### PR TITLE
Add debug.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 test.html
+*debug.log*
 
 # shh
 *.ignore.*


### PR DESCRIPTION
Recent versions of VSCode or yarn or node or something are generating a debug.log file I keep having to exclude from commits. Updooting the gitignore so I don't have to pay attention anymore...