### PR TITLE
BLU: Goblin Punch is a front positional

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -219,6 +219,7 @@
   "blu.phantom_flurry.dropped_kicks.why": "",
   "blu.phantom_flurry.dropped_ticks.content": "",
   "blu.phantom_flurry.dropped_ticks.why": "",
+  "blu.positionals.checklist.description": "",
   "blu.revenge_blast.bad.content": "",
   "blu.revenge_blast.bad.why": "",
   "blu.revenge_blast.rotation-table.header.blast-count": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -219,6 +219,7 @@
   "blu.phantom_flurry.dropped_kicks.why": "{missingFlurryKicks, plural, one {# Phantom Flurry big kick was} other {# Phantom Flurry big kicks were}} dropped by not pressing the button again before the effect ran out.",
   "blu.phantom_flurry.dropped_ticks.content": "Dropping out of <0/> too early will lose damage ticks. If you are in a <1/> window you want to wait out the entire channel. If you are using it outside of a window and activating the final kick, wait until the last second the <2/> effect is active.",
   "blu.phantom_flurry.dropped_ticks.why": "{missingFlurryTicks, plural, one {# Phantom Flurry tick was} other {# Phantom Flurry ticks were}} dropped due to cancelling the channel too early.",
+  "blu.positionals.checklist.description": "<0/> is a front positional.  For BLU tanks, missing the positional is damage neutral compared to our filler, but you should still aim to use it from the front to do the most damage.",
   "blu.revenge_blast.bad.content": "Only use <0/> if your HP will be below 20% by the time the slidecast window starts.",
   "blu.revenge_blast.bad.why": "{0, plural, one {# Revenge Blast cast} other {# Revenge Blast casts}} happened when above 20% HP",
   "blu.revenge_blast.rotation-table.header.blast-count": "Revenge Blasts",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -219,6 +219,7 @@
   "blu.phantom_flurry.dropped_kicks.why": "",
   "blu.phantom_flurry.dropped_ticks.content": "",
   "blu.phantom_flurry.dropped_ticks.why": "",
+  "blu.positionals.checklist.description": "",
   "blu.revenge_blast.bad.content": "",
   "blu.revenge_blast.bad.why": "",
   "blu.revenge_blast.rotation-table.header.blast-count": "",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -219,6 +219,7 @@
   "blu.phantom_flurry.dropped_kicks.why": "",
   "blu.phantom_flurry.dropped_ticks.content": "",
   "blu.phantom_flurry.dropped_ticks.why": "",
+  "blu.positionals.checklist.description": "",
   "blu.revenge_blast.bad.content": "",
   "blu.revenge_blast.bad.why": "",
   "blu.revenge_blast.rotation-table.header.blast-count": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -219,6 +219,7 @@
   "blu.phantom_flurry.dropped_kicks.why": "",
   "blu.phantom_flurry.dropped_ticks.content": "",
   "blu.phantom_flurry.dropped_ticks.why": "",
+  "blu.positionals.checklist.description": "",
   "blu.revenge_blast.bad.content": "",
   "blu.revenge_blast.bad.why": "",
   "blu.revenge_blast.rotation-table.header.blast-count": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -219,6 +219,7 @@
   "blu.phantom_flurry.dropped_kicks.why": "{missingFlurryKicks, plural, other {# 次鬼宿脚终结踢}}没有被打出。",
   "blu.phantom_flurry.dropped_ticks.content": "太早结束 <0/> 会丢失伤害次数。在 <1/> 末尾使用时，可以等到打满。其他场合使用时，等到 <2/> 的最后一秒再踢出最后一脚。",
   "blu.phantom_flurry.dropped_ticks.why": "{missingFlurryTicks, plural, other {# 次鬼宿脚伤害}} 由于过早中断而丢失。",
+  "blu.positionals.checklist.description": "",
   "blu.revenge_blast.bad.content": "只在生命低于20%时使用 <0/>。生命在滑步窗口同时判定。",
   "blu.revenge_blast.bad.why": "{0, plural, other {# 次复仇冲击}} 在生命值高于20%时打出。",
   "blu.revenge_blast.rotation-table.header.blast-count": "复仇冲击",

--- a/src/data/ACTIONS/root/BLU.ts
+++ b/src/data/ACTIONS/root/BLU.ts
@@ -1,5 +1,5 @@
 import {Attribute, DamageType} from 'event'
-import {Action, ensureActions} from '../type'
+import {Action, ensureActions, BonusModifier, PotencySpecialCase} from '../type'
 
 const MAGICAL = DamageType.MAGICAL
 const PHYSICAL = DamageType.PHYSICAL
