### PR TITLE
fix: change dev server default open URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "webpack serve --hot --mode development --open",
+    "start": "webpack serve --hot --mode development",
     "build": "webpack --mode production",
     "test": "jest",
     "lint": "eslint src",
@@ -140,5 +140,6 @@
     "webpack-cli": "^4.3.1",
     "webpack-dev-server": "^4.0.0-beta.0",
     "webpackbar": "^5.0.0-3"
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -43,6 +43,7 @@ export default (env: Environment, {
 	devServer: {
 		host: 'localhost',
 		port: 3000,
+		open: 'http://localhost:3000',
 		historyApiFallback: true,
 		overlay: true,
 		liveReload: false,
@@ -162,7 +163,7 @@ export default (env: Environment, {
 			// Lingui message files
 			{
 				test: /locale.+\.json$/,
-				resourceQuery: { not: [/raw/] },
+				resourceQuery: {not: [/raw/]},
 				type: 'javascript/auto',
 				use: [
 					{loader: '@lingui/loader'},


### PR DESCRIPTION
## Pull request type

- [X] This is a bugfix to existing functionality

## Pull request details

- [X] This is in response to a discussion or thread on Discord: *[Link to thread or start of discussion]*
https://discord.com/channels/441414116914233364/441424599310270464/1261094757912936478

This changes the startup URL behavior of webpack-dev-server to always open http://localhost:3000 instead of trying the IP address when it launches on IPv6 localhost, to fix the fact that Chrome is a bit stupid about connecting to localhost by IP address instead of by DNS name.
