### PR TITLE
Fix ability items appearing wider than intended on firefox

### DIFF
--- a/src/parser/core/modules/Timeline/config/Item.module.css
+++ b/src/parser/core/modules/Timeline/config/Item.module.css
@@ -1,3 +1,5 @@
+@value defaultRowHeight from '../components/Timeline.module.css';
+
 /* Colours picked to mimic vis for now */
 @value backgroundColour: rgba(213, 221, 246, .4);
 
@@ -10,6 +12,8 @@
 
 .abilityItem > img {
 	max-height: 100%;
+	/* HACK: Firefox@127 does not seem to infer the box model width of images correctly if the height is as we have configured it. Setting an explicit height resolves the issue. */
+	height: defaultRowHeight;
 }
 
 .zeroWidthAbility {

--- a/src/parser/core/modules/Timeline/config/Item.module.css.d.ts
+++ b/src/parser/core/modules/Timeline/config/Item.module.css.d.ts
@@ -4,6 +4,7 @@ declare namespace ItemModuleCssNamespace {
   export interface IItemModuleCss {
     abilityItem: string;
     backgroundColour: string;
+    defaultRowHeight: string;
     zeroWidthAbility: string;
   }
 }


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/608127960142315530/1258908733560324128


## Testing / Validation

before:
![image](https://github.com/xivanalysis/xivanalysis/assets/534235/d07a250f-5417-47b5-9289-3e7a3377c428)
after:
![image](https://github.com/xivanalysis/xivanalysis/assets/534235/918c3957-d4e0-48f9-80f9-eaabfd3a2a4d)
