### PR TITLE
Improve error message when an unknown node is encountered in module dependency graph

### DIFF
--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -119,15 +119,16 @@ class Parser {
 		try {
 			this.executionOrder = toposort.array(nodes, edges).reverse()
 		} catch (error) {
-			// If we get an unknown node error; Work out _what_ nodes are unkown so the error is a bit more meaningful.
-			if (error instanceof Error && error.message.includes('unknown node')) {
-				const nodeSet = new Set(nodes)
-				const unknown = edges
-					.filter(([_source, target]) => !nodeSet.has(target))
-					.map(([source, target]) => `${source}→${target}`)
-				throw new Error(`Unregistered modules in dependency graph: ${unknown.join(', ')}`)
+			if (!(error instanceof Error) || !error.message.includes('unknown node')) {
+				throw error
 			}
-			throw error
+
+			// If we get an unknown node error; Work out _what_ nodes are unknown so the error is a bit more meaningful.
+			const nodeSet = new Set(nodes)
+			const unknown = edges
+				.filter(([_source, target]) => !nodeSet.has(target))
+				.map(([source, target]) => `${source}→${target}`)
+			throw new Error(`Unregistered modules in dependency graph: ${unknown.join(', ')}`)
 		}
 
 		// Initialise the modules


### PR DESCRIPTION
title. error is actually from the lib we use to sort it.

## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/441424599310270464/1258079599523270746

e.g.
![image](https://github.com/xivanalysis/xivanalysis/assets/534235/611776e5-275a-427d-abac-aac377782d0b)
