### PR TITLE
RDM: Magic finishers under Magicked Swordplay are fine

### DIFF
--- a/src/parser/jobs/rdm/modules/MagickedSwordplay.tsx
+++ b/src/parser/jobs/rdm/modules/MagickedSwordplay.tsx
@@ -80,6 +80,12 @@ export class MagickedSwordplay extends BuffWindow {
 					this.data.actions.ENCHANTED_MOULINET.id,
 					this.data.actions.ENCHANTED_MOULINET_DEUX.id,
 					this.data.actions.ENCHANTED_MOULINET_TROIS.id,
+
+					// Finishers
+					this.data.actions.VERHOLY.id,
+					this.data.actions.VERFLARE.id,
+					this.data.actions.SCORCH.id,
+					this.data.actions.RESOLUTION.id,
 				],
 				globalCooldown: this.globalCooldown,
 				suggestionIcon,


### PR DESCRIPTION
## Pull request type

- [X] This is a bugfix to existing functionality

## Pull request details

- [X] The goal of this PR is detailed below:

Previously we were dinging people for this:

    `Enchanted Riposte`
        => `Enchanted Zwerchau`
            => `Enchanted Redoublement`
                => `Manafication`
                    => magic finishers
                        => second melee combo

But that's actually a pretty common way to use Manafication, in order to fit two sets of finishers under buffs, or three under pot.

This commir adds the magic finishers to the list of allowed GCDs when the Magicked Swordplay buff is active.

## Testing / Validation

- [X] I used the log(s) listed below to develop and test this bugfix:
https://www.fflogs.com/reports/6YT2JarVHFk8BbDA#fight=22&source=71
(apologies, am a console player, so the logs don't belong to me)

