### PR TITLE
WIP: Core Weaving module: Tighten the check

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,13 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2023-08-14'),
+		Changes: () => <>
+			Tightened the detection of Weaving issues.
+		</>,
+		contributors: [CONTRIBUTORS.HUGMEIR],
+	},
+	{
 		date: new Date('2023-07-28'),
 		Changes: () => <>
 			Fix a bug with status application event ordering that sometimes caused extra action uses to by synthesized.

--- a/src/parser/core/modules/Weaving.tsx
+++ b/src/parser/core/modules/Weaving.tsx
@@ -16,7 +16,10 @@ import React, {ReactNode} from 'react'
 import {Button, Table} from 'semantic-ui-react'
 import {Timeline} from './Timeline'
 
-const ANIMATION_LOCK_MS = 800 // on lower pings this apparently goes down to as little as 600ms
+const LATENCY_FUDGE_FACTOR_MS = 200 // 200ms of fudge factor to accoutn for higher latency folk
+const INSTANT_GCD_ANIMATION_LOCK_MS = 100 + LATENCY_FUDGE_FACTOR_MS
+const CAST_GCD_ANIMATION_LOCK_MS = 600 + LATENCY_FUDGE_FACTOR_MS
+const OGCD_ANIMATION_LOCK_MS = 600 + LATENCY_FUDGE_FACTOR_MS
 const CLIPPING_GRACE_PERIOD_MS = 50 // you're allowed to clip a GCD by this much
 // The grace period is just here to reflect reality -- Gold parses on fflogs are
 // clipping their GCDs by about 20-30ms during bursts, so showing these kind
@@ -232,8 +235,9 @@ export class Weaving extends Analyser {
 
 		const castTime = this.castTime.forEvent(weave.leadingGcdEvent) ?? 0
 		const recastTime = this.castTime.recastForEvent(weave.leadingGcdEvent) ?? BASE_GCD
-		const weavingTime = Math.max(0, recastTime - castTime - ANIMATION_LOCK_MS) // max(0, ...) for e.g. RDM hardcasting one of the 5s spells
-		const maxWeaves = Math.max(0, Math.floor(weavingTime / ANIMATION_LOCK_MS))
+		const gcdLock = castTime === 0 ? INSTANT_GCD_ANIMATION_LOCK_MS : CAST_GCD_ANIMATION_LOCK_MS
+		const weavingTime = Math.max(0, recastTime - castTime - gcdLock) // max(0, ...) for e.g. RDM hardcasting one of the 5s spells
+		const maxWeaves = Math.max(0, Math.floor(weavingTime / OGCD_ANIMATION_LOCK_MS))
 		return maxWeaves
 	}
 

--- a/src/parser/core/modules/Weaving.tsx
+++ b/src/parser/core/modules/Weaving.tsx
@@ -17,6 +17,10 @@ import {Button, Table} from 'semantic-ui-react'
 import {Timeline} from './Timeline'
 
 const ANIMATION_LOCK_MS = 800 // on lower pings this apparently goes down to as little as 600ms
+const CLIPPING_GRACE_PERIOD_MS = 50 // you're allowed to clip a GCD by this much
+// The grace period is just here to reflect reality -- Gold parses on fflogs are
+// clipping their GCDs by about 20-30ms during bursts, so showing these kind
+// of clips is just unactionable spam.
 
 const DEFAULT_MAX_WEAVES = 2
 
@@ -196,7 +200,7 @@ export class Weaving extends Analyser {
 
 		const recast = ((weave.leadingGcdEvent != null) ? this.castTime.recastForEvent(weave.leadingGcdEvent) : undefined) ?? BASE_GCD
 		// Check the downtime-adjusted GCD time difference for this weave - do not treat multiple weaves during downtime as bad weaves
-		return weave.gcdTimeDiff > recast && weaveCount > this.getMaxWeaves(weave)
+		return weave.gcdTimeDiff > (recast + CLIPPING_GRACE_PERIOD_MS) && weaveCount > this.getMaxWeaves(weave)
 	}
 
 	private clearWeave(event: Events['death']) {


### PR DESCRIPTION
Previously this was looking at the cast time for an action and going by a simple table to decide how many weaves you had.

The problem is that this lead to several false-negatives.

The initial implementation of this PR made the check slightly more strict, first by assuming that the animation lock (for both GCDs and weaves) is 800ms[*], then by running the equivalent of this:

    floor( (recastTime - castTime - animationLock) / animationLock )

However, that actually made it *too* strict, causing it to display some real-but-unactionable issues, like this from the current top RDM report:
<img width="388" alt="Screenshot 2023-08-14 at 14 58 08" src="https://github.com/xivanalysis/xivanalysis/assets/215227/4bb94f76-0e7a-4eb6-bff0-5fa707f582e3">

So to reduce the noise, this also adds a 50ms grace period for clips -- Essentially allowing GCD clips so long as they are 50ms or less.

Weaving issues on current HEAD:
<img width="447" alt="Screenshot 2023-08-14 at 15 12 56" src="https://github.com/xivanalysis/xivanalysis/assets/215227/769288a4-a05d-4eee-9e95-3fb8ed573480">

Weaving issues with this PR applied (note the 3:17 and 5:11 clips):
<img width="450" alt="Screenshot 2023-08-14 at 15 13 15" src="https://github.com/xivanalysis/xivanalysis/assets/215227/9d0aff19-a8f8-449b-8a74-293ac9f2fe8d">

[*] I'm told that for people with low latency this goes as low as 600ms, but this seems a bit more forgiving for anyone not hugging the DCs.

