### PR TITLE
[BugFix] Bring Searing Light's buff count tracking in-line with RaidBuffWindow

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -1021,8 +1021,6 @@
   "smn.searinglight.players-count": "Spieler gebufft",
   "smn.searinglight.suggestiongs.ghosted.why": "",
   "smn.searinglight.suggestions.ghosted.content": "",
-  "smn.searinglight.suggestions.missed-players.content": "Versuche sicherzugehen, dass deine <0/> Zauber deine ganze Party verstärken, ansonsten verlierst du Raid Schaden.",
-  "smn.searinglight.suggestions.missed-players.why": "",
   "smn.searinglight.table-header": "",
   "smn.searinglight.title": "Gleißender Schein",
   "smn.slipstream.title": "Wirbelströmung",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1021,8 +1021,6 @@
   "smn.searinglight.players-count": "Players Buffed",
   "smn.searinglight.suggestiongs.ghosted.why": "{ghostedWindows, plural, one {# Searing Light use was} other {# Searing Light uses were}} lost.",
   "smn.searinglight.suggestions.ghosted.content": "Make sure carbuncle has enough time to cast <0/> before summoning an Arcanum or demi summon or your cast will be wasted.",
-  "smn.searinglight.suggestions.missed-players.content": "Try to make sure your <0/> casts buff your full party with each use. Failing to do so is a raid damage loss.",
-  "smn.searinglight.suggestions.missed-players.why": "{missedPlayersWindows} of your Searing Light uses did not buff the full party.",
   "smn.searinglight.table-header": "Searing Light Actions",
   "smn.searinglight.title": "Searing Light",
   "smn.slipstream.title": "Slipstream",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -1021,8 +1021,6 @@
   "smn.searinglight.players-count": "Buff du joueurs",
   "smn.searinglight.suggestiongs.ghosted.why": "{ghostedWindows, plural, one {# Éclat Ardent a été perdu} other {# Éclats Ardents ont été perdus}}.",
   "smn.searinglight.suggestions.ghosted.content": "Assurez-vous que Carbuncle a suffisemment de temps pour lancer <0/> avant d'invoquer une Arcane ou une Demi-invocation, sinon votre sort sera gâché.",
-  "smn.searinglight.suggestions.missed-players.content": "Essayez de faire en sorte que vos <0/> touchent tous le monde à chaque utilisation. Ne pas le faire résulte en une perte de dégât de groupe.",
-  "smn.searinglight.suggestions.missed-players.why": "{missedPlayersWindows} de vos Éclats Ardents n'ont pas touchés tout le groupe.",
   "smn.searinglight.table-header": "Actions durant Éclat Ardent",
   "smn.searinglight.title": "Éclat Ardent",
   "smn.slipstream.title": "Sillage",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -1021,8 +1021,6 @@
   "smn.searinglight.players-count": "バフを与えられた人数",
   "smn.searinglight.suggestiongs.ghosted.why": "",
   "smn.searinglight.suggestions.ghosted.content": "",
-  "smn.searinglight.suggestions.missed-players.content": "<0/>は使用時にパーティー全体にかかっているか意識してみてください。失敗しているとダメージロスになります。",
-  "smn.searinglight.suggestions.missed-players.why": "{missedPlayersWindows} 回のシアリングライトでパーティー全体にかかっていませんでした。",
   "smn.searinglight.table-header": "シアリングライトアクション",
   "smn.searinglight.title": "シアリングライト",
   "smn.slipstream.title": "スリップストリーム",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -1021,8 +1021,6 @@
   "smn.searinglight.players-count": "버프 받은 파티원",
   "smn.searinglight.suggestiongs.ghosted.why": "타오르는 빛 사용 횟수를 {ghostedWindows, plural, other {#}}회 잃었습니다.",
   "smn.searinglight.suggestions.ghosted.content": "카벙클의 신비 구간 또는 데미 소환수 구간에 진입하기 전에 카벙클이 <0/> 기술을 시전할 시간이 충분한지 확인하십시오. 기술이 낭비될 수 있습니다.",
-  "smn.searinglight.suggestions.missed-players.content": "<0/> 기술을 쓸 때마다 파티원 전체에게 적용되도록 하십시오. 파티원 모두에게 버프를 주지 못한다면 파티 피해량에서 손실이 발생합니다.",
-  "smn.searinglight.suggestions.missed-players.why": "모든 파티원에게 타오르는 빛 버프를 {missedPlayersWindows}회 부여하지 못했습니다.",
   "smn.searinglight.table-header": "타오르는 빛 중 기술",
   "smn.searinglight.title": "타오르는 빛",
   "smn.slipstream.title": "반동 기류",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -1021,8 +1021,6 @@
   "smn.searinglight.players-count": "收到增益的队员",
   "smn.searinglight.suggestiongs.ghosted.why": "浪费了 {ghostedWindows} 次 Searing Light。",
   "smn.searinglight.suggestions.ghosted.content": "在召唤奥秘或亚灵神之前，确保宝石兽有足够的时间施放<0/>，否则技能将会被浪费。",
