### PR TITLE
[Bugfix] - Incorrect 'missed' Technical Finishes

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -82,4 +82,9 @@ export const changelog = [
 		Changes: () => <>Adjust Devilment timing check to account for changed Technical Finish status application timing after 6.4.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
+	{
+		date: new Date('2023-09-04'),
+		Changes: () => <>Fix a bug related to the Technical Finish status application changes from 6.4 that occasionally caused incorrect 'missed' Finish reports.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
 ]

--- a/src/parser/jobs/dnc/modules/DirtyDancing.tsx
+++ b/src/parser/jobs/dnc/modules/DirtyDancing.tsx
@@ -174,6 +174,10 @@ export class DirtyDancing extends Analyser {
 	private resolveDance(event: Events['damage']) {
 		const dance = this.lastDance
 
+		// Tech Finish's buff range extension from 6.4 sometimes produces unsequenced 'damage' events 'targeting' the source player that 'miss'.
+		// If they come before the actual damage event, it'll mess things up so just ignore them
+		if (!event.sequence) { return }
+
 		if (!dance || dance.resolved) {
 			return
 		}


### PR DESCRIPTION
Report link: https://xivanalysis.com/fflogs/14DVaFHBgwzNPRyn/14/140

Apparently the 6.4 buff range changes not only messed with devilment timing, it also occasionally (always?) produces a 'damage' event without a sequence number that targets the source player and 'misses'. If this event comes before the real damage events, it was closing the window early and marking it as a missed finish.

We probably ought to handle this down in adapter space, but I can't debug into that to try to see how it's winding up making these events, so I'm just dealing with it here.