### PR TITLE
Patch 7.01 - Definition and bump for unchanged/previously supported jobs

### DIFF
--- a/src/data/ACTIONS/layers/index.ts
+++ b/src/data/ACTIONS/layers/index.ts
@@ -1,8 +1,10 @@
 import {Layer} from 'data/layer'
 import {ActionRoot} from '../root'
+import {patch701} from './patch7.01'
 
 export const layers: Array<Layer<ActionRoot>> = [
 	// Layers should be in their own files, and imported for use here.
 	// Example layer:
 	// {patch: '5.05', data: {ATTACK: {id: 9001}}},
+	patch701,
 ]

--- a/src/data/ACTIONS/layers/patch7.01.ts
+++ b/src/data/ACTIONS/layers/patch7.01.ts
@@ -1,0 +1,9 @@
+import {Layer} from 'data/layer'
+import {ActionRoot} from '../root'
+
+export const patch701: Layer<ActionRoot> = {
+	patch: '7.01',
+	data: {
+		// Patch 7.01 actions
+	},
+}

--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -61,6 +61,11 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 			[GameEdition.GLOBAL]: 1719565200, // 28/06/24 09:00:00 GMT
 		},
 	},
+	'7.01': {
+		date: {
+			[GameEdition.GLOBAL]: 1721113200, // 16/07/24 07:00:00 GMT
+		},
+	},
 })
 
 export type PatchNumber = keyof typeof PATCHES

--- a/src/data/STATUSES/layers/index.ts
+++ b/src/data/STATUSES/layers/index.ts
@@ -1,8 +1,10 @@
 import {Layer} from 'data/layer'
 import {StatusRoot} from '../root'
+import {patch701} from './patch7.01'
 
 export const layers: Array<Layer<StatusRoot>> = [
 	// Layers should be in their own files, and imported for use here.
 	// Example layer:
 	// {patch: '5.05', data: {BIO_II: {id: 9001}}}}
+	patch701,
 ]

--- a/src/data/STATUSES/layers/patch7.01.ts
+++ b/src/data/STATUSES/layers/patch7.01.ts
@@ -1,0 +1,9 @@
+import {Layer} from 'data/layer'
+import {StatusRoot} from '../root'
+
+export const patch701: Layer<StatusRoot> = {
+	patch: '7.01',
+	data: {
+		// Patch 7.01 statuses
+	},
+}

--- a/src/parser/core/index.tsx
+++ b/src/parser/core/index.tsx
@@ -15,7 +15,7 @@ export const CORE = new Meta({
 	// Read `docs/patch-checklist.md` before editing the following values.
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 })
 

--- a/src/parser/jobs/dnc/index.tsx
+++ b/src/parser/jobs/dnc/index.tsx
@@ -25,7 +25,7 @@ export const DANCER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -16,7 +16,7 @@ export const DRAGOON = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -20,7 +20,7 @@ export const DARK_KNIGHT = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -20,7 +20,7 @@ export const GUNBREAKER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/mch/index.tsx
+++ b/src/parser/jobs/mch/index.tsx
@@ -25,7 +25,7 @@ export const MACHINIST = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/nin/index.tsx
+++ b/src/parser/jobs/nin/index.tsx
@@ -17,7 +17,7 @@ export const NINJA = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sge/index.tsx
+++ b/src/parser/jobs/sge/index.tsx
@@ -18,7 +18,7 @@ export const SAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -22,7 +22,7 @@ export const SUMMONER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/vpr/index.tsx
+++ b/src/parser/jobs/vpr/index.tsx
@@ -18,7 +18,7 @@ export const VIPER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

- [x] The job(s) in this patch bump had no changes for this patch

- Added patch definition and layer files for 7.01.
- Reviewed logs of each of the normal mode fights, no weird invuln stuff to account for
- ran yarn generate, no new UTA statuses this time
- Saving job maintaners/reviewers some time while we're busy with new expac work by pre-emptively marking the jobs that had support for 7.0 and had no notable changes as also supported for 7.01

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
