### PR TITLE
BuffWindow - filter events that occurred at or after the end of the window

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,13 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2023-19-13'),
+		Changes: () => <>
+			Fix event ordering inaccuracies when a buff status removal and a damage event occur on the same timestamp.
+		</>,
+		contributors: [CONTRIBUTORS.HINT],
+	},
+	{
 		date: new Date('2023-08-01'),
 		Changes: () => <>
 			Fix a bug that could cause deaths and raises to throw off some gauge's total generation calculations.

--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,7 +10,7 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
-		date: new Date('2023-10-13'),
+		date: new Date('2024-02-19'),
 		Changes: () => <>
 			Fix event ordering inaccuracies when a buff status removal and a damage event occur on the same timestamp.
 		</>,

--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,7 +10,7 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
-		date: new Date('2023-19-13'),
+		date: new Date('2023-10-13'),
 		Changes: () => <>
 			Fix event ordering inaccuracies when a buff status removal and a damage event occur on the same timestamp.
 		</>,

--- a/src/parser/core/modules/ActionWindow/windows/BuffWindow.ts
+++ b/src/parser/core/modules/ActionWindow/windows/BuffWindow.ts
@@ -72,6 +72,22 @@ export abstract class BuffWindow extends ActionWindow {
 	}
 
 	/**
+	 * End window at the timestamp provided, removing history entries
+	 * which do not belong in the window.
+	 *
+	 * @param timestamp Time of statusRemove event.
+	 */
+	protected override onWindowEnd(timestamp: number): void {
+		const currentWindow = this.history.getCurrent()
+
+		if (currentWindow != null) {
+			currentWindow.data = currentWindow.data.filter(event => event.timestamp < timestamp)
+		}
+
+		super.onWindowEnd(timestamp)
+	}
+
+	/**
 	 * Start window at the timestamp provided and attach hook for closing the window
 	 * after the duration of the buff.
 	 *


### PR DESCRIPTION
This fixes the longstanding bug where actions that occur on the same timestamp as a buff falling off will be treated as if they landed inside the buff (in all such cases I've seen, these actions do not receive the effects of the buff).

Sample log (the last GCD of RoF at 4:04 should not be counted within the window): https://xivanalysis.com/fflogs/aN9y7vxT3gBw2fZJ/1/1