### PR TITLE
SCH 6.5 support

### DIFF
--- a/src/parser/jobs/sch/index.js
+++ b/src/parser/jobs/sch/index.js
@@ -18,7 +18,7 @@ export const SCHOLAR = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.45',
+		to: '6.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.MYPS, role: ROLES.DEVELOPER},


### PR DESCRIPTION
No operative job changes, so SCH is good to go.