### PR TITLE
Drastically improve perf of DeduplicateAoEStep

### DIFF
--- a/src/reportSources/legacyFflogs/eventAdapter/deduplicateAoE.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/deduplicateAoE.ts
@@ -1,6 +1,8 @@
 import {Event, Events} from 'event'
 import {AdapterStep} from './base'
 
+type SequencedEvent = Events['damage' | 'heal']
+
 /**
  * FFLogs models damage or healing events that hit multiple targets as separate events
  * with the same SequenceID and timestamp.  The actual event stream models them in a single AoE packet
@@ -8,36 +10,49 @@ import {AdapterStep} from './base'
  */
 export class DeduplicateAoEStep extends AdapterStep {
 	private deduplicatedEvents: Event[] = []
+	private sequenceMapping = new Map<string, SequencedEvent>()
 
 	override postprocess(adaptedEvents: Event[]) {
+		for (const adaptedEvent of adaptedEvents) {
+			const matchingEvent = this.getMatchingEvent(adaptedEvent)
+			if (matchingEvent == null) {
+				this.deduplicatedEvents.push(adaptedEvent)
+				continue
+			}
 
-		adaptedEvents.forEach(adaptedEvent => {
 			// N.B.: For performance reasons, we are not cloning the events, just working with them as-is and keeping track of which events we want to keep in the deduplicatedEvents array
 			//   Separate array for the return so we don't mess with the iterator of our forEach, but just add the events onto the dedupe array as references - no cloning
 			//   This means that if you're debugging, the targets property of events will change in both the adaptedEvents and deduplicatedEvents arrays as you step through things
-			const matchingEvent = this.getMatchingEvent(adaptedEvent)
-			if (matchingEvent != null) {
-				if (adaptedEvent.type === 'damage') {
-					(matchingEvent as Events['damage']).targets.push(adaptedEvent.targets[0])
-				}
-				if (adaptedEvent.type === 'heal') {
-					(matchingEvent as Events['heal']).targets.push(adaptedEvent.targets[0])
-				}
-			} else {
-				this.deduplicatedEvents.push(adaptedEvent)
+			if (adaptedEvent.type === 'damage') {
+				(matchingEvent as Events['damage']).targets.push(adaptedEvent.targets[0])
 			}
-		})
+			if (adaptedEvent.type === 'heal') {
+				(matchingEvent as Events['heal']).targets.push(adaptedEvent.targets[0])
+			}
+		}
 
 		return this.deduplicatedEvents
 	}
 
-	private getMatchingEvent(event: Event): Event | undefined {
-		if (!(event.type === 'damage' || event.type === 'heal')) {
-			return undefined
+	private getMatchingEvent(event: Event): SequencedEvent | undefined {
+		if (
+			// Only damage/heal are paired.
+			!(event.type === 'damage' || event.type === 'heal')
+			// Events with no sequence ID are from over time effects or the passive regeneration, do not deduplicate.
+			|| event.sequence == null
+		) {
+			return
 		}
 
-		// Events with no sequence ID are from over time effects or the passive regeneration, do not deduplicate
-		return this.deduplicatedEvents.find(e => e.type === event.type && e.sequence != null && e.sequence === event.sequence)
-	}
+		const mappingKey = `${event.type}:${event.sequence}`
+		const match = this.sequenceMapping.get(mappingKey)
 
+		// If there was no match, record this event as the first.
+		// NOTE: We don't return the current event in this case, as it would result in a self-recursive object!
+		if (match == null) {
+			this.sequenceMapping.set(mappingKey, event)
+		}
+
+		return match
+	}
 }


### PR DESCRIPTION
Title. Like, unironically. This shaves a good second off the adapt stage on a dev build (less on a prod build). Basically just boils down to replacing a `.find` in the event array with a map lookup.

Obviously there's more improvements that can be made but this is a pretty sizeable win for a minimal changeset.

Before:
![image](https://github.com/xivanalysis/xivanalysis/assets/534235/5454f31a-f4bf-4545-a891-804986d3a4c9)

After (arrow required):
![image](https://github.com/xivanalysis/xivanalysis/assets/534235/f4d7b136-df1a-47cb-885a-91ee0b46aea8)
