### PR TITLE
BLU: Swiftcasting Moon Flute itself is rarely a good idea

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -229,6 +229,7 @@
   "blu.revenge_blast.unwhistled.why": "",
   "blu.song_of_torment.suggestion.unbuffed.content": "",
   "blu.song_of_torment.suggestion.unbuffed.why": "",
+  "blu.swiftcast.table.note.bad-mf": "",
   "blu.triple_trident.unbuffed.content": "",
   "blu.triple_trident.unbuffed.why": "",
   "blu.weaving.bad_surpanakha.content": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -229,6 +229,7 @@
   "blu.revenge_blast.unwhistled.why": "{0, plural, one {# Revenge Blast window} other {# Revenge Blast windows}} did not have the <0/> buff.",
   "blu.song_of_torment.suggestion.unbuffed.content": "Ideally every <0/> should be buffed by first using <1/>. This is a minor potency gain.",
   "blu.song_of_torment.suggestion.unbuffed.why": "{0, plural, one {# Song of Torment was} other {# Songs of Torment were}} not buffed.",
+  "blu.swiftcast.table.note.bad-mf": "Swiftcasting Moon Flute will lose you a damaging GCD",
   "blu.triple_trident.unbuffed.content": "<0/> should always be buffed with <1/> and <2/>. For <3/> windows, you want to cast <4/> and <5/> before casting <6/>.",
   "blu.triple_trident.unbuffed.why": "{0, plural, one {# Triple Trident use} other {# Triple Trident uses}} were not buffed",
   "blu.weaving.bad_surpanakha.content": "Use all four <0/> charges at the same time, with no other actions in-between. Even <1/> or using an item will cancel the buff.",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -229,6 +229,7 @@
   "blu.revenge_blast.unwhistled.why": "",
   "blu.song_of_torment.suggestion.unbuffed.content": "",
   "blu.song_of_torment.suggestion.unbuffed.why": "",
+  "blu.swiftcast.table.note.bad-mf": "",
   "blu.triple_trident.unbuffed.content": "",
   "blu.triple_trident.unbuffed.why": "",
   "blu.weaving.bad_surpanakha.content": "",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -229,6 +229,7 @@
   "blu.revenge_blast.unwhistled.why": "",
   "blu.song_of_torment.suggestion.unbuffed.content": "理想的には、最初に <1/> を使用してすべての <0/> をバフする必要があります。 これはわずかな能力の向上です。",
   "blu.song_of_torment.suggestion.unbuffed.why": "{0, plural, other {# 回の苦悶の歌}}はバフされませんでした。",
+  "blu.swiftcast.table.note.bad-mf": "",
   "blu.triple_trident.unbuffed.content": "<0/> は常に <1/> と <2/> でバフするべきです。 <3/> 効果時間中の場合、<6/> を詠唱する前に <4/> と <5/> を詠唱する必要があります。",
   "blu.triple_trident.unbuffed.why": "{0, plural, other {# 回の銛三段}} はバフされませんでした。",
   "blu.weaving.bad_surpanakha.content": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -229,6 +229,7 @@
   "blu.revenge_blast.unwhistled.why": "",
   "blu.song_of_torment.suggestion.unbuffed.content": "",
   "blu.song_of_torment.suggestion.unbuffed.why": "",
+  "blu.swiftcast.table.note.bad-mf": "",
   "blu.triple_trident.unbuffed.content": "",
   "blu.triple_trident.unbuffed.why": "",
   "blu.weaving.bad_surpanakha.content": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -229,6 +229,7 @@
   "blu.revenge_blast.unwhistled.why": "{0, plural, other {# 个复仇冲击机会期}} 没有使用 <0/> buff。",
   "blu.song_of_torment.suggestion.unbuffed.content": "理想情况下，每次 <0/> 之前都应该用 <1/> 强化，不过这个收益比较小。",
   "blu.song_of_torment.suggestion.unbuffed.why": "{0, plural, other {# 次苦闷之歌}}未被强化。",
