### PR TITLE
[BugFix] - Correct the single Last Dance allowance calculation

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-07-14'),
+		Changes: () => <>Fix a bug in the logic that allows a single Last Dance if no GCD weaker than Saber Dance is used under Technical Finish</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-07-11'),
 		Changes: () => <>Add expected actions evaluation for Technical Finish windows, warn against using lower potency combo and proc actions, and mark as supported for Dawntrail</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/dnc/modules/Technicalities.tsx
+++ b/src/parser/jobs/dnc/modules/Technicalities.tsx
@@ -174,7 +174,7 @@ export class Technicalities extends RaidBuffWindow {
 
 		// If the window included only the allowed GCDs, they had a lot of Esprit to burn.
 		// Since Saber Dance has the same potency, we can allow them to only hit one Last Dance
-		if (window.data.filter(event => this.allowedTechnicalGcdIds.includes(event.action.id)).length === window.data.length) {
+		if (window.data.filter(event => event.action.onGcd).every(event => this.allowedTechnicalGcdIds.includes(event.action.id))) {
 			return -1
 		}
 


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1262148789226176573

Technical Finish's expected GCDs evaluator expects 2 Last Dances by default, but is supposed to allow a single one, if the player had a lot of Esprit to dump and didn't use any GCD weaker than Saber Dance (ie, combos or procs). Like a numpty, I forgot to narrow the actions in the window to only things on the GCD when doing that check...

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix: http://localhost:3000/fflogs/CcazBW86Vt4K3yqY/5/8

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
