### PR TITLE
Bump core to 6.5

### DIFF
--- a/src/parser/core/index.tsx
+++ b/src/parser/core/index.tsx
@@ -15,7 +15,7 @@ export const CORE = new Meta({
 	// Read `docs/patch-checklist.md` before editing the following values.
 	supportedPatches: {
 		from: '6.0',
-		to: '6.45',
+		to: '6.5',
 	},
 })
 


### PR DESCRIPTION
No new UTA statuses detected after re-running `yarn generate` and nothing notable on the invulnerability front checking over a selection of new EX and 24man logs. Something odd seems to be going on with the 3rd boss of the 24man since every log I looked at showed it as a wipe, but since fflogs does too that seems to be a problem on their end/a quirk with the fight, not an issue with our code. Guess I'll see what's up with that when I get to run it later tonight.

Edit: Seems that fflogs fixed things on their end at some point overnight, 24man fight 3 looks fine now.