### PR TITLE
BLU: Odd-minute bursts should still enforce Surpanakha usage rules

### DIFF
--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-08-07'),
+		Changes: () => <>BLU's odd-minute bursts now enforce the usual Surpanakha rules: either all 4 stacks, or zero stacks.</>,
+		contributors: [CONTRIBUTORS.HUGMEIR],
+	},
+	{
 		date: new Date('2023-07-24'),
 		Changes: () => <>
 			<ul>


### PR DESCRIPTION
Either 0 uses or 4 uses -- anything else will almost certainly be a DPS loss (or at best, drift your upcoming bursts)