### PR TITLE
DO NOT MERGE: Emergency revert for icon update.

### DIFF
--- a/src/data/icon.ts
+++ b/src/data/icon.ts
@@ -1,5 +1,4 @@
 export function iconUrl(icon: number): string {
 	const group = Math.floor(icon / 1000) * 1000
-	const gamePath = `ui/icon/${group.toString(10).padStart(6, '0')}/${icon.toString(10).padStart(6, '0')}_hr1.tex`
-	return `https://beta.xivapi.com/api/1/asset/${gamePath}?format=png`
+	return `https://xivapi.com/i/${group.toString(10).padStart(6, '0')}/${icon.toString(10).padStart(6, '0')}.png`
 }


### PR DESCRIPTION
This will update the icon utility to redirect icons back to the old xivapi static endpoint.

Please do _not_ merge this unless required. cc @supamiu, drop a line here, on discord, or anywhere if server isn't coping and this needs to be rolled back.