### PR TITLE
BLU: Triple Trident and SpS need special handling

### DIFF
--- a/src/parser/jobs/blu/modules/MoonFlute.tsx
+++ b/src/parser/jobs/blu/modules/MoonFlute.tsx
@@ -2,9 +2,12 @@ import {t} from '@lingui/macro'
 import {Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
 import {RotationTargetOutcome} from 'components/ui/RotationTable'
+import {Event} from 'event'
+import {filter} from 'parser/core/filter'
 import {dependency} from 'parser/core/Injectable'
 import {BuffWindow, EvaluatedAction, TrackedActionGroup, ExpectedActionGroupsEvaluator, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
 import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
+import {Cooldowns} from 'parser/core/modules/Cooldowns'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
@@ -50,17 +53,31 @@ const EXPECTED_GCD_COUNT = 5
 //
 // Also, if they used Final Sting, then we window can be as short as a single
 // GCD!
+const neutralOrPositiveOutcome = (actual: number, expected?: number) => {
+	if (expected !== undefined && actual === expected) {
+		return RotationTargetOutcome.POSITIVE
+	}
+	return RotationTargetOutcome.NEUTRAL
+}
 
 export class MoonFlute extends BuffWindow {
 	static override handle = 'moonflutes'
 	static override title = t('blu.moonflutes.title')`Moon Flute Windows`
 
 	@dependency globalCooldown!: GlobalCooldown
+	@dependency private cooldowns!: Cooldowns
 
 	override buffStatus = this.data.statuses.WAXING_NOCTURNE
 
+	private windowMissedTT = new Set<number>()
+
 	override initialise() {
 		super.initialise()
+
+		// Add a Waning Moon hook, essentially telling us exactly when a MF window ended.
+		const extraFilter = filter<Event>().source(this.parser.actor.id).type('statusApply')
+			.status(this.data.statuses.WANING_NOCTURNE.id)
+		this.addEventHook(extraFilter, this.onWaningNocturneApply)
 
 		const suggestionIcon = this.data.actions.MOON_FLUTE.icon
 		const suggestionWindowName = <ActionLink action="MOON_FLUTE" showIcon={false}/>
@@ -147,23 +164,51 @@ export class MoonFlute extends BuffWindow {
 		return finalStingUsed
 	}
 
+	private onWaningNocturneApply() {
+		// This will be 0 if TT is available, and some number of milliseconds otherwise
+		const ttCd = this.cooldowns.remaining('TRIPLE_TRIDENT')
+		if (ttCd > 0) { return }
+
+		// They just finished a MF window and TT was available.  This is a Big Loss(tm);
+		// for Spell Speed builds this means they missed aligning their TT with the 6m
+		// MF window, and for Crit builds they just lost a ton of damage.
+		const current = this.history.getCurrent()
+		if (current == null) { return }
+		this.windowMissedTT.add(current.start)
+	}
+
 	private adjustExpectedGcdCount(window: HistoryEntry<EvaluatedAction[]>) {
 		const finalStingUsed = this.finalStingsUsedInWindow(window)
 		return finalStingUsed >= 1 ? (-window.data.length+1) : 0
 	}
 
-	private adjustExpectedActionOutcome(window: HistoryEntry<EvaluatedAction[]>, _action: TrackedActionGroup) {
+	private adjustExpectedActionOutcome(window: HistoryEntry<EvaluatedAction[]>, trackedActions: TrackedActionGroup) {
 		const finalStingUsed = this.finalStingsUsedInWindow(window)
 		if (finalStingUsed === 0) {
+			// Final Sting not used here
+			if (trackedActions.actions.length !== 1) {
+				// Default handling:
+				return
+			}
+			const trackedActionId = trackedActions.actions[0].id
+			if (trackedActionId === this.data.actions.TRIPLE_TRIDENT.id) {
+				// Using TT on cooldown, on a long enough timeline, can be a DPS gain over
+				// holding it for a MF window, particularly for SpS builds.
+				// So let's be understanding -- We only dock points if they were in a
+				// Moon Flute window, had TT available, and didn't use it.
+				if (!this.windowMissedTT.has(window.start)) {
+					// TT was either used, or wasn't available during the window.
+					// Either way, this check will either be a Positive or a Neutral,
+					// never a negative.
+					return neutralOrPositiveOutcome
+				}
+			}
+			// Default handling:
 			return
 		}
 
-		return (actual: number, expected?: number) => {
-			if (expected !== undefined && actual === expected) {
-				return RotationTargetOutcome.POSITIVE
-			}
-			return RotationTargetOutcome.NEUTRAL
-		}
+		// Final Sting used, so don't dock any points for missed actions:
+		return neutralOrPositiveOutcome
 	}
 }
 


### PR DESCRIPTION
The standard burst for BLU has us using Triple Trident under Moon Flute, but the story is a bit more complicated than that.

For Spell Speed builds, using Triple Trident on cooldown is a (small!) DPS gain over holding it for the Moon Flute window.

This commit adds handling for this case -- If TT was off cooldown during the burst window, either because this is the opener or because it re-aligned itself, then the report requires it to be used. If it was on cooldown, we don't dock them points for not being able to use it.

Sample log:
https://www.fflogs.com/reports/QNnLX27TH3d16YGj#fight=4&source=7
Particularly, the burst at 2:08 cannot use TT, since it was used on cooldown earlier, at around ~1:27

<img width="690" alt="Screenshot 2023-07-14 at 20 00 24" src="https://github.com/xivanalysis/xivanalysis/assets/215227/5fa95b98-3f14-4814-ad61-711f29eba200">