+  "blu.swiftcast.table.note.bad-mf": "",
   "blu.triple_trident.unbuffed.content": "<0/> 应总在 <1/> 和 <2/> 的效果加成下使用。要在 <3/> 期间使用的场合，最好提前使用 <4/> 和 <5/> 后再使用 <6/>。",
   "blu.triple_trident.unbuffed.why": "{0, plural, other {# 次渔叉三段}}未被强化。",
   "blu.weaving.bad_surpanakha.content": "一口气打完4层 <0/> 充能，中间不要插入别的技能。即使使用 <1/> 或者道具都会取消穿甲散弹强化效果。",

--- a/src/parser/jobs/blu/changelog.tsx
+++ b/src/parser/jobs/blu/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2023-08-11'),
+		Changes: () => <>Swiftcasting Moon Flute will lose you a damaging GCD under burst</>,
+		contributors: [CONTRIBUTORS.HUGMEIR],
+	},
+	{
 		date: new Date('2023-08-10'),
 		Changes: () => <>Report missed Goblin Punch positionals</>,
 		contributors: [CONTRIBUTORS.HUGMEIR],

--- a/src/parser/jobs/blu/modules/Swiftcast.tsx
+++ b/src/parser/jobs/blu/modules/Swiftcast.tsx
@@ -1,8 +1,44 @@
+import {Trans} from '@lingui/react'
+import {EvaluatedAction} from 'parser/core/modules/ActionWindow'
+import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
 import {Swiftcast as CoreSwiftcast} from 'parser/core/modules/Swiftcast'
+import React from 'react'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 
 // Annoyingly we can't directly use the Swiftcast
 export class Swiftcast extends CoreSwiftcast {
 	static override displayOrder = DISPLAY_ORDER.SWIFTCAST
+	private badSwiftValidator = (window: HistoryEntry<EvaluatedAction[]>) => {
+		if (window.data.length <= 0) {
+			return {isValid: true}
+		}
+
+		// Swifting a Moon Flute is bizarrely a significant loss!
+		// Normally casting Moon Flute gives you 14.5s worth of GCDs under
+		// Waxing Nocturne, because you get the effect when the spell
+		// finishes casting.
+		//
+		// Swifting the Moon Flute cast gives you the effect immediately,
+		// leaving you with 12.5s worth of Moon Flute for GCDs.
+		if (window.data[0].action !== this.data.actions.MOON_FLUTE) {
+			return {isValid: true}
+		}
+
+		// Edge case: It's the end of the fight and you're swifting MF to
+		// fit in some extra oGCDs.
+		// I guess there's some optimization cases before downtime too?
+		// We consider Waning Nocturne as downtime so checking that is going
+		// be really annoying. Assume they know what they're doing.
+		const timeRemaining = (this.parser.pull.timestamp + this.parser.pull.duration) - window.start
+		if (timeRemaining <= this.data.statuses.WAXING_NOCTURNE.duration) {
+			return {isValid: true}
+		}
+
+		return {
+			isValid: false,
+			note: <Trans id="blu.swiftcast.table.note.bad-mf">Swiftcasting Moon Flute will lose you a damaging GCD</Trans>,
+		}
+	}
+	override swiftcastValidators = [this.badSwiftValidator]
 }
 


### PR DESCRIPTION
Moon Flute is a GCD that gives you a 15 second buff that increases your damage by 50%; it has a 2 second cast time and 2.5 second GCD.

That means that if you hardcast it, you end up with 14.5s worth of the buff that you can use on other GCDs -- but if you Swiftcast it, you only end up with 12.5 seconds usable for other GCDs.

While there's some edge cases for this (you might want to swift moon flute before downtime or before the end of the fight in order to cram in some extra oGCDs) the general recommendation is to NOT do this, since it'll lose you a damaging GCD under buffs.