### PR TITLE
BLU: Winged Reprobation cooldown fun!

### DIFF
--- a/src/data/ACTIONS/root/BLU.ts
+++ b/src/data/ACTIONS/root/BLU.ts
@@ -1244,7 +1244,8 @@ export const BLU = ensureActions({
 		speedAttribute: Attribute.SPELL_SPEED,
 	},
 	WINGED_REPROBATION: {
-		// TODO: This spell is weird and does weird things with the cooldown.
+		// NOTE: This spell handles cooldowns in a very unusual way;
+		// see the WingedReprobation module for details.
 		id: 34576,
 		name: 'Winged Reprobation',
 		icon: 'https://xivapi.com/i/003000/003371.png',

--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-07-22'),
+		Changes: () => <>Winged Reprobation's cooldown will be displayed correctly in the timeline.</>,
+		contributors: [CONTRIBUTORS.HUGMEIR],
+	},
+	{
 		date: new Date('2023-07-20'),
 		Changes: () => <>Added BLU's new 6.45 spells & effects.</>,
 		contributors: [CONTRIBUTORS.HUGMEIR],

--- a/src/parser/jobs/blu/modules/GeneralCDDowntime.ts
+++ b/src/parser/jobs/blu/modules/GeneralCDDowntime.ts
@@ -1,8 +1,26 @@
+import {Events} from 'event'
+import {dependency} from 'parser/core/Injectable'
+import {Actors} from 'parser/core/modules/Actors'
 import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
 
 const DEFAULT_ALLOWED_DOWNTIME = 1000
+const MAX_WINGED_STACKS_BEFORE_CD = 3
 export class GeneralCDDowntime extends CooldownDowntime {
 	override defaultAllowedAverageDowntime = DEFAULT_ALLOWED_DOWNTIME
+
+	@dependency private actors!: Actors
+
+	override countUsage(e: Events['action']): boolean {
+		const actionId = e.action
+		if (actionId !== this.data.actions.WINGED_REPROBATION.id) {
+			return true
+		}
+		const wingedReprobationStacks = this.actors.current.getStatusData(this.data.statuses.WINGED_REPROBATION.id) ?? 0
+		if (wingedReprobationStacks < MAX_WINGED_STACKS_BEFORE_CD) {
+			return false
+		}
+		return true
+	}
 
 	override trackedCds = [
 		{

--- a/src/parser/jobs/blu/modules/WingedReprobation.tsx
+++ b/src/parser/jobs/blu/modules/WingedReprobation.tsx
@@ -1,0 +1,50 @@
+import {Event, Events} from 'event'
+import {Analyser} from 'parser/core/Analyser'
+import {filter} from 'parser/core/filter'
+import {dependency} from 'parser/core/Injectable'
+import {Cooldowns} from 'parser/core/modules/Cooldowns'
+import {Data} from 'parser/core/modules/Data'
+
+// Winged Reprobation (spell #118) works weird.  The description
+// says it is a 1s cast time, 90s cooldown GCD.
+//
+// But when you cast it, you get a stack of a buff. When you get
+// that buff, it resets the cooldown of Winged Reprobation, up to
+// 4 stacks -- when you get 4 stacks, you lose the buff and the
+// cooldown actually happens.
+//
+// So if we're getting the Winged Reprobation buff, and it's
+// not the 4-stack version, then reset the skill's cooldown.
+
+const MAX_WINGED_REPROBATION_STACKS = 4
+
+export class WingedReprobation extends Analyser {
+	static override handle = 'wingedprobation'
+
+	@dependency private data!: Data
+	@dependency private cooldowns!: Cooldowns
+
+	override initialise() {
+		super.initialise()
+
+		const wingedActorFilter = filter<Event>()
+			.source(this.parser.actor.id)
+			.type('statusApply')
+			.status(this.data.statuses.WINGED_REPROBATION.id)
+
+		this.addEventHook(wingedActorFilter, this.onApplyWingedReprobation)
+	}
+
+	private onApplyWingedReprobation(event: Events['statusApply']) {
+		const stacks = event.data ?? 1
+		if (stacks === MAX_WINGED_REPROBATION_STACKS) {
+			// In-game, you get the 4th stack and it immediately drops off and you
+			// get Winged Redemption.
+			// The logs don't seem to reflect this -- they show up to the third stack,
+			// but no data: 4 in there.
+			// Still, handle the case very simply, by not resetting the cooldown
+			return
+		}
+		this.cooldowns.reset('WINGED_REPROBATION')
+	}
+}

--- a/src/parser/jobs/blu/modules/index.tsx
+++ b/src/parser/jobs/blu/modules/index.tsx
@@ -18,6 +18,7 @@ import {StatusTimeline} from './StatusTimeline'
 import {Swiftcast} from './Swiftcast'
 import {TripleTrident} from './TripleTrident'
 import {BLUWeaving} from './Weaving'
+import {WingedReprobation} from './WingedReprobation'
 
 export default [
 	MightyGuardGCDing,
@@ -40,4 +41,5 @@ export default [
 	StatusTimeline,
 	TripleTrident,
 	DroppedBuffs,
+	WingedReprobation,
 ]


### PR DESCRIPTION
Winged Reprobation (spell #118) works weird.  The description says it is a 1s cast time, 90s cooldown GCD.

But when you cast it, you get a stack of a buff. When you get that buff, it resets the cooldown of Winged Reprobation, up to 4 stacks -- when you get 4 stacks, you lose the buff and the cooldown actually happens.

So if we're getting the Winged Reprobation buff, and it's not the 4-stack version, then reset the skill's cooldown.

NOTE: This also includes the changes in https://github.com/xivanalysis/xivanalysis/pull/1863 since that's what actually introduces the spell.