### PR TITLE
Leylines to buffwindow

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -105,8 +105,6 @@
   "blm.gauge.title": "Balken",
   "blm.leylines.checklist": "",
   "blm.leylines.checklist-caption": "Bleibe in deinen <0/>",
-  "blm.leylines.timelinelink-button": "Springe zur Zeitleiste",
-  "blm.leylines.timestamp-header": "Zeitstempel",
   "blm.leylines.title": "Ley-Linien",
   "blm.leylines.uptime-header": "Uptime",
   "blm.notcasting.duration-header": "Dauer",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -105,8 +105,6 @@
   "blm.gauge.title": "Gauge",
   "blm.leylines.checklist": "Try to avoid leaving your <0/> after placing them. Take advantage of <1/>' size to stay in them while dodging AOEs and being in range of healers. If you can't stay in them for the majority of a <2/>' duration, consider changing where they're placed in the fight.",
   "blm.leylines.checklist-caption": "Stay in your <0/>",
-  "blm.leylines.timelinelink-button": "Jump to Timeline",
-  "blm.leylines.timestamp-header": "Timestamp",
   "blm.leylines.title": "Ley Lines",
   "blm.leylines.uptime-header": "Uptime",
   "blm.notcasting.duration-header": "Duration",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -105,8 +105,6 @@
   "blm.gauge.title": "Jauge",
   "blm.leylines.checklist": "Évitez de quitter vos <0/> après les avoir placés. Profitez de la taille du cercle de vos <1/> pour rester dedans tout en esquivant les AoEs et en vous tenant à portée des soigneurs. Si vous n'arrivez pas à rester dedans durant la majorité de la durée de <2/>, veuillez considérer l'idée de changer l'emplacement où vous les déposez durant ce combat.",
   "blm.leylines.checklist-caption": "Restez à l'intérieur de vos <0/>",
-  "blm.leylines.timelinelink-button": "Voir sur la Chronologie",
-  "blm.leylines.timestamp-header": "Horodatage",
   "blm.leylines.title": "Manalignements",
   "blm.leylines.uptime-header": "Durée active",
   "blm.notcasting.duration-header": "Durée",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -105,8 +105,6 @@
   "blm.gauge.title": "ゲージ",
   "blm.leylines.checklist": "設置後に<0/>から離れないでください。<1/>'を利用して、AOEを避けヒーラーの回復範囲内にいる間は留まってください。もし<2/>'の持続時間の大半で留まれないならば、戦闘中にそれを設置する場所の変更を検討してください。",
   "blm.leylines.checklist-caption": "<0/>から出ないでください。",
-  "blm.leylines.timelinelink-button": "タイムラインに移動",
-  "blm.leylines.timestamp-header": "タイムスタンプ",
   "blm.leylines.title": "黒魔紋",
   "blm.leylines.uptime-header": "アクティブ率",
   "blm.notcasting.duration-header": "効果時間",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -105,8 +105,6 @@
   "blm.gauge.title": "극성과 언어",
   "blm.leylines.checklist": "<0/> 배치 후 최대한 벗어나지 마십시오. <1/> 크기를 최대한 살려 범위 공격을 피하고 힐러의 치유 범위에 닿도록 하십시오. <2/> 지속 시간 중 상당 시간을 범위 내에 머무르지 못했다면 다른 곳에 설치하는 것을 고려하십시오.",
   "blm.leylines.checklist-caption": "<0/> 내에 머무르기",
-  "blm.leylines.timelinelink-button": "타임라인으로 이동",
-  "blm.leylines.timestamp-header": "타임스탬프",
   "blm.leylines.title": "흑마법 문양",
   "blm.leylines.uptime-header": "적용 시간",
   "blm.notcasting.duration-header": "지속 시간",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -105,8 +105,6 @@
   "blm.gauge.title": "职业量谱",
   "blm.leylines.checklist": "在放下<0/>后尽量不要离开它。充分利用<1/>的面积优势呆在里面，躲开AoE，接受治疗。如果大部分时间无法站在<2/>里。请考虑更换放置的时机和位置。",
   "blm.leylines.checklist-caption": "站在你的<0/>中",
-  "blm.leylines.timelinelink-button": "跳转到时间轴",
-  "blm.leylines.timestamp-header": "时间截",
   "blm.leylines.title": "黑魔纹",
   "blm.leylines.uptime-header": "覆盖率",
   "blm.notcasting.duration-header": "持续时间",

