### PR TITLE
[BugFix] Zoe is a consumeable buff

### DIFF
--- a/src/parser/jobs/sge/modules/Zoe.tsx
+++ b/src/parser/jobs/sge/modules/Zoe.tsx
@@ -5,6 +5,7 @@ import {ActionKey} from 'data/ACTIONS'
 import {Status} from 'data/STATUSES'
 import {dependency} from 'parser/core/Injectable'
 import {BuffWindow, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
+import {EndOfWindowHandlingMode} from 'parser/core/modules/ActionWindow/windows/BuffWindow'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
@@ -27,6 +28,7 @@ export class Zoe extends BuffWindow {
 	@dependency private globalCooldown!: GlobalCooldown
 
 	override buffStatus: Status = this.data.statuses.ZOE
+	override endOfWindowHandlingMode: EndOfWindowHandlingMode = 'SAME-TIMESTAMP'
 
 	override initialise() {
 		super.initialise()


### PR DESCRIPTION
Turns out Zoe should've been tagged with the SAME-TIMESTAMP EndOfWindowHandlingMode like Swiftcast after all

ref logs:
- https://xivanalysis.com/fflogs/GpKyjv6LAV7q8Hbr/6/68
- https://xivanalysis.com/fflogs/hTFWabGcd1yv2pZD/22/123