### PR TITLE
6.5 bump for pld, drk, and war

### DIFF
--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -18,7 +18,7 @@ export const DARK_KNIGHT = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.45',
+		to: '6.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AZARIAH, role: ROLES.MAINTAINER},

--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -19,7 +19,7 @@ export const PALADIN = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.3',
-		to: '6.45',
+		to: '6.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.STYRFIRE, role: ROLES.MAINTAINER},

--- a/src/parser/jobs/war/index.tsx
+++ b/src/parser/jobs/war/index.tsx
@@ -16,7 +16,7 @@ export const WARRIOR = new Meta({
 	</>,
 	supportedPatches: {
 		from: '6.0',
-		to: '6.45',
+		to: '6.5',
 	},
 	contributors: [
 		{user: CONTRIBUTORS.AY, role: ROLES.MAINTAINER},


### PR DESCRIPTION
No changes to any of these jobs (except for potency changes for pld which xiva doesn't track)