### PR TITLE
BLU Defensives: Add per-mimicry defensives

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -195,6 +195,8 @@
   "blu.droppedbuffs.suggestions.overwritten.content": "",
   "blu.droppedbuffs.suggestions.overwritten.why": "",
   "blu.interrupts.suggestion.content": "",
+  "blu.mimicry_missing.content": "",
+  "blu.mimicry_missing.why": "",
   "blu.moonflutes.suggestions.expected-actions.content": "",
   "blu.moonflutes.suggestions.gcds.content": "",
   "blu.moonflutes.title": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -195,6 +195,8 @@
   "blu.droppedbuffs.suggestions.overwritten.content": "<0/> was overwritten.",
   "blu.droppedbuffs.suggestions.overwritten.why": "{overwrittenStatusCount, plural, one {# Use of } other {# Uses of }} <0/> were overwritten.",
   "blu.interrupts.suggestion.content": "Blue Mage has few movement tools. Our <0/> will either be used during the <1/> window, or be left in reserve for a resurrect. In very select circumstances <2/> can be used to get 15 seconds of free movement, but this is rare. Generally, you will want to pre-position and use slidecast windows as much as you can.",
+  "blu.mimicry_missing.content": "You did not have any <0/> stance on.  This is free damage!",
+  "blu.mimicry_missing.why": "You should always have this.",
   "blu.moonflutes.suggestions.expected-actions.content": "<0/> is only worth using if the buffed actions during the window will give you an extra 1260 potency (equivalent to casting <1/> six times). The more of your larger cooldowns you can fit into the window, the better the result. High-priority targets are <2/>, and finishing the combo with a <3/>.",
   "blu.moonflutes.suggestions.gcds.content": "Regardless of spell speed, ideally a <0/> window should contain at least 4 GCDs and end in <1/>. If you have higher latency this can be problematic. Changing your speed speed might help, and in a pinch you can try moving certain oGCDs out of the window (<2/>, <3/>,<4/>), or replacing <5/>with a <6/>.",
   "blu.moonflutes.title": "Moon Flute Windows",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -195,6 +195,8 @@
   "blu.droppedbuffs.suggestions.overwritten.content": "",
   "blu.droppedbuffs.suggestions.overwritten.why": "",
   "blu.interrupts.suggestion.content": "",
+  "blu.mimicry_missing.content": "",
+  "blu.mimicry_missing.why": "",
   "blu.moonflutes.suggestions.expected-actions.content": "",
   "blu.moonflutes.suggestions.gcds.content": "",
   "blu.moonflutes.title": "",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -195,6 +195,8 @@
   "blu.droppedbuffs.suggestions.overwritten.content": "",
   "blu.droppedbuffs.suggestions.overwritten.why": "",
   "blu.interrupts.suggestion.content": "",
+  "blu.mimicry_missing.content": "",
+  "blu.mimicry_missing.why": "",
   "blu.moonflutes.suggestions.expected-actions.content": "",
   "blu.moonflutes.suggestions.gcds.content": "",
   "blu.moonflutes.title": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -195,6 +195,8 @@
   "blu.droppedbuffs.suggestions.overwritten.content": "",
   "blu.droppedbuffs.suggestions.overwritten.why": "",
   "blu.interrupts.suggestion.content": "",
+  "blu.mimicry_missing.content": "",
+  "blu.mimicry_missing.why": "",
   "blu.moonflutes.suggestions.expected-actions.content": "",
   "blu.moonflutes.suggestions.gcds.content": "",
   "blu.moonflutes.title": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -195,6 +195,8 @@
   "blu.droppedbuffs.suggestions.overwritten.content": "<0/> 被覆盖了。",
   "blu.droppedbuffs.suggestions.overwritten.why": "{overwrittenStatusCount, plural, other {# 次 }} <0/> 被覆盖了。",
   "blu.interrupts.suggestion.content": "青魔法师没什么移动用的技能。<0/> 一般在 <1/> 期间打掉了，或者留着复活用。少数情况可以用 <2/> 获得15秒自由移动时间。总体来说，尽量提前站位，利用好滑步。",
+  "blu.mimicry_missing.content": "",
+  "blu.mimicry_missing.why": "",
   "blu.moonflutes.suggestions.expected-actions.content": "只有能覆盖额外1260威力的技能时，<0/>才有收益(相当于打6个<1/>)。把更多能力打进月之笛窗口以进一步提升收益，比如 <2/>，并以 <3/> 结尾。",
   "blu.moonflutes.suggestions.gcds.content": "不管咏速如何，理想的 <0/> 应该包含至少4个GCD并以 <1/> 结尾。如果你的延迟偏高，这可能会有点问题。可以考虑调节咏速，紧急情况下可以放弃一个能力(<2/>、<3/>、<4/>)，或者把 <5/> 换成 <6/>。",
   "blu.moonflutes.title": "月之笛",

--- a/src/parser/core/modules/Defensives.tsx
+++ b/src/parser/core/modules/Defensives.tsx
@@ -56,7 +56,7 @@ export class Defensives extends Analyser {
 		return this.getUses(defensive).length
 	}
 
