### PR TITLE
Dawntrail - SGE supported

### DIFF
--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	// },
 	{
 		date: new Date('2024-07-10'),
+		Changes: () => <>Update Defensives and Tincture tracking, and mark as supported for Dawntrail</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2024-07-10'),
 		Changes: () => <>Exclude Philosophia healing from overheal tracking, similar to Kardia</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},

--- a/src/parser/jobs/sge/index.tsx
+++ b/src/parser/jobs/sge/index.tsx
@@ -17,8 +17,8 @@ export const SAGE = new Meta({
 	Description: () => <TransMarkdown source={description}/>,
 
 	supportedPatches: {
-		from: '✖',
-		to: '✖',
+		from: '7.0',
+		to: '7.0',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sge/modules/Defensives.tsx
+++ b/src/parser/jobs/sge/modules/Defensives.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 
 export class Defensives extends CoreDefensives {
 	protected override trackedDefensives = [
+		this.data.actions.PHILOSOPHIA,
 		this.data.actions.PNEUMA,
 		this.data.actions.HOLOS,
 		this.data.actions.PANHAIMA,

--- a/src/parser/jobs/sge/modules/Tincture.tsx
+++ b/src/parser/jobs/sge/modules/Tincture.tsx
@@ -22,6 +22,10 @@ export class Tincture extends CoreTincture {
 					action: this.data.actions.EUKRASIAN_DOSIS_III,
 					expectedPerWindow: 1,
 				},
+				{
+					action: this.data.actions.PSYCHE,
+					expectedPerWindow: 1,
+				},
 			],
 			suggestionIcon: this.data.actions.INFUSION_MND.icon,
 			suggestionContent: <Trans id="sge.tincture.suggestions.trackedActions.content">


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

This PR adds a couple overlooked analysis items for Sage, and completes it's readiness for 7.0 support:
- Added Psyche to the list of expected actions for a Tincture window
- Added Philosophia to the list of tracked Defensive actions

- [x] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix: http://localhost:3000/fflogs/VCXanHx8B2FGzm1d/4/3

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
