### PR TITLE
Fixed the Endwalker launch dates for Korea/China that got mixed up in the flattening

### DIFF
--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -49,8 +49,8 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 	'Endwalker': {
 		date: {
 			[GameEdition.GLOBAL]: 1637312400, // 19/11/21 09:00:00 GMT
-			[GameEdition.KOREAN]: 1664870400, // 04/10/22 08:00:00 GMT
-			[GameEdition.CHINESE]: 1660032000, // 09/08/22 08:00:00 GMT
+			[GameEdition.KOREAN]: 1652169600, // 10/05/22 08:00:00 GMT
+			[GameEdition.CHINESE]: 1647417600, // 16/03/22 08:00:00 GMT
 		},
 		branch: {
 			baseUrl: 'https://endwalker.xivanalysis.com',


### PR DESCRIPTION
Smol PR to fix the EW launch dates for Korea and China, because we used the 6.1 ones in [this PR](https://github.com/xivanalysis/xivanalysis/pull/1945/files#diff-8059e0020f1bd7222e8e5fa045e2682ba95eceecf9e42e2f8ff5d3ec10df02a6) instead of 6.08.