### PR TITLE
SCH: Added Bio II to make the level 70 timelines complete

### DIFF
--- a/src/data/ACTIONS/root/SCH.ts
+++ b/src/data/ACTIONS/root/SCH.ts
@@ -218,6 +218,16 @@ export const SCH = ensureActions({
 		castTime: 1500,
 	},
 
+	BIO_II: {
+		id: 17865,
+		name: 'Bio II',
+		icon: 'https://xivapi.com/i/000000/000504.png',
+		onGcd: true,
+		speedAttribute: Attribute.SPELL_SPEED,
+		statusesApplied: ['BIO_II'],
+	},
+
+
 	CHAIN_STRATAGEM: {
 		id: 7436,
 		name: 'Chain Stratagem',

--- a/src/data/STATUSES/root/SCH.ts
+++ b/src/data/STATUSES/root/SCH.ts
@@ -1,6 +1,12 @@
 import {ensureStatuses} from '../type'
 
 export const SCH = ensureStatuses({
+	BIO_II: {
+		id: 189,
+		name: 'Bio II',
+		icon: 'https://xivapi.com/i/010000/010505.png',
+		duration: 30000,
+	},
 	BIOLYSIS: {
 		id: 1895,
 		name: 'Biolysis',


### PR DESCRIPTION
Current base:
<img width="524" alt="Screenshot 2023-11-13 at 10 53 54" src="https://github.com/xivanalysis/xivanalysis/assets/215227/6b614030-93c5-4243-934b-eeb93c38f208">

With the patch:
<img width="516" alt="Screenshot 2023-11-13 at 10 53 29" src="https://github.com/xivanalysis/xivanalysis/assets/215227/7c12d74d-1423-408c-aa07-5033a935c756">
