### PR TITLE
Bump NIN support to 6.5

### DIFF
--- a/src/parser/jobs/nin/index.tsx
+++ b/src/parser/jobs/nin/index.tsx
@@ -14,7 +14,7 @@ export const NINJA = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.05',
-		to: '6.45',
+		to: '6.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.TOASTDEIB, role: ROLES.MAINTAINER},


### PR DESCRIPTION
No job changes means ez bump.