### PR TITLE
Retrieve logged level for content and display in about

### DIFF
--- a/src/event.ts
+++ b/src/event.ts
@@ -227,6 +227,8 @@ interface EventActorUpdate extends FieldsForActor {
 	targetable?: boolean
 	/** Current attributes (stats) */
 	attributes?: AttributeValue[]
+	/** Current level */
+	level?: number
 }
 
 export interface EventDancerGaugeUpdate extends FieldsForActor {

--- a/src/parser/core/modules/About.tsx
+++ b/src/parser/core/modules/About.tsx
@@ -8,14 +8,18 @@ import {AVAILABLE_MODULES} from 'parser/AVAILABLE_MODULES'
 import {Analyser, DisplayMode} from 'parser/core/Analyser'
 import React from 'react'
 import {Header} from 'semantic-ui-react'
+import {dependency} from '../Injectable'
 import styles from './About.module.css'
+import {Actors} from './Actors'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 export default class About extends Analyser {
-	static handle = 'about'
-	static displayOrder = DISPLAY_ORDER.ABOUT
-	static displayMode = DisplayMode.RAW
-	static title = t('core.about.title')`About`
+	static override handle = 'about'
+	static override displayOrder = DISPLAY_ORDER.ABOUT
+	static override displayMode = DisplayMode.RAW
+	static override title = t('core.about.title')`About`
+
+	@dependency private actors!: Actors
 
 	Description = null
 	contributors = []
@@ -25,6 +29,7 @@ export default class About extends Analyser {
 	//		from: ...,
 	//		to: ...,
 	// }
+	supportedLevels = null
 
 	set supportedPatch(value) {
 		// Warn the dev that they're using a deprecated prop
@@ -49,6 +54,8 @@ export default class About extends Analyser {
 		this.supportedPatches = jobMeta.supportedPatches != null
 			? this.parser.meta.supportedPatches
 			: undefined
+
+		this.supportedLevels = jobMeta.supportedLevels ?? {from: 100, to: 100}
 	}
 
 	output() {
@@ -77,6 +84,9 @@ export default class About extends Analyser {
 			this.parser.pull.timestamp / 1000,
 		)
 
+		const {from: fromLevel, to: toLevel = from} = this.supportedLevels
+		const loggedLevel = this.actors.get(this.parser.actor).at(this.parser.pull.timestamp + this.parser.pull.duration).level
+
 		const {Description} = this
 
 		return (
@@ -101,6 +111,12 @@ export default class About extends Analyser {
 				<dl className={styles.meta}>
 					<dt><Trans id="core.about.supported-patches">Supported Patches:</Trans></dt>
 					<dd>{from}{from !== to && `–${to}`}</dd>
+
+					<dt><Trans id="core.about.supported-levels">Supported Levels:</Trans></dt>
+					<dd>{fromLevel}{fromLevel !== toLevel && `-${toLevel}`}</dd>
+
+					<dt>Logged Level:</dt>
+					<dd>{loggedLevel}</dd>
 
 					{this.contributors.length > 0 && <>
 						<dt><Trans id="core.about.contributors">Contributors:</Trans></dt>

--- a/src/parser/core/modules/Actors/Actor.ts
+++ b/src/parser/core/modules/Actors/Actor.ts
@@ -18,9 +18,11 @@ class ActorResources {
 	hp: Readonly<Resource>
 	mp: Readonly<Resource>
 	position: Readonly<Position>
-	level: number | undefined
 	get targetable() {
 		return this.getHistoricalValue(event => event.targetable, true)
+	}
+	get level() {
+		return this.getHistoricalValue(event => event.level, undefined)
 	}
 	attributes: Readonly<Record<Attribute, AttributeValue>>
 
@@ -40,7 +42,6 @@ class ActorResources {
 		this.mp = this.buildResource('mp')
 		this.position = this.buildPosition()
 		this.attributes = this.buildAttributes()
-		this.level = this.getLevel()
 	}
 
 	hasStatus(statusId: Status['id'], source?: Actor['id']) {
@@ -122,13 +123,6 @@ class ActorResources {
 				return getHistoricalAttribute(Attribute.SPELL_SPEED)
 			},
 		}
-	}
-
-	private getLevel() {
-		return this.getHistoricalValue(
-			event => event.level,
-			undefined
-		)
 	}
 
 	/**

--- a/src/parser/core/modules/Actors/Actor.ts
+++ b/src/parser/core/modules/Actors/Actor.ts
@@ -18,6 +18,7 @@ class ActorResources {
 	hp: Readonly<Resource>
 	mp: Readonly<Resource>
 	position: Readonly<Position>
+	level: number | undefined
 	get targetable() {
 		return this.getHistoricalValue(event => event.targetable, true)
 	}
@@ -39,6 +40,7 @@ class ActorResources {
 		this.mp = this.buildResource('mp')
 		this.position = this.buildPosition()
 		this.attributes = this.buildAttributes()
+		this.level = this.getLevel()
 	}
 
 	hasStatus(statusId: Status['id'], source?: Actor['id']) {
@@ -120,6 +122,13 @@ class ActorResources {
 				return getHistoricalAttribute(Attribute.SPELL_SPEED)
 			},
 		}
+	}
+
+	private getLevel() {
+		return this.getHistoricalValue(
+			event => event.level,
+			undefined
+		)
 	}
 
 	/**

--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -231,6 +231,12 @@ Array [
     "type": "action",
   },
   Object {
+    "actor": "15",
+    "level": 90,
+    "timestamp": 1600002865189,
+    "type": "actorUpdate",
+  },
+  Object {
     "source": "15",
     "status": 1000743,
     "target": "15",

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -1180,22 +1180,31 @@ describe('Event adapter', () => {
 		}])
 
 		/* eslint-disable @typescript-eslint/no-magic-numbers */
-		expect(result).toEqual([{
-			timestamp: timestamp + 100,
-			type: 'actorUpdate',
-			actor: '1',
-			attributes: [
-				{attribute: Attribute.SKILL_SPEED, value: 100, estimated: false},
-				{attribute: Attribute.SPELL_SPEED, value: 100, estimated: false},
-			],
-		}, {
-			timestamp: timestamp + 200,
-			type: 'actorUpdate',
-			actor: '1',
-			attributes: [
-				{attribute: Attribute.SPELL_SPEED, value: 200, estimated: false},
-			],
-		}])
+		expect(result).toEqual([
+			{
+				timestamp: timestamp + 100,
+				type: 'actorUpdate',
+				actor: '1',
+				level: 90,
+			},
+			{
+				timestamp: timestamp + 100,
+				type: 'actorUpdate',
+				actor: '1',
+				attributes: [
+					{attribute: Attribute.SKILL_SPEED, value: 100, estimated: false},
+					{attribute: Attribute.SPELL_SPEED, value: 100, estimated: false},
+				],
+			},
+			{
+				timestamp: timestamp + 200,
+				type: 'actorUpdate',
+				actor: '1',
+				attributes: [
+					{attribute: Attribute.SPELL_SPEED, value: 200, estimated: false},
+				],
+			},
+		])
 		/* eslint-enable @typescript-eslint/no-magic-numbers */
 	})
 

--- a/src/reportSources/legacyFflogs/eventAdapter/deduplicateActorUpdates.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/deduplicateActorUpdates.ts
@@ -39,6 +39,7 @@ export class DeduplicateActorUpdateStep extends AdapterStep {
 			['position', this.resolvePosition(prev.position, next.position)],
 			['targetable', this.resolveValue(prev.targetable, next.targetable)],
 			['attributes', this.resolveAttributes(prev.attributes, next.attributes)],
+			['level', this.resolveValue(prev.level, next.level)],
 		])
 
 		// If nothing has changed, we can noop this entire event

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -414,6 +414,20 @@ export class TranslateAdapterStep extends AdapterStep {
 		}
 
 		const ourEvents = new Array<Events['actorUpdate'] | Events['statusApply']>()
+
+		if (event.level != null) {
+			ourEvents.push({
+				...this.adaptBaseFields(event),
+				type: 'actorUpdate',
+				level: event.level,
+				actor: resolveActorId({
+					id: event.sourceID,
+					instance: event.sourceInstance,
+					actor: event.source,
+				}),
+			})
+		}
+
 		// "Auras" seems to be a holdover from WoW, but over here they mainly cover Stances;
 		// Tank Stance (Grit, etc), as well as the BLU mimickries.
 		// The minimum thing we can do here is just report these as a statusApply at the


### PR DESCRIPTION
Draft PR for initial interface and criticism.  At a minimum, I want to clean up the About.tsx file further before this merges this way (and it looks like I may need to touch up the unit tests for the ActorUpdate synths as well)