### PR TITLE
Dawntrail - PCT AoEUsage tracking

### DIFF
--- a/src/parser/jobs/pct/changelog.tsx
+++ b/src/parser/jobs/pct/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-07-11'),
+		Changes: () => <>Add checks for using AoE spells with too few targets</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-07-07'),
 		Changes: () => <>Add <DataLink showIcon={false} action="TEMPERA_GRASSA" /> to Defensives tracking and handle cooldown refunding on shield break from it and <DataLink showIcon={false} action="TEMPERA_COAT" />.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/pct/modules/AoEUsages.ts
+++ b/src/parser/jobs/pct/modules/AoEUsages.ts
@@ -1,0 +1,38 @@
+import {AoEUsages as CoreAoE} from 'parser/core/modules/AoEUsages'
+
+export class AoEUsages extends CoreAoE {
+	suggestionIcon = this.data.actions.FOUL.icon
+
+	trackedActions = [
+		{
+			aoeAction: this.data.actions.FIRE_II_IN_RED,
+			stActions: [this.data.actions.FIRE_IN_RED],
+			minTargets: 5,
+		},
+		{
+			aoeAction: this.data.actions.AERO_II_IN_GREEN,
+			stActions: [this.data.actions.AERO_IN_GREEN],
+			minTargets: 5,
+		},
+		{
+			aoeAction: this.data.actions.WATER_II_IN_BLUE,
+			stActions: [this.data.actions.WATER_IN_BLUE],
+			minTargets: 4,
+		},
+		{
+			aoeAction: this.data.actions.BLIZZARD_II_IN_CYAN,
+			stActions: [this.data.actions.BLIZZARD_IN_CYAN],
+			minTargets: 5,
+		},
+		{
+			aoeAction: this.data.actions.STONE_II_IN_YELLOW,
+			stActions: [this.data.actions.STONE_IN_YELLOW],
+			minTargets: 5,
+		},
+		{
+			aoeAction: this.data.actions.THUNDER_II_IN_MAGENTA,
+			stActions: [this.data.actions.THUNDER_IN_MAGENTA],
+			minTargets: 4,
+		},
+	]
+}

--- a/src/parser/jobs/pct/modules/AoEUsages.ts
+++ b/src/parser/jobs/pct/modules/AoEUsages.ts
@@ -1,7 +1,7 @@
 import {AoEUsages as CoreAoE} from 'parser/core/modules/AoEUsages'
 
 export class AoEUsages extends CoreAoE {
-	suggestionIcon = this.data.actions.FOUL.icon
+	suggestionIcon = this.data.actions.THUNDER_II_IN_MAGENTA.icon
 
 	trackedActions = [
 		{

--- a/src/parser/jobs/pct/modules/AoEUsages.ts
+++ b/src/parser/jobs/pct/modules/AoEUsages.ts
@@ -7,12 +7,12 @@ export class AoEUsages extends CoreAoE {
 		{
 			aoeAction: this.data.actions.FIRE_II_IN_RED,
 			stActions: [this.data.actions.FIRE_IN_RED],
-			minTargets: 5,
+			minTargets: 4,
 		},
 		{
 			aoeAction: this.data.actions.AERO_II_IN_GREEN,
 			stActions: [this.data.actions.AERO_IN_GREEN],
-			minTargets: 5,
+			minTargets: 4,
 		},
 		{
 			aoeAction: this.data.actions.WATER_II_IN_BLUE,
@@ -22,12 +22,12 @@ export class AoEUsages extends CoreAoE {
 		{
 			aoeAction: this.data.actions.BLIZZARD_II_IN_CYAN,
 			stActions: [this.data.actions.BLIZZARD_IN_CYAN],
-			minTargets: 5,
+			minTargets: 4,
 		},
 		{
 			aoeAction: this.data.actions.STONE_II_IN_YELLOW,
 			stActions: [this.data.actions.STONE_IN_YELLOW],
-			minTargets: 5,
+			minTargets: 4,
 		},
 		{
 			aoeAction: this.data.actions.THUNDER_II_IN_MAGENTA,

--- a/src/parser/jobs/pct/modules/index.ts
+++ b/src/parser/jobs/pct/modules/index.ts
@@ -1,10 +1,12 @@
 import {Interrupts} from 'parser/core/modules/Interrupts'
 import {Tincture} from 'parser/core/modules/Tincture'
+import {AoEUsages} from './AoEUsages'
 import {CooldownDowntime} from './CooldownDowntime'
 import {Defensives} from './Defensives'
 import {Swiftcast} from './Swiftcast'
 
 export default [
+	AoEUsages,
 	CooldownDowntime,
 	Defensives,
 	Interrupts,


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

PR adds AoEUsage tracking for Pictomancer's additive/subtractive paint combo spells. Launch potencies changed it so all AoE versions are a gain on 4 or more targets.

## Testing / Validation

Pick a dungeon log I guess, avoiding looking at those atm since I'm still working through the MSQ.

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
