### PR TITLE
[BugFix] PLD synthing wrong action in dungeon pulls

### DIFF
--- a/src/data/ACTIONS/layers/patch6.3.ts
+++ b/src/data/ACTIONS/layers/patch6.3.ts
@@ -21,6 +21,9 @@ export const patch630: Layer<ActionRoot> = {
 		ROYAL_AUTHORITY: {
 			statusesApplied: ['SWORD_OATH', 'DIVINE_MIGHT'],
 		},
+		PROMINENCE: {
+			statusesApplied: ['DIVINE_MIGHT'],
+		},
 		CONFITEOR: {
 			combo: undefined,
 		},

--- a/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
@@ -15,6 +15,8 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 	private observedStatuses = new Map<Actor['id'], Set<number>>()
 	private precastEvents: Event[] = []
 
+	static override debug = false
+
 	override postprocess(adaptedEvents: Event[]): Event[] {
 		for (const event of adaptedEvents) {
 			if (event.type !== 'statusApply' && event.type !== 'statusRemove') {
@@ -31,6 +33,7 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 					continue
 				}
 
+				this.debug(`Timestamp ${event.timestamp}: Saw first statusApply for status ${event.status} on target ${event.target}`)
 				this.synthesizeActionIfNew(event)
 
 				// If the first observed instance of a status that is applied
@@ -100,6 +103,8 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 			// We've already seen an action that applies this status, skip
 			return
 		}
+
+		this.debug(`Timestamp ${event.timestamp}: Found unmatched application of ${statusKey} on ${event.target} - synthesizing action ${action.name}`)
 
 		const actionEvent: Events['action'] = {
 			...event,


### PR DESCRIPTION
Simplest solution here is to be more accurate with which actions apply Divine Might, which will actually cause prepullStatus to never try to synth an action since it can't narrow possibilities down to just one action.

Also added some debug code to prepullStatus while isolating this, leaving code available for future use.