### PR TITLE
BLU StatusTimeline: Merge the effects from Bad Breath & Moon Flute

### DIFF
--- a/src/parser/jobs/blu/modules/StatusTimeline.ts
+++ b/src/parser/jobs/blu/modules/StatusTimeline.ts
@@ -1,0 +1,9 @@
+import STATUSES from 'data/STATUSES'
+import {StatusTimeline as CoreStatusTimeline} from 'parser/core/modules/StatusTimeline'
+
+export class StatusTimeline extends CoreStatusTimeline {
+	static override statusesStackMapping = {
+		[STATUSES.BAD_BREATH_POISON.id]: STATUSES.MALODOROUS.id,
+		[STATUSES.WANING_NOCTURNE.id]: STATUSES.WAXING_NOCTURNE.id,
+	}
+}

--- a/src/parser/jobs/blu/modules/index.tsx
+++ b/src/parser/jobs/blu/modules/index.tsx
@@ -12,6 +12,7 @@ import {Interrupts} from './Interrupts'
 import {MoonFlute} from './MoonFlute'
 import {BLUOverheal} from './Overheal'
 import {RevengeBlast} from './RevengeBlast'
+import {StatusTimeline} from './StatusTimeline'
 import {Swiftcast} from './Swiftcast'
 import {TripleTrident} from './TripleTrident'
 import {BLUWeaving} from './Weaving'
@@ -32,6 +33,7 @@ export default [
 	RevengeBlast,
 	BLURaidBuffs,
 	BLUOverheal,
+	StatusTimeline,
 	TripleTrident,
 	DroppedBuffs,
 ]


### PR DESCRIPTION
Malodorous (10% mit) and Poison (tiny DoT) both apply at the same time and for the same duration, so tracking them separately is just noise.

For Moon Flute, Waning Nocturne automatically applies as soon as Waxing Nocturne falls off, so having another row in the timeline tells you nothing.

Presumably Lightheaded and Burns would go here too, but only some ARR Extremes are affected by those, so we don't have to care.