### PR TITLE
Core ActionTimeline: Option to resolve the label name late

### DIFF
--- a/src/parser/jobs/blu/modules/ActionTimeline.tsx
+++ b/src/parser/jobs/blu/modules/ActionTimeline.tsx
@@ -1,0 +1,57 @@
+import {ActionRow, ActionTimeline as CoreActionTimeline} from 'parser/core/modules/ActionTimeline'
+
+export class ActionTimeline extends CoreActionTimeline {
+	static override rows: ActionRow[] = [
+		...CoreActionTimeline.rows,
+		'NIGHTBLOOM',
+		'TRIPLE_TRIDENT',
+		{
+			lateResolveLabel: true,
+			content: ['THE_ROSE_OF_DESTRUCTION', 'CHELONIAN_GATE'],
+		},
+		{
+			lateResolveLabel: true,
+			content: ['SHOCK_STRIKE', 'BLU_MOUNTAIN_BUSTER'],
+		},
+		'GLASS_DANCE',
+		'SURPANAKHA',
+		{
+			lateResolveLabel: true,
+			content: ['MATRA_MAGIC', 'DRAGON_FORCE', 'ANGELS_SNACK'],
+		},
+		{
+			lateResolveLabel: true,
+			content: ['FEATHER_RAIN', 'ERUPTION'],
+		},
+		{
+			lateResolveLabel: true,
+			content: ['PHANTOM_FLURRY', 'PHANTOM_FLURRY_KICK'],
+		},
+		{
+			lateResolveLabel: true,
+			content: ['QUASAR', 'J_KICK'],
+		},
+		{
+			label: 'Raid Buffs',
+			content: [
+				'PECULIAR_LIGHT',
+				'OFF_GUARD',
+			],
+		},
+		'COLD_FOG',
+
+		// Standard role actions
+		'LUCID_DREAMING',
+		'SWIFTCAST',
+
+		// Mit
+		'ADDLE',
+		'MAGIC_HAMMER',
+
+		// Ressurect
+		'ANGEL_WHISPER',
+
+		// Tanking CDs
+		'DEVOUR',
+	]
+}

--- a/src/parser/jobs/blu/modules/GeneralCDDowntime.ts
+++ b/src/parser/jobs/blu/modules/GeneralCDDowntime.ts
@@ -51,4 +51,9 @@ export class GeneralCDDowntime extends CooldownDowntime {
 			firstUseOffset: 50000, // up to 50 seconds into the pull, if people are staggering their buffs
 		},
 	]
+	override suggestionOnlyCooldowns = [
+		{cooldowns: [this.data.actions.MATRA_MAGIC]},
+		{cooldowns: [this.data.actions.DRAGON_FORCE]},
+		{cooldowns: [this.data.actions.ANGELS_SNACK]},
+	]
 }

--- a/src/parser/jobs/blu/modules/index.tsx
+++ b/src/parser/jobs/blu/modules/index.tsx
@@ -1,5 +1,6 @@
 import {LucidDreaming} from 'parser/core/modules/LucidDreaming'
 import {Tincture} from 'parser/core/modules/Tincture'
+import {ActionTimeline} from './ActionTimeline'
 import {AlwaysBeCasting} from './AlwaysBeCasting'
 import {BLURaidBuffs} from './BLURaidBuffs'
 import {ColdFog} from './ColdFog'
@@ -19,6 +20,7 @@ import {BLUWeaving} from './Weaving'
 
 export default [
 	Defensives,
+	ActionTimeline,
 	BLUDeath,
 	BLUWeaving,
 	AlwaysBeCasting,


### PR DESCRIPTION
This is really just groundwork for a QoL change in BLU; we have several abilities that share cooldowns, like Quasar and J Kick -- because of spell slot limitations, people will only take one or the other, so it's much nicer if the timeline shows the name of the ability they used.

Internally, this introduces a `lateResolveLabel` attribute to the action row config.  Normally, timeline labels are resolved immediately (during `initialise()`), so we cannot check which cooldowns have been used yet.
If `lateResolveLabel` is there and true, then when passing multiple alternative abilities for one row, it will wait until the last possible moment, then look at the cooldowns and find which one of the provided abilities was used.

You can see a sample of the end result in these two:
<img width="566" alt="Screenshot 2023-07-12 at 13 12 34" src="https://github.com/xivanalysis/xivanalysis/assets/215227/95a81ef1-fdd8-4a45-8dbd-a3ac875ea8a7">
<img width="632" alt="Screenshot 2023-07-12 at 13 12 49" src="https://github.com/xivanalysis/xivanalysis/assets/215227/7ae86260-2462-443d-b13c-cbef728ee917">

Note that J Kick / Quasar, Eruption / Feather Rain, Angel's Snack / Matra Magic each share cooldowns, but the timeline just shows whichever they first used.