### PR TITLE
Patch definition for 6.5

### DIFF
--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -95,6 +95,11 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 			[GameEdition.GLOBAL]: 1689667200, // 18/07/23 08:00:00 GMT
 		},
 	},
+	'6.5': {
+		date: {
+			[GameEdition.GLOBAL]: 1696320000, // 03/10/23 08:00:00 GMT
+		},
+	},
 })
 
 export type PatchNumber = keyof typeof PATCHES


### PR DESCRIPTION
Since we know we're getting at least some job changes, pre-emptively adding in the patch date for 6.5 so maintainers can start their patch bump PRs once we have the full patch notes. Probably best to not merge this until after the servers are down though.