### PR TITLE
Fixed the Kazematoi gauge

### DIFF
--- a/src/parser/jobs/nin/modules/Kazematoi.tsx
+++ b/src/parser/jobs/nin/modules/Kazematoi.tsx
@@ -1,7 +1,7 @@
 import {t} from '@lingui/macro'
 import {Trans, Plural} from '@lingui/react'
+import Color from 'color'
 import {ActionLink} from 'components/ui/DbLink'
-import {JOBS} from 'data/JOBS'
 import {Event} from 'event'
 import {filter} from 'parser/core/filter'
 import {dependency} from 'parser/core/Injectable'
@@ -12,6 +12,9 @@ import React from 'react'
 const MAX_KAZEMATOI_STACKS = 5
 const ARMOR_CRUSH_MODIFIER = 2
 const AEOLIAN_EDGE_MODIFIER = -1
+
+const FADE_AMOUNT = 0.25
+const GAUGE_COLOR = Color('#8040bf').fade(FADE_AMOUNT)
 
 const OVERCAP_SEVERITY = {
 	// TODO - Confirm what these should be
@@ -31,6 +34,7 @@ const UNBUFFED_SEVERITY = {
 
 // TODO - Implement some bullshit potency tracking logic so we can correct the gauge for multi-boss instances like dungeons and 24-man raids
 export class Kazematoi extends CoreGauge {
+	static override handle = 'kazematoigauge'
 	static override title = t('nin.kazematoi.title')`Kazematoi Gauge`
 
 	@dependency private suggestions!: Suggestions
@@ -38,7 +42,7 @@ export class Kazematoi extends CoreGauge {
 	private kazematoiGauge = this.add(new CounterGauge({
 		graph: {
 			label: <Trans id="nin.kazematoi.resource.label">Kazematoi</Trans>,
-			color: JOBS.NINJA.colour,
+			color: GAUGE_COLOR,
 		},
 		maximum: MAX_KAZEMATOI_STACKS,
 	}))

--- a/src/parser/jobs/nin/modules/Ninki.tsx
+++ b/src/parser/jobs/nin/modules/Ninki.tsx
@@ -1,5 +1,6 @@
 import {t} from '@lingui/macro'
 import {Trans, Plural} from '@lingui/react'
+import Color from 'color'
 import {ActionLink} from 'components/ui/DbLink'
 import {iconUrl} from 'data/icon'
 import {JOBS} from 'data/JOBS'
@@ -28,8 +29,11 @@ const FROG_SEVERITY = {
 }
 
 const ICON_SHUKIHO = 5411
+const FADE_AMOUNT = 0.25
+const GAUGE_COLOR = Color(JOBS.NINJA.colour).fade(FADE_AMOUNT)
 
 export class Ninki extends CoreGauge {
+	static override handle = 'ninkigauge'
 	static override title = t('nin.ninki.title')`Ninki Gauge`
 
 	@dependency private suggestions!: Suggestions
@@ -37,7 +41,7 @@ export class Ninki extends CoreGauge {
 	private ninkiGauge = this.add(new CounterGauge({
 		graph: {
 			label: <Trans id="nin.ninki.resource.label">Ninki</Trans>,
-			color: JOBS.NINJA.colour,
+			color: GAUGE_COLOR,
 		},
 	}))
 


### PR DESCRIPTION
Small PR this time; the Kazematoi gauge wasn't appearing due to a shared handle with the Ninki gauge, so those both have their own explicitly unique ones now. I also updated the colors so they wouldn't be identical, for a clearer visual.
![image](https://github.com/xivanalysis/xivanalysis/assets/7410959/79c5931a-486b-4343-862d-3d8b01c33dde)
