### PR TITLE
Mark WHM supported for 6.5

### DIFF
--- a/src/parser/jobs/whm/index.tsx
+++ b/src/parser/jobs/whm/index.tsx
@@ -21,7 +21,7 @@ export const WHITE_MAGE = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.45',
+		to: '6.5',
 	},
 	contributors: [
 		// {user: CONTRIBUTORS.YOU, role: ROLES.DEVELOPER},


### PR DESCRIPTION
No changes. Glare and Stone.