--- a/src/parser/core/modules/ActionWindow/evaluators/NotesEvaluator.ts
+++ b/src/parser/core/modules/ActionWindow/evaluators/NotesEvaluator.ts
@@ -6,12 +6,13 @@ import {EvaluationOutput, WindowEvaluator} from './WindowEvaluator'
 
 export abstract class NotesEvaluator implements WindowEvaluator {
 
-	protected abstract header : RotationTarget
+	protected abstract header : RotationTarget | undefined
 	protected abstract generateNotes(window: HistoryEntry<EvaluatedAction[]>): JSX.Element
 
 	suggest(_windows: Array<HistoryEntry<EvaluatedAction[]>>): Suggestion | undefined { return undefined }
 
-	public output(windows: Array<HistoryEntry<EvaluatedAction[]>>): EvaluationOutput  {
+	public output(windows: Array<HistoryEntry<EvaluatedAction[]>>): EvaluationOutput | undefined {
+		if (this.header == null) { return }
 		return {
 			format: 'notes',
 			header: this.header,

--- a/src/parser/core/modules/ActionWindow/evaluators/RulePassedEvaluator.tsx
+++ b/src/parser/core/modules/ActionWindow/evaluators/RulePassedEvaluator.tsx
@@ -1,0 +1,44 @@
+import {RotationTarget} from 'components/ui/RotationTable'
+import React, {ReactNode} from 'react'
+import {Icon} from 'semantic-ui-react'
+import {Suggestion} from '../../Suggestions'
+import {EvaluatedAction} from '../EvaluatedAction'
+import {HistoryEntry} from '../History'
+import {NotesEvaluator} from './NotesEvaluator'
+
+export interface RulePassedEvaluatorOpts {
+	header?: RotationTarget
+	passesRule: (window: HistoryEntry<EvaluatedAction[]>) => boolean | undefined
+	suggestion? : (windows: Array<HistoryEntry<EvaluatedAction[]>>) => Suggestion | undefined
+	ruleContext? : (window: HistoryEntry<EvaluatedAction[]>) => ReactNode
+}
+
+export class RulePassedEvaluator extends NotesEvaluator {
+	override header: RotationTarget | undefined
+	private passesRule : (window: HistoryEntry<EvaluatedAction[]>) => boolean | undefined
+	override suggest : (windows: Array<HistoryEntry<EvaluatedAction[]>>) => Suggestion | undefined
+	private ruleContext : (window: HistoryEntry<EvaluatedAction[]>) => ReactNode
+
+	constructor(opts: RulePassedEvaluatorOpts) {
+		super()
+		this.header = opts.header,
+		this.passesRule = opts.passesRule
+		this.suggest = opts.suggestion ?? (() => { return undefined })
+		this.ruleContext = opts.ruleContext ?? (() => { return <></> })
+	}
+
+	override generateNotes(window: HistoryEntry<EvaluatedAction[]>) {
+		const rulePassed = this.passesRule(window)
+		if (rulePassed == null) {
+			return <><Icon name={'minus'} className={'text-warning'} /><br/>{this.ruleContext(window)}</>
+		}
+		return <><Icon
+			name={rulePassed ? 'checkmark' : 'remove'}
+			className={rulePassed ? 'text-success' : 'text-error'}
+		/><br/>{this.ruleContext(window)}</>
+	}
+
+	public failedRuleCount(windows: Array<HistoryEntry<EvaluatedAction[]>>): number {
+		return windows.filter(window => this.passesRule(window) === false).length
+	}
+}

--- a/src/parser/core/modules/ActionWindow/evaluators/RulePassedEvaluator.tsx
+++ b/src/parser/core/modules/ActionWindow/evaluators/RulePassedEvaluator.tsx
@@ -1,41 +1,26 @@
-import {RotationTarget} from 'components/ui/RotationTable'
 import React, {ReactNode} from 'react'
 import {Icon} from 'semantic-ui-react'
-import {Suggestion} from '../../Suggestions'
 import {EvaluatedAction} from '../EvaluatedAction'
 import {HistoryEntry} from '../History'
 import {NotesEvaluator} from './NotesEvaluator'
 
-export interface RulePassedEvaluatorOpts {
-	header?: RotationTarget
-	passesRule: (window: HistoryEntry<EvaluatedAction[]>) => boolean | undefined
-	suggestion? : (windows: Array<HistoryEntry<EvaluatedAction[]>>) => Suggestion | undefined
-	ruleContext? : (window: HistoryEntry<EvaluatedAction[]>) => ReactNode
-}
+export abstract class RulePassedEvaluator extends NotesEvaluator {
 
-export class RulePassedEvaluator extends NotesEvaluator {
-	override header: RotationTarget | undefined
-	private passesRule : (window: HistoryEntry<EvaluatedAction[]>) => boolean | undefined
-	override suggest : (windows: Array<HistoryEntry<EvaluatedAction[]>>) => Suggestion | undefined
-	private ruleContext : (window: HistoryEntry<EvaluatedAction[]>) => ReactNode
-
-	constructor(opts: RulePassedEvaluatorOpts) {
-		super()
-		this.header = opts.header,
-		this.passesRule = opts.passesRule
-		this.suggest = opts.suggestion ?? (() => { return undefined })
-		this.ruleContext = opts.ruleContext ?? (() => { return <></> })
-	}
+	protected abstract passesRule(window: HistoryEntry<EvaluatedAction[]>): boolean | undefined
+	protected ruleContext(_window: HistoryEntry<EvaluatedAction[]>): ReactNode { return <></> }
 
 	override generateNotes(window: HistoryEntry<EvaluatedAction[]>) {
 		const rulePassed = this.passesRule(window)
+		let ruleIcon
 		if (rulePassed == null) {
-			return <><Icon name={'minus'} className={'text-warning'} /><br/>{this.ruleContext(window)}</>
+			ruleIcon = <Icon name={'minus'} className={'text-warning'} />
+		} else {
+			ruleIcon = <Icon
+				name={rulePassed ? 'checkmark' : 'remove'}
+				className={rulePassed ? 'text-success' : 'text-error'}
+			/>
 		}
-		return <><Icon
-			name={rulePassed ? 'checkmark' : 'remove'}
-			className={rulePassed ? 'text-success' : 'text-error'}
-		/><br/>{this.ruleContext(window)}</>
+		return <>{ruleIcon}<br/>{this.ruleContext(window)}</>
 	}
 
 	public failedRuleCount(windows: Array<HistoryEntry<EvaluatedAction[]>>): number {

--- a/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
+++ b/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
@@ -22,8 +22,8 @@ export type HistoryEntryPredicate = (e: HistoryEntry<EvaluatedAction[]>) => bool
 export abstract class ActionWindow extends Analyser {
 
 	@dependency protected data!: Data
-	@dependency private suggestions!: Suggestions
-	@dependency private timeline!: Timeline
+	@dependency protected suggestions!: Suggestions
+	@dependency protected timeline!: Timeline
 
 	/**
 	 * The captured windows.
@@ -152,7 +152,7 @@ export abstract class ActionWindow extends Analyser {
 		this.addEventHook('complete', this.onComplete)
 	}
 
-	private onComplete() {
+	protected onComplete() {
 		this.onWindowEnd(this.parser.pull.timestamp + this.parser.pull.duration)
 
 		const actionHistory = this.mapHistoryActions()

--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -8,13 +8,68 @@ export const changelog = [
 	// 	contrubutors: [CONTRIBUTORS.YOU],
 	// },
 	{
-		date: new Date('2021-11-04'),
-		Changes: () => <>Initial data scaffolding and basic updates to handle removal of Enochian ability.</>,
+		date: new Date('2023-07-30'),
+		Changes: () => <>Update Ley Lines table to be consistent with other buff window displays, and show whether each use got the expected amount of uptime.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2023-06-05'),
+		Changes: () => <>Display timestamps for Paradox and Polyglot overwrites.</>,
+		contributors: [CONTRIBUTORS.MALI],
+	},
+	{
+		date: new Date('2023-05-24'),
+		Changes: () => <>Foul now requires 3 targets to outperform Xenoglossy due to 6.4 potency increase.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2022-03-19'),
+		Changes: () => <>Fixed a bug with the Not Casting check that was giving incorrect results for fight downtime and end-of-fight casts.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2022-01-10'),
+		Changes: () => <>Fixed a bug causing Sharpcasts to appear as if they were consumed by Umbral Ice Paradoxes in the timeline.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2022-01-08'),
+		Changes: () => <>Mark missed Umbral Ice Paradoxes as a cycle error and update the Rotation Outliers table header copy.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2022-01-04'),
+		Changes: () => <>Mark as supported for 6.05.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2021-12-24'),
+		Changes: () => <>Correct Paradox gauge handling to grant a stack of the active stance, instead of just a timer refresh.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2021-12-21'),
+		Changes: () => <>Suggestions not to overwrite Sharpcast or Triplecast while the statuses are still active.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2021-12-20'),
+		Changes: () => <>Keep track of Manaward and Addle usage.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2021-12-15'),
+		Changes: () => <>Miscellaneous bug fixes, and marking supported for Endwalker.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2021-12-12'),
+		Changes: () => <>Handle Paradox being instant-cast in Umbral Ice.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 	{
 		date: new Date('2021-11-27'),
-		Changes: () => <>Preliminary updates to gauge state and rotation tracking, including suggestion not to waste Paradoxes.</>,
+		Changes: () => <>Update cooldown tracking checklist to include Amplifier and Sharpcast, drop separate Sharpcast usage statistic, and add handling for Paradox consuming Sharpcast while in Astral Fire.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 	{
@@ -24,62 +79,12 @@ export const changelog = [
 	},
 	{
 		date: new Date('2021-11-27'),
-		Changes: () => <>Update cooldown tracking checklist to include Amplifier and Sharpcast, drop separate Sharpcast usage statistic, and add handling for Paradox consuming Sharpcast while in Astral Fire.</>,
+		Changes: () => <>Preliminary updates to gauge state and rotation tracking, including suggestion not to waste Paradoxes.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 	{
-		date: new Date('2021-12-12'),
-		Changes: () => <>Handle Paradox being instant-cast in Umbral Ice.</>,
+		date: new Date('2021-11-04'),
+		Changes: () => <>Initial data scaffolding and basic updates to handle removal of Enochian ability.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2021-12-15'),
-		Changes: () => <>Miscellaneous bug fixes, and marking supported for Endwalker.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2021-12-20'),
-		Changes: () => <>Keep track of Manaward and Addle usage.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2021-12-21'),
-		Changes: () => <>Suggestions not to overwrite Sharpcast or Triplecast while the statuses are still active.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2021-12-24'),
-		Changes: () => <>Correct Paradox gauge handling to grant a stack of the active stance, instead of just a timer refresh.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2022-01-04'),
-		Changes: () => <>Mark as supported for 6.05.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2022-01-08'),
-		Changes: () => <>Mark missed Umbral Ice Paradoxes as a cycle error and update the Rotation Outliers table header copy.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2022-01-10'),
-		Changes: () => <>Fixed a bug causing Sharpcasts to appear as if they were consumed by Umbral Ice Paradoxes in the timeline.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2022-03-19'),
-		Changes: () => <>Fixed a bug with the Not Casting check that was giving incorrect results for fight downtime and end-of-fight casts.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2023-05-24'),
-		Changes: () => <>Foul now requires 3 targets to outperform Xenoglossy due to 6.4 potency increase.</>,
-		contributors: [CONTRIBUTORS.AKAIRYU],
-	},
-	{
-		date: new Date('2023-06-05'),
-		Changes: () => <>Display timestamps for Paradox and Polyglot overwrites.</>,
-		contributors: [CONTRIBUTORS.MALI],
 	},
 ]

--- a/src/parser/jobs/blm/modules/Leylines.tsx
+++ b/src/parser/jobs/blm/modules/Leylines.tsx
@@ -1,61 +1,56 @@
 import {t} from '@lingui/macro'
 import {Trans} from '@lingui/react'
 import {ActionLink} from 'components/ui/DbLink'
+import {Status} from 'data/STATUSES'
 import {Event, Events} from 'event'
-import {Analyser} from 'parser/core/Analyser'
-import {filter, oneOf} from 'parser/core/filter'
+import {filter} from 'parser/core/filter'
 import {dependency} from 'parser/core/Injectable'
+import {BuffWindow, EvaluatedAction} from 'parser/core/modules/ActionWindow'
+import {RulePassedEvaluator} from 'parser/core/modules/ActionWindow/evaluators/RulePassedEvaluator'
+import {History, HistoryEntry} from 'parser/core/modules/ActionWindow/History'
 import CastTime from 'parser/core/modules/CastTime'
 import Checklist, {Rule, Requirement} from 'parser/core/modules/Checklist'
-import {Data} from 'parser/core/modules/Data'
-import {SimpleRow, StatusItem, Timeline} from 'parser/core/modules/Timeline'
+import {SimpleRow, StatusItem} from 'parser/core/modules/Timeline'
 import React from 'react'
-import {Table, Button} from 'semantic-ui-react'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
-interface LeyLinesWindow {
-	start: number,
-	stop?: number
-}
+//pretty random. Should be revised, maybe based on fights? 10% is ~ 1 GCD. So we allow that.
+const TARGET_UPTIME_PCT = 90
 
-interface LeyLinesWindows {
-	current?: LeyLinesWindow,
-	history: LeyLinesWindow[]
-}
-
-export default class Leylines extends Analyser {
+export default class Leylines extends BuffWindow {
 	static override handle = 'leylines'
 	static override title = t('blm.leylines.title')`Ley Lines`
 	static override displayOrder = DISPLAY_ORDER.LEY_LINES
 
-	@dependency private data!: Data
 	@dependency private checklist!: Checklist
-	@dependency private timeline!: Timeline
 	@dependency private castTime!: CastTime
 
-	private leyLinesStatuses: number[] = [
-		this.data.statuses.LEY_LINES.id,
-		this.data.statuses.CIRCLE_OF_POWER.id,
-	]
+	override buffStatus = [this.data.statuses.LEY_LINES]
 
-	private buffWindows: {[key: number]: LeyLinesWindows} = {}
+	private circleOfPowerHistory = new History<null>(() => null)
 	private castTimeIndex: number | null = null
 
 	override initialise() {
-		const leyLinesFilter = filter<Event>()
+		super.initialise()
+
+		const circleOfPowerFilter = filter<Event>()
 			.source(this.parser.actor.id)
-			.status(oneOf(this.leyLinesStatuses))
-		this.addEventHook(leyLinesFilter.type('statusApply'), this.onGain)
-		this.addEventHook(leyLinesFilter.type('statusRemove'), this.onDrop)
+			.status(this.data.statuses.CIRCLE_OF_POWER.id)
+		this.addEventHook(circleOfPowerFilter.type('statusApply'), this.onGainCircle)
+		this.addEventHook(circleOfPowerFilter.type('statusRemove'), this.onDropCircle)
 		this.addEventHook({
 			type: 'death',
 			actor: this.parser.actor.id,
 		}, this.onDeath)
-		this.addEventHook('complete', this.onComplete)
 
-		this.leyLinesStatuses.forEach(status => {
-			this.buffWindows[status] = {history: []}
-		})
+		this.addEvaluator(new RulePassedEvaluator({
+			header: {
+				header: <Trans id="blm.leylines.uptime-header">Uptime</Trans>,
+				accessor: 'powertime',
+			},
+			passesRule: this.encircled.bind(this),
+			ruleContext: this.uptimeContext.bind(this),
+		}))
 	}
 
 	public getStatusDurationInRange(
@@ -63,74 +58,42 @@ export default class Leylines extends Analyser {
 		start: number = this.parser.pull.timestamp,
 		end: number = this.parser.pull.timestamp + this.parser.pull.duration
 	) {
-		let duration = 0
-		for (const window of this.buffWindows[statusId].history) {
-			if (window.stop == null || window.stop <= start || window.start >= end) {
-				continue
+		const history = statusId === this.data.statuses.LEY_LINES.id ? this.history : this.circleOfPowerHistory
+		return history.entries.map(window => {
+			return {
+				start: window.start,
+				end: window.end ?? end,
 			}
-			duration += Math.max(0, Math.min(window.stop, end) - Math.max(window.start, start))
-		}
-
-		const currentWindows = this.buffWindows[statusId].current
-		if (currentWindows != null) {
-			duration += Math.max(end - Math.max(currentWindows.start, start), 0)
-		}
-
-		return duration
+		}).reduce((total, window) => {
+			if (window.end <= start || window.start >= end) {
+				return total
+			}
+			return total + Math.max(0, Math.min(window.end, end) - Math.max(window.start, start))
+		}, 0)
 	}
 
-	// Manage buff windows
-	private onGain(event: Events['statusApply']) {
-		const status = this.data.getStatus(event.status)
+	// Manage circle of power windows
+	private onGainCircle(event: Events['statusApply']) {
+		this.circleOfPowerHistory.getCurrentOrOpenNew(event.timestamp)
 
-		// Something is not right
-		if (!status) { return }
-
-		// Track the new window
-		const tracker = this.buffWindows[status.id]
-
-		// Don't open a new window if one's already going
-		if (tracker.current) { return }
-
-		tracker.current = {
-			start: event.timestamp,
-		}
-
-		if (status.id === this.data.statuses.CIRCLE_OF_POWER.id) {
-			this.castTimeIndex = this.castTime.setPercentageAdjustment('all', this.data.statuses.CIRCLE_OF_POWER.speedModifier, 'both')
-		}
+		this.castTimeIndex = this.castTime.setPercentageAdjustment('all', this.data.statuses.CIRCLE_OF_POWER.speedModifier, 'both')
 	}
 
-	private onDrop(event: Events['statusRemove']) {
-		this.stopAndSave(event.status, event.timestamp)
+	private onDropCircle(event: Events['statusRemove']) {
+		this.stopAndSave(event.timestamp)
 	}
 
-	// We died, close windows
+	// We died, make sure circle of power gets closed
 	private onDeath(event: Events['death']) {
-		this.stopAndSave(this.data.statuses.LEY_LINES.id, event.timestamp)
+		this.stopAndSave(event.timestamp)
 	}
 
 	// Finalise a buff window
-	private stopAndSave(statusId: number, endTime: number = this.parser.currentEpochTimestamp) {
-		const tracker = this.buffWindows[statusId]
+	private stopAndSave(endTime: number = this.parser.currentEpochTimestamp) {
+		this.circleOfPowerHistory.closeCurrent(endTime)
 
-		// Already closed, nothing to do here
-		if (!tracker.current) { return }
-
-		// Close the window
-		tracker.current.stop = endTime
-		tracker.history.push(tracker.current)
-		tracker.current = undefined
-
-		// Close dependency windows
-		if (statusId === this.data.statuses.LEY_LINES.id) {
-			this.stopAndSave(this.data.statuses.CIRCLE_OF_POWER.id, endTime)
-		}
-
-		if (statusId === this.data.statuses.CIRCLE_OF_POWER.id) {
-			this.castTime.reset(this.castTimeIndex)
-			this.castTimeIndex = null
-		}
+		this.castTime.reset(this.castTimeIndex)
+		this.castTimeIndex = null
 	}
 
 	// A reminder of man's ability to generate electricity
@@ -138,9 +101,25 @@ export default class Leylines extends Analyser {
 		return (power / lines) * 100
 	}
 
-	private onComplete() {
+	private encircled(window: HistoryEntry<EvaluatedAction[]>): boolean {
+		return this.getUptimeForWindow(window) >= TARGET_UPTIME_PCT
+	}
+
+	private uptimeContext(window: HistoryEntry<EvaluatedAction[]>): string {
+		return this.getUptimeForWindow(window).toFixed(2) + '%'
+	}
+
+	private getUptimeForWindow(window: HistoryEntry<EvaluatedAction[]>) {
+		const linesDuration = (window.end ?? this.parser.pull.timestamp + this.parser.pull.duration) - window.start
+		const copDuration = this.getStatusDurationInRange(this.data.statuses.CIRCLE_OF_POWER.id, window.start, window.end)
+		return this.dontMovePercent(copDuration, linesDuration)
+	}
+
+	override onComplete() {
 		// Current time will be end of fight so no need to pass it here
-		this.stopAndSave(this.data.statuses.LEY_LINES.id)
+		this.stopAndSave(this.data.statuses.CIRCLE_OF_POWER.id)
+
+		super.onComplete()
 
 		// Build the grouping row
 		const parentRow = this.timeline.addRow(new SimpleRow({
@@ -148,24 +127,9 @@ export default class Leylines extends Analyser {
 			order: 0,
 		}))
 
-		const fightStart = this.parser.pull.timestamp
-
 		// For each buff, add it to timeline
-		this.leyLinesStatuses.forEach(buff => {
-			const status = this.data.getStatus(buff)
-			if (!status) { return }
-
-			const row = parentRow.addRow(new SimpleRow({label: status.name}))
-
-			this.buffWindows[buff].history.forEach(window => {
-				if (!window.stop) { return }
-				row.addItem(new StatusItem({
-					status,
-					start: window.start - fightStart,
-					end: window.stop - fightStart,
-				}))
-			})
-		})
+		this.addHistoryToTimeline(this.data.statuses.LEY_LINES, this.history, parentRow)
+		this.addHistoryToTimeline(this.data.statuses.CIRCLE_OF_POWER, this.circleOfPowerHistory, parentRow)
 
 		// Get the total duration of CoP uptime and Ley Lines, so we can get the overall percentage uptime
 		const copDuration = this.getStatusDurationInRange(this.data.statuses.CIRCLE_OF_POWER.id)
@@ -180,46 +144,20 @@ export default class Leylines extends Analyser {
 					percent: this.dontMovePercent(copDuration, linesDuration),
 				}),
 			],
-			//pretty random. Should be revised, maybe based on fights? 10% is ~ 1 GCD. So we allow that.
-			target: 90,
+			target: TARGET_UPTIME_PCT,
 		}))
 	}
 
-	override output() {
-		const fightEnd = this.parser.pull.timestamp + this.parser.pull.duration
-		return <Table collapsing unstackable compact="very">
-			<Table.Header>
-				<Table.Row>
-					<Table.HeaderCell><Trans id="blm.leylines.timestamp-header">Timestamp</Trans></Table.HeaderCell>
-					<Table.HeaderCell><Trans id="blm.leylines.uptime-header">Uptime</Trans></Table.HeaderCell>
-					<Table.HeaderCell></Table.HeaderCell>
-				</Table.Row>
-			</Table.Header>
-			<Table.Body>
-				{this.buffWindows[this.data.statuses.LEY_LINES.id].history.map(leyLinesEvent => {
-					// Find the CoPs that were inside this Ley Lines
-					const thisCoPHistory = this.buffWindows[this.data.statuses.CIRCLE_OF_POWER.id].history.filter(cops => ((cops.start >= leyLinesEvent.start) && ((cops.stop || 0) <= (leyLinesEvent.stop || 0))))
-
-					// For this set of CoPs, get the uptime
-					const thisCoPUptime = thisCoPHistory.reduce((duration, cop) => duration + Math.max((cop.stop || 0) - cop.start, 0), 0)
-
-					// Note that since we're getting the actual duration, rather than the expected duration,
-					// technically we'll call it 100% uptime if you stay in the lines and die halfway through...
-					// However, since that'll get flagged as a morbid checklist item, that's probably ok.
-					const thisPercent = this.dontMovePercent(thisCoPUptime, (leyLinesEvent.stop || fightEnd) - leyLinesEvent.start).toFixed(2)
-
-					return <Table.Row key={leyLinesEvent.start}>
-						<Table.Cell>{this.parser.formatEpochTimestamp(leyLinesEvent.start)}</Table.Cell>
-						<Table.Cell>{thisPercent}%</Table.Cell>
-						<Table.Cell>
-							<Button onClick={() =>
-								this.timeline.show(leyLinesEvent.start - this.parser.pull.timestamp, (leyLinesEvent.stop || fightEnd) - this.parser.pull.timestamp)}>
-								<Trans id="blm.leylines.timelinelink-button">Jump to Timeline</Trans>
-							</Button>
-						</Table.Cell>
-					</Table.Row>
-				})}
-			</Table.Body>
-		</Table>
+	private addHistoryToTimeline(status: Status, history: History<Array<Events['action']> | null>, parentRow: SimpleRow) {
+		const row = parentRow.addRow(new SimpleRow({label: status.name}))
+		const fightStart = this.parser.pull.timestamp
+		history.entries.forEach(window => {
+			if (window.end == null) { return }
+			row.addItem(new StatusItem({
+				status,
+				start: window.start - fightStart,
+				end: window.end - fightStart,
+			}))
+		})
 	}
 }


### PR DESCRIPTION
Swapped LeyLines' implementation from standalone Analyser to buffwindow to cut down on how much bespoke window handling code was around, and to change its UI to be more consistent with other windows.

Pulled over the new RulePassedEvaluator added on #1832 and added a 'ruleContext' option to the output in addition to the checkmark/x icons, to allow this to retain the per-window uptime % display alongside the indicator of whether that window met the uptime expectation of 90%.