### PR TITLE
BLU: Add the statuses for Chelonian Gate and Auspicious Trance

### DIFF
--- a/src/data/ACTIONS/root/BLU.ts
+++ b/src/data/ACTIONS/root/BLU.ts
@@ -778,6 +778,7 @@ export const BLU = ensureActions({
 		gcdRecast: 2500,
 		cooldown: 30000,
 		cooldownGroup: BLU_COOLDOWN_GROUP.THE_ROSE_OF_DESTRUCTION,
+		statusesApplied: ['CHELONIAN_GATE', 'AUSPICIOUS_TRANCE'],
 	},
 	DIVINE_CATARACT: {
 		id: 23274,

--- a/src/data/STATUSES/root/BLU.ts
+++ b/src/data/STATUSES/root/BLU.ts
@@ -208,4 +208,15 @@ export const BLU = ensureStatuses({
 		icon: 'https://xivapi.com/i/013000/013534.png',
 		duration: 15000,
 	},
+	CHELONIAN_GATE: {
+		id: 2496,
+		name: 'Chelonian Gate',
+		icon: 'https://xivapi.com/i/013000/013535.png',
+		duration: 10000,
+	},
+	AUSPICIOUS_TRANCE: {
+		id: 2497,
+		name: 'Auspicious Trance',
+		icon: 'https://xivapi.com/i/013000/013536.png',
+	},
 })


### PR DESCRIPTION
Currently just for completeness/groundwork, might eventually get used as part of the BLU tank suggestions ala not popping DRK's TBN.