### PR TITLE
Fix DRK tinctures to show Delirium actions used in window

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -515,6 +515,7 @@
   "drk.saltanddarkness.title": "",
   "drk.saltanddarkness.unused.content": "",
   "drk.saltanddarkness.unused.why": "",
+  "drk.tincture.description": "",
   "game.job.astrologian": "Astrologe",
   "game.job.bard": "Barde",
   "game.job.black-mage": "Schwarzmagier",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -515,6 +515,7 @@
   "drk.saltanddarkness.title": "Salt And Darkness",
   "drk.saltanddarkness.unused.content": "Use <0/> every time you use <1/> in order to do additional damage to enemies inside the <2/> area of effect.",
   "drk.saltanddarkness.unused.why": "You did not use <0/> after <1/> {unused, plural, one {# time} other {# times}}.",
+  "drk.tincture.description": "While you can use <0/> either before or during your potion window, you should be sure to fit all three <1/> enhanced skills within the potion window.",
   "game.job.astrologian": "Astrologian",
   "game.job.bard": "Bard",
   "game.job.black-mage": "Black Mage",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -515,6 +515,7 @@
   "drk.saltanddarkness.title": "Sel et Ténèbres",
   "drk.saltanddarkness.unused.content": "Utilisez <0/> chaque fois que vous utilisez <1/> dans le but de faire des dégâts supplémentaires aux ennemis à l'intérieur de la zone <2/>.",
   "drk.saltanddarkness.unused.why": "Vous n'avez pas utilisé <0/> après <1/> {unused} fois.",
+  "drk.tincture.description": "",
   "game.job.astrologian": "Astromancien",
   "game.job.bard": "Barde",
   "game.job.black-mage": "Mage noir",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -515,6 +515,7 @@
   "drk.saltanddarkness.title": "ソルト・アンド・ダーク",
   "drk.saltanddarkness.unused.content": "<1/>を使用するたびに<0/>を使用して、<2/>の効果範囲内の敵に追加ダメージを与えます。",
   "drk.saltanddarkness.unused.why": "",
+  "drk.tincture.description": "",
   "game.job.astrologian": "占星術師",
   "game.job.bard": "吟遊詩人",
   "game.job.black-mage": "黒魔導士",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -515,6 +515,7 @@
   "drk.saltanddarkness.title": "어둠 감염",
   "drk.saltanddarkness.unused.content": "<1/> 기술을 사용할 때마다 <0/> 기술을 사용하여 <2/> 구역 내의 적에게 추가 피해를 입히십시오.",
   "drk.saltanddarkness.unused.why": "<1/> 기술을 사용한 후 <0/> 기술을 {unused, plural, other {#회}} 사용하지 않았습니다.",
+  "drk.tincture.description": "",
   "game.job.astrologian": "점성술사",
   "game.job.bard": "음유시인",
   "game.job.black-mage": "흑마도사",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -515,6 +515,7 @@
   "drk.saltanddarkness.title": "腐秽黑暗",
   "drk.saltanddarkness.unused.content": "每次使用<1/>后都要使用<0/>，以对<2/>范围内的敌人造成额外伤害。",
   "drk.saltanddarkness.unused.why": "你有 {unused} 次没有在<1/>后使用<0/>。",
+  "drk.tincture.description": "",
   "game.job.astrologian": "占星术士",
   "game.job.bard": "吟游诗人",
   "game.job.black-mage": "黑魔法师",

--- a/src/parser/core/modules/ActionWindow/evaluators/ExpectedActionGroupsEvaluator.tsx
+++ b/src/parser/core/modules/ActionWindow/evaluators/ExpectedActionGroupsEvaluator.tsx
@@ -58,17 +58,20 @@ export class ExpectedActionGroupsEvaluator implements WindowEvaluator {
 
 	public output(windows: Array<HistoryEntry<EvaluatedAction[]>>): EvaluationOutput[]  {
 		return this.expectedActionGroups.map(actionGroup => {
-			const headerActions = actionGroup.actions.map((action, i) => {
-				return <>
-					{ i > 0 && <> / </> }
-					<ActionLink key={i} showName={false} {...action}/>
-				</>
-			})
+			const header = (actionGroup.overrideHeader != null ?
+				<><ActionLink showName={false} {...actionGroup.overrideHeader}/></>
+				: actionGroup.actions.map((action, i) => {
+					return <>
+						{ i > 0 && <> / </> }
+						<ActionLink key={i} showName={false} {...action}/>
+					</>
+				})
+			)
 
 			return {
 				format: 'table',
 				header: {
-					header: <>{headerActions}</>,
+					header: header,
 					accessor: _.first(actionGroup.actions)?.name ?? '',
 				},
 				rows: windows.map(window => {

--- a/src/parser/core/modules/ActionWindow/evaluators/TrackedActionGroup.ts
+++ b/src/parser/core/modules/ActionWindow/evaluators/TrackedActionGroup.ts
@@ -18,6 +18,11 @@ export interface TrackedActionGroup {
 	 * This may be a minimum or maximum depending on the evaluator.
 	 */
 	expectedPerWindow: number
+	/**
+	 * Optional parameter to specify a single action icon to display as the header for this group
+	 * Will override the default behavior of showing all actions in the group separated by "/"
+	 */
+	overrideHeader?: Action
 }
 
 /**

--- a/src/parser/jobs/drk/modules/Tincture.tsx
+++ b/src/parser/jobs/drk/modules/Tincture.tsx
@@ -5,12 +5,18 @@ import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import {Tincture as CoreTincture} from 'parser/core/modules/Tincture'
 import React from 'react'
+import {Message} from 'semantic-ui-react'
 
 const TINCTURE_OPENER_BUFFER = 10000
 const BLOODSPILLER_REQUIREMENT = 2
 const BLOODSPILLER_REQUIREMENT_OPENER = 1
 
 export class Tincture extends CoreTincture {
+	override prependMessages = <Message>
+		<Trans id="drk.tincture.description">
+			While you can use <DataLink action="DELIRIUM" /> either before or during your potion window, you should be sure to fit all three <DataLink action="DELIRIUM" /> enhanced skills within the potion window.
+		</Trans>
+	</Message>
 
 	override initialise() {
 		super.initialise()
@@ -18,8 +24,9 @@ export class Tincture extends CoreTincture {
 		this.addEvaluator(new ExpectedActionGroupsEvaluator({
 			expectedActionGroups: [
 				{
-					actions: [this.data.actions.DELIRIUM],
-					expectedPerWindow: 1,
+					actions: [this.data.actions.SCARLET_DELIRIUM, this.data.actions.COMEUPPANCE, this.data.actions.TORCLEAVER, this.data.actions.IMPALEMENT],
+					expectedPerWindow: 3,
+					overrideHeader: this.data.actions.DELIRIUM,
 				},
 				{
 					actions: [this.data.actions.BLOODSPILLER],


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [ ] This is in response to a discussion or thread on Discord: *[Link to thread or start of discussion]*
- [x] The goal of this PR is detailed below:

I received a report via The Balance that analysis was showing 0/1 uses of Delirium within a Tinctures window and complaining if the player used Delirium pre-potion but then still used all three Delirium enhanced skills inside the window.  This PR adjusts the Tinctures window behavior to count any Delirium enhanced skill and expect 3 of them in total, and adds an optional parameter to a TrackedActionGroup to specify a column override in cases like this combo where having 4 skill icons in the column header would be unreasonably wide.

## Testing / Validation
- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:

https://xivanalysis.com/fflogs/rAX3tk4FMCJQKpRW/19/361

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