-	private getUses(defensive: Action): CooldownHistoryEntry[] {
+	protected getUses(defensive: Action): CooldownHistoryEntry[] {
 		return this.cooldowns.cooldownHistory(defensive).filter((entry) => entry.endReason !== CooldownEndReason.INTERRUPTED)
 	}
 

--- a/src/parser/jobs/blu/modules/Defensives.tsx
+++ b/src/parser/jobs/blu/modules/Defensives.tsx
@@ -1,8 +1,84 @@
+import {Trans} from '@lingui/react'
+import {DataLink} from 'components/ui/DbLink'
+import {Status} from 'data/STATUSES'
+import {Event, Events} from 'event'
+import {filter, oneOf} from 'parser/core/filter'
+import {dependency} from 'parser/core/Injectable'
 import {Defensives as CoreDefensives} from 'parser/core/modules/Defensives'
+import Suggestions, {SEVERITY, Suggestion} from 'parser/core/modules/Suggestions'
+import React from 'react'
 
+// Defensive suggestions are a bit different for each mimicry.
+// And since we are already checking for mimicry, add a suggestion
+// if they don't have one running!
 export class Defensives extends CoreDefensives {
+
+	// Basic defensives are Addle and Magic Hammer.
+	// Due to spell slot limitations, not everyone will be carrying Magic Hammer,
+	// so later we filter this out of the report if they never used it.
 	protected override trackedDefensives = [
 		this.data.actions.ADDLE,
 		this.data.actions.MAGIC_HAMMER,
 	]
+
+	@dependency private suggestions!: Suggestions
+
+	private currentMimicry?: Status['id']
+	override initialise() {
+		super.initialise()
+
+		// This is missing a million edge cases, like people taking off
+		// mimicry mid-pull or turning it on mid-pull.  But it's fine --
+		// it should just point out if they had a pull without mimicry
+		const playerFilter = filter<Event>().source(this.parser.actor.id)
+		this.addEventHook(playerFilter.type('statusApply').status(oneOf([
+			this.data.statuses.MIMICRY_TANK.id,
+			this.data.statuses.MIMICRY_HEALER.id,
+			this.data.statuses.MIMICRY_DPS.id,
+		])), this.onApplyMimicry)
+
+		this.addEventHook('complete', this.onCompleteDefensives)
+	}
+
+	private onApplyMimicry(event: Events['statusApply']) {
+		this.currentMimicry = event.status
+	}
+
+	private onCompleteDefensives() {
+		// Filter out Magic Hammer if they never used it -- Assume that they just didn't
+		// have it slotted.
+		if (this.getUses(this.data.actions.MAGIC_HAMMER).length === 0) {
+			const index = this.trackedDefensives.indexOf(this.data.actions.MAGIC_HAMMER)
+			this.trackedDefensives.splice(index, 1)
+		}
+
+		switch (this.currentMimicry) {
+		case this.data.statuses.MIMICRY_TANK.id:
+			this.trackedDefensives.push(
+				this.data.actions.DRAGON_FORCE,
+				this.data.actions.CHELONIAN_GATE,
+				this.data.actions.DEVOUR,
+			)
+			break
+		case this.data.statuses.MIMICRY_HEALER.id:
+			this.trackedDefensives.push(this.data.actions.ANGELS_SNACK)
+			break
+		case this.data.statuses.MIMICRY_DPS.id:
+			// DPSes just get Addle and possibly Magic Hammer.
+			break
+		default:
+			// No mimicry at all!  This is the first time I would genuinely argue for a
+			// "Morbid" severity -- essentially missing a 20% damage buff that lasts the
+			// entire fight and requires zero resources or upkeep.
+			this.suggestions.add(new Suggestion({
+				icon: this.data.actions.AETHERIAL_MIMICRY.icon,
+				content: <Trans id="blu.mimicry_missing.content">
+					You did not have any <DataLink action="AETHERIAL_MIMICRY"/> stance on.  This is free damage!
+				</Trans>,
+				severity: SEVERITY.MAJOR,
+				why: <Trans id="blu.mimicry_missing.why">You should always have this.</Trans>,
+			}))
+			break
+		}
+	}
 }


### PR DESCRIPTION
Plus a MAJOR level severity if people are missing mimickry! It's free real estate/damage.

NOTE: Mimicry detection requires handling prepull auras, which is separately done here: https://github.com/xivanalysis/xivanalysis/pull/1813
This one is pretty useless without that.

Sample logs:
Healer defensives:
https://www.fflogs.com/reports/NK4cfhJz3B9vqGRx#fight=25&source=2

Tank defensives:
https://www.fflogs.com/reports/NK4cfhJz3B9vqGRx#fight=25&source=3

DPS with Magic Hammer slotted:
https://www.fflogs.com/reports/NK4cfhJz3B9vqGRx#fight=25&source=6

DPS without Magic Hammer:
https://www.fflogs.com/reports/NK4cfhJz3B9vqGRx#fight=25&source=1