### PR TITLE
[RPR] 6.5 Support

### DIFF
--- a/src/parser/jobs/rpr/index.tsx
+++ b/src/parser/jobs/rpr/index.tsx
@@ -17,7 +17,7 @@ export const REAPER = new Meta({
 
 	supportedPatches: {
 		from: '6.0',
-		to: '6.45',
+		to: '6.5',
 	},
 
 	contributors: [


### PR DESCRIPTION
RPR was buffed, no rotational changes. No data changes are required.