-  "smn.searinglight.suggestions.missed-players.content": "尝试确保你的<0/>施放到你的所有小队成员身上，若没有则会造成rdps的损失。",
-  "smn.searinglight.suggestions.missed-players.why": "你有 {missedPlayersWindows} 次 Searing Light 没有覆盖到团队所有成员。",
   "smn.searinglight.table-header": "灼热之光的使用",
   "smn.searinglight.title": "灼热之光",
   "smn.slipstream.title": "螺旋气流",

--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -28,6 +28,11 @@ export const SUMMONER = new Meta({
 
 	changelog: [
 		{
+			date: new Date('2024-02-26'),
+			Changes: () => <>Fix Searing Light's tracking of players buffed to be consistent with other raid buffs.</>,
+			contributors: [CONTRIBUTORS.AKAIRYU],
+		},
+		{
 			date: new Date('2023-01-14'),
 			Changes: () => <>Removed outdated Swiftcast message.</>,
 			contributors: [CONTRIBUTORS.KELOS],

--- a/src/parser/jobs/smn/modules/SearingLight.tsx
+++ b/src/parser/jobs/smn/modules/SearingLight.tsx
@@ -1,6 +1,6 @@
 import {t} from '@lingui/macro'
 import {Trans, Plural} from '@lingui/react'
-import {ActionLink, StatusLink} from 'components/ui/DbLink'
+import {ActionLink} from 'components/ui/DbLink'
 import {RotationTable, RotationTableEntry} from 'components/ui/RotationTable'
 import {ActionKey} from 'data/ACTIONS'
 import {Event, Events} from 'event'
@@ -235,27 +235,6 @@ export class SearingLight extends Analyser {
 		this.history.closeCurrent(this.parser.pull.timestamp + this.parser.pull.duration)
 
 		if (this.history.entries.length === 0) { return }
-
-		const missedPlayersWindows = this.history.entries
-			.filter(slUse => slUse.data.playersHit.size <= PLAYERS_HIT_SUGGESTION_THRESHOLD)
-			.length
-		const totalMissedPlayers = this.history.entries
-			.reduce((totalMissed, slUse) => {
-				return totalMissed + ((slUse.data.ghosted) ? 0 :  PLAYERS_HIT_TARGET - slUse.data.playersHit.size)
-			}, 0)
-
-		if (totalMissedPlayers > 0) {
-			this.suggestions.add(new Suggestion({
-				icon: this.data.actions.SEARING_LIGHT.icon,
-				content: <Trans id="smn.searinglight.suggestions.missed-players.content">
-					Try to make sure your <StatusLink status="SEARING_LIGHT"/> casts buff your full party with each use. Failing to do so is a raid damage loss.
-				</Trans>,
-				severity: SEVERITY.MINOR,
-				why: <Trans id="smn.searinglight.suggestions.missed-players.why">
-					{missedPlayersWindows} of your Searing Light uses did not buff the full party.
-				</Trans>,
-			}))
-		}
 
 		const ghostedWindows = this.history.entries.filter(slUse => slUse.data.ghosted).length
 		if (ghostedWindows) {

--- a/src/parser/jobs/smn/modules/SearingLight.tsx
+++ b/src/parser/jobs/smn/modules/SearingLight.tsx
@@ -17,8 +17,7 @@ import React from 'react'
 import {Icon} from 'semantic-ui-react'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 
-const PLAYERS_HIT_TARGET = 8
-const PLAYERS_HIT_SUGGESTION_THRESHOLD = 7
+const FULL_PARTY_SIZE = 8
 const MAX_BUFF_DURATION = 30000
 
 const OTHER_PET_ACTIONS: ActionKey[] = [
@@ -59,8 +58,15 @@ export class SearingLight extends Analyser {
 	private slPending: number = 0 // timestamp
 	private petIds: string[] = []
 
+	private expectedCount: number = 0
+
 	override initialise() {
 		super.initialise()
+
+		const partyMembers = this.parser.pull.actors
+			.filter(actor => actor.playerControlled)
+			.map(actor => actor.id)
+		this.expectedCount = Math.min(partyMembers.length, FULL_PARTY_SIZE) // 24-mans count the other alliance members as 'party members' but you can't buff them...
 
 		this.petIds = this.parser.pull.actors
 			.filter(actor => actor.owner === this.parser.actor)
@@ -274,7 +280,7 @@ export class SearingLight extends Analyser {
 				const targetsData = {
 					players: {
 						actual: slUse.data.playersHit.size,
-						expected: PLAYERS_HIT_TARGET,
+						expected: this.expectedCount,
 					},
 				}
 				const notesMap = {


### PR DESCRIPTION
Searing Light was using the outdated assumption that the number of players to be buffed was always 8. While we don't target this at dungeons, it still looks bad to have most jobs (which are mostly/all ported over to core RaidBuffWindow) recognizing when the party size is smaller, and SMN isn't.

We'll handle this in Dawntrail with the expected port of Searing Light to core, but in the meantime, I replicated the expected buff denominator logic from there into Searing Light. Also taking the opportunity to remove the suggestion to hit all players to make that consistent with other jobs, since that is not fully in the player's control.