### PR TITLE
Fix Kunai's Bane windows

### DIFF
--- a/src/parser/core/modules/ActionWindow/windows/BuffWindow.ts
+++ b/src/parser/core/modules/ActionWindow/windows/BuffWindow.ts
@@ -11,11 +11,6 @@ import {ActionWindow} from './ActionWindow'
 
 const SECONDS_TO_MS: number = 1000
 
-// In true XIV fashion, statuses tend to stick around for slightly longer than
-// their specified duration. It's pretty consistently about a second, so we're
-// adding that as a fudge.
-const STATUS_DURATION_FUDGE = SECONDS_TO_MS
-
 /**
  * STRICT:
  *   The default. Events that occur on the same timestamp
@@ -38,6 +33,13 @@ export abstract class BuffWindow extends ActionWindow {
 	 * The status that the buff window tracks.
 	 */
 	abstract buffStatus: Status | Status[]
+
+	/**
+	 * In true XIV fashion, statuses tend to stick around for slightly longer than their specified duration.
+	 * It's pretty consistently about a second, so we're adding that as the default fudge, with the ability
+	 * for implementing modules to override it as needed.
+	 */
+	protected statusDurationFudge: number = SECONDS_TO_MS
 
 	/**
 	 * Determines if a window ended early due to the end of the pull.
@@ -118,7 +120,7 @@ export abstract class BuffWindow extends ActionWindow {
 		if (this.durationHook != null) {
 			this.removeTimestampHook(this.durationHook)
 		}
-		this.durationHook = this.addTimestampHook(timestamp + this.buffDuration + STATUS_DURATION_FUDGE,
+		this.durationHook = this.addTimestampHook(timestamp + this.buffDuration + this.statusDurationFudge,
 			this.endWindowByTime)
 	}
 

--- a/src/parser/jobs/nin/changelog.tsx
+++ b/src/parser/jobs/nin/changelog.tsx
@@ -17,4 +17,9 @@ export const changelog = [
 		Changes: () => <>Updated Kazematoi suggestion tiers.</>,
 		contributors: [CONTRIBUTORS.TOASTDEIB],
 	},
+	{
+		date: new Date('2024-07-12'),
+		Changes: () => <>Fixed a bug with Kunai's Bane not always registering the last attack in a window.</>,
+		contributors: [CONTRIBUTORS.TOASTDEIB],
+	},
 ]

--- a/src/parser/jobs/nin/modules/KunaisBaneWindow.tsx
+++ b/src/parser/jobs/nin/modules/KunaisBaneWindow.tsx
@@ -15,6 +15,8 @@ const BASE_GCDS_PER_WINDOW = 7
 // For opener detection - first Kunai's Bane should be 8-9s into the fight, with a bit of wiggle room for late starts
 const FIRST_KUNAIS_BANE_BUFFER = 12000
 
+const FUDGE_FACTOR_MS = 1500
+
 const MUDRAS: ActionKey[] = [
 	'TEN',
 	'TEN_KASSATSU',
@@ -55,6 +57,7 @@ export class KunaisBaneWindow extends BuffWindow {
 	@dependency globalCooldown!: GlobalCooldown
 
 	override buffStatus = this.data.statuses.KUNAIS_BANE
+	override statusDurationFudge = FUDGE_FACTOR_MS
 
 	override initialise() {
 		super.initialise()


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1261479643907887145
- [ ] The goal of this PR is detailed below:

A bug was surfaced in which Kunai's Bane windows were sometimes failing to include the last attack because the buff duration in game (~16.25s) is longer than the fudge factor allows (15+1s). The fix in this PR makes the fudge factor in the core `BuffWindow` module an overridable property with a default of 1s (so as to maintain the status quo elsewhere), allowing implementing modules to extended (or shorten) it as needed, and then implements an override of 1.5s in the Kunai's Bane module.

## Testing / Validation

- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:

 * **SPOILER WARNING FOR REVIEWERS, THIS LOG IS FROM EX2**: https://www.fflogs.com/reports/MW3nfDgr4YjvkG6K#fight=160&type=summary

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