@@ -1155,6 +1155,24 @@ export const BLU = ensureActions({
 		gcdRecast: 2500,
 		damageType: PHYSICAL,
 		speedAttribute: Attribute.SPELL_SPEED,
+		potencies: [{
+			value: 120,
+			bonusModifiers: [],
+			baseModifiers: [],
+		}, {
+			value: 220,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: [],
+		}, {
+			// Mighty Guard increases the potency of Goblin Punch by 100
+			value: 220,
+			bonusModifiers: [],
+			baseModifiers: [PotencySpecialCase.BLU_MIGHTY_GOBLIN_PUNCH],
+		}, {
+			value: 320,
+			bonusModifiers: [BonusModifier.POSITIONAL],
+			baseModifiers: [PotencySpecialCase.BLU_MIGHTY_GOBLIN_PUNCH],
+		}],
 	},
 	RIGHT_ROUND: {
 		id: 34564,

--- a/src/data/ACTIONS/type.ts
+++ b/src/data/ACTIONS/type.ts
@@ -18,8 +18,11 @@ export enum BonusModifier {
 
 // DRG lance mastery is a special case hidden field that
 // augments the potency of the 5th hit.
+// Similarly, BLU's Goblin Punch deals extra potency when
+// cast under Mighty Guard (one of the tank stances)
 export enum PotencySpecialCase {
 	DRG_LANCE_MASTERY,
+	BLU_MIGHTY_GOBLIN_PUNCH,
 }
 
 // When calculating the bonusPercent that the game uses to display

--- a/src/parser/core/modules/Positionals.tsx
+++ b/src/parser/core/modules/Positionals.tsx
@@ -123,6 +123,13 @@ export abstract class Positionals extends Analyser {
 		/>
 	}
 
+	protected missedPositionalsChecklistDescription(): JSX.Element {
+		return <Trans id="core.positionals.checklist.description">
+			Melee DPS jobs have some skills that will do more damage when used from the rear or flank.
+			Make sure you use those skills in the right position to do the most damage, or
+			use <DataLink action="TRUE_NORTH"/> when you are out of position.
+		</Trans>
+	}
 	private onComplete() {
 		if (this.positionalResults.length === 0) {
 			return
@@ -130,11 +137,7 @@ export abstract class Positionals extends Analyser {
 		this.checklist.add(new Rule({
 			name: <Trans id="core.positionals.checklist.title">Hit your positionals</Trans>,
 			displayOrder: DISPLAY_ORDER.POSITIONALS,
-			description: <Trans id="core.positionals.checklist.description">
-				Melee DPS jobs have some skills that will do more damage when used from the rear or flank.
-				Make sure you use those skills in the right position to do the most damage, or
-				use <DataLink action="TRUE_NORTH"/> when you are out of position.
-			</Trans>,
+			description: this.missedPositionalsChecklistDescription(),
 			requirements: this.positionalResults.map(this.positionalRequirement),
 		}))
 	}

--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-08-10'),
+		Changes: () => <>Report missed Goblin Punch positionals</>,
+		contributors: [CONTRIBUTORS.HUGMEIR],
+	},
+	{
 		date: new Date('2023-08-07'),
 		Changes: () => <>BLU's odd-minute bursts now enforce the usual Surpanakha rules: either all 4 stacks, or zero stacks.</>,
 		contributors: [CONTRIBUTORS.HUGMEIR],

--- a/src/parser/jobs/blu/modules/Positionals.tsx
+++ b/src/parser/jobs/blu/modules/Positionals.tsx
@@ -1,0 +1,16 @@
+import {Trans} from '@lingui/react'
+import {DataLink} from 'components/ui/DbLink'
+import {Positionals as CorePositionals} from 'parser/core/modules/Positionals'
+import React from 'react'
+
+export class Positionals extends CorePositionals {
+	positionals = [
+		this.data.actions.GOBLIN_PUNCH,
+	]
+
+	override missedPositionalsChecklistDescription(): JSX.Element {
+		return <Trans id="blu.positionals.checklist.description">
+			<DataLink action="GOBLIN_PUNCH" showIcon={false} /> is a front positional.  For BLU tanks, missing the positional is damage neutral compared to our filler, but you should still aim to use it from the front to do the most damage.
+		</Trans>
+	}
+}

--- a/src/parser/jobs/blu/modules/index.tsx
+++ b/src/parser/jobs/blu/modules/index.tsx
@@ -13,6 +13,7 @@ import {Interrupts} from './Interrupts'
 import {MightyGuardGCDing} from './MightyGuardGCDing'
 import {MoonFlute} from './MoonFlute'
 import {BLUOverheal} from './Overheal'
+import {Positionals} from './Positionals'
 import {RevengeBlast} from './RevengeBlast'
 import {StatusTimeline} from './StatusTimeline'
 import {Swiftcast} from './Swiftcast'
@@ -42,4 +43,5 @@ export default [
 	TripleTrident,
 	DroppedBuffs,
 	WingedReprobation,
+	Positionals,
 ]


### PR DESCRIPTION
This PR makes BLU use the core Positionals module to track missed positionals.

Sample log: https://xivanalysis.com/fflogs/a:1MPYLmK2rBtWAGfJ/9/4
Which produces these:
<img width="892" alt="Screenshot 2023-08-10 at 16 17 13" src="https://github.com/xivanalysis/xivanalysis/assets/215227/975c6f12-1eca-4718-8866-53cab6bc7105">
<img width="883" alt="Screenshot 2023-08-10 at 16 17 18" src="https://github.com/xivanalysis/xivanalysis/assets/215227/2b68142c-01fc-4fe6-bfec-3cbe8c2545b0">
