### PR TITLE
RDM: add the new 7.0 actions

### DIFF
--- a/src/data/ACTIONS/root/RDM.ts
+++ b/src/data/ACTIONS/root/RDM.ts
@@ -400,4 +400,32 @@ export const RDM = ensureActions({
 		cooldown: 120000,
 		statusesApplied: ['MAGICK_BARRIER'],
 	},
+	JOLT_III: {
+		id: 37004,
+		name: 'Jolt III',
+		icon: iconUrl(3241),
+		onGcd: true,
+		potency: 380,
+		breaksCombo: true,
+	},
+	VICE_OF_THORNS: {
+		id: 37005,
+		name: 'Vice of Thorns',
+		icon: iconUrl(3242),
+		potency: 700,
+	},
+	GRAND_IMPACT: {
+		id: 37006,
+		name: 'Grand Impact',
+		icon: iconUrl(3243),
+		onGcd: true,
+		potency: 600,
+		breaksCombo: true,
+	},
+	PREFULGENCE: {
+		id: 37007,
+		name: 'Prefulgence',
+		icon: iconUrl(3244),
+		potency: 900,
+	},
 })


### PR DESCRIPTION
## Pull request type

- [X] This is new functionality or an addition to existing functionality

## Pull request details

This MR is adding the four new RDM actions added in Dawntrail (`Jolt 3`, `Grand Impact`, `Vice of Thorns`, `Prefulgence`).  It's not changing the existing logic from EW, and it is not adding the related effects (`Thorned Flourish`, `Prefulgence Ready`, `Grand Impact Ready`) -- so this just fixes the timeline & GCD uptime, but does not mean DT RDM is fully supported.

## Testing / Validation

I'm a console player so I can't generate my own logs, but I did test it against this one:
https://www.fflogs.com/reports/6bkZFHrqdJztLYcK#fight=10&type=damage-done

Really, any RDM log from DT will suffice.
