### PR TITLE
BLU Cooldowns: Only track used spells, & track three new 6.45 cooldowns

### DIFF
--- a/src/parser/core/modules/CooldownDowntime.tsx
+++ b/src/parser/core/modules/CooldownDowntime.tsx
@@ -174,7 +174,7 @@ export abstract class CooldownDowntime extends Analyser {
 		})
 	}
 
-	private onComplete() {
+	protected onComplete() {
 		const cdRequirements = []
 		for (const cdGroup of this.trackedCds) {
 			cdRequirements.push(this.createRequirement(cdGroup))

--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -3,6 +3,16 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-07-24'),
+		Changes: () => <>
+			<ul>
+				<li>BLU's cooldowns will filter out spells that were not used at all.</li>
+				<li>BLU's cooldowns now track Being Mortal, Sea Shanty, and Winged Reprobation.</li>
+			</ul>
+		</>,
+		contributors: [CONTRIBUTORS.HUGMEIR],
+	},
+	{
 		date: new Date('2023-07-22'),
 		Changes: () => <>BLU now counts the Apokalypsis channel as uptime, and gives a suggestion if channel ticks were dropped.</>,
 		contributors: [CONTRIBUTORS.HUGMEIR],

--- a/src/parser/jobs/blu/modules/GeneralCDDowntime.ts
+++ b/src/parser/jobs/blu/modules/GeneralCDDowntime.ts
@@ -74,4 +74,9 @@ export class GeneralCDDowntime extends CooldownDowntime {
 		{cooldowns: [this.data.actions.DRAGON_FORCE]},
 		{cooldowns: [this.data.actions.ANGELS_SNACK]},
 	]
+
+	override onComplete() {
+		this.trackedCds = this.trackedCds.filter(cdGroup => this.calculateUsageCount(cdGroup) !== 0)
+		return super.onComplete()
+	}
 }

--- a/src/parser/jobs/blu/modules/GeneralCDDowntime.ts
+++ b/src/parser/jobs/blu/modules/GeneralCDDowntime.ts
@@ -45,6 +45,15 @@ export class GeneralCDDowntime extends CooldownDowntime {
 			allowedAverageDowntime: 30000, // DPS gain to hold this until the Moon Flute window
 		},
 		{
+			cooldowns: [this.data.actions.SEA_SHANTY],
+			firstUseOffset: 12500,
+		},
+		{
+			cooldowns: [this.data.actions.BEING_MORTAL, this.data.actions.APOKALYPSIS],
+			// If they are taking Apokalypsis, they may be holding it until the odd-minute burst
+			firstUseOffset: 75000,
+		},
+		{
 			cooldowns: [this.data.actions.J_KICK, this.data.actions.QUASAR],
 			firstUseOffset: 2500,
 		},
@@ -56,6 +65,10 @@ export class GeneralCDDowntime extends CooldownDowntime {
 		{
 			cooldowns: [this.data.actions.THE_ROSE_OF_DESTRUCTION],
 			firstUseOffset: 5000,
+		},
+		{
+			cooldowns: [this.data.actions.WINGED_REPROBATION],
+			firstUseOffset: 35000, // First use will at best be during MF, but the cooldown won't trigger until after
 		},
 		{
 			cooldowns: [this.data.actions.COLD_FOG],


### PR DESCRIPTION
This first half of this is similar in vein to a change BLU has for `Defensives`, where we filter out defensives that were completely unused, assuming they just didn't slot it in.

This does the same but for our general cooldown downtime report, since even more so unlike level 70 BLU, the extra new spells mean that we now have a fair chunk of spells we may not be able to take due to spell slot limitations (Glass Dance, Sea Shanty, Rose of Destruction, even Cold Fog can be on the cut list!).

And speaking of new spells, this adds tracking for `Being Mortal` / `Apokalypsis`, `Sea Shanty`, and `Winged Reprobation`.