### PR TITLE
BLU: Bump support to 6.5

### DIFF
--- a/src/parser/jobs/blu/index.tsx
+++ b/src/parser/jobs/blu/index.tsx
@@ -25,7 +25,7 @@ export const BLUE_MAGE = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.45',
+		to: '6.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.HUGMEIR, role: ROLES.DEVELOPER},


### PR DESCRIPTION
Only change for BLU this patch was a bugfix for an interaction between Basic Instinct and the Deep Clean HoT that you get from the Peat Pelt => Spick-and-span combo.

We actually don't yet handle Deep Clean in the Overheal report, so nothing has really changed for us.

Note that this requires https://github.com/xivanalysis/xivanalysis/pull/1901 to be merged first.