### PR TITLE
Manafication 7.01 update, add RDM combo breakers

### DIFF
--- a/src/data/STATUSES/layers/patch7.01.ts
+++ b/src/data/STATUSES/layers/patch7.01.ts
@@ -11,5 +11,8 @@ export const patch701: Layer<StatusRoot> = {
 			duration: 20000,
 		},
 
+		MANAFICATION: {
+			duration: 30000,
+		},
 	},
 }

--- a/src/parser/core/modules/Combos.tsx
+++ b/src/parser/core/modules/Combos.tsx
@@ -41,7 +41,7 @@ declare module 'event' {
 	}
 }
 
-interface ComboBreak {
+export interface ComboBreak {
 	timestamp: number
 	cause: Cause
 }

--- a/src/parser/jobs/rdm/changelog.tsx
+++ b/src/parser/jobs/rdm/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2024-07-17'),
+		Changes: () => <>Fixed issue with Manafication not breaking melee combos</>,
+		contributors: [CONTRIBUTORS.LEYLIA, CONTRIBUTORS.AZARIAH],
+	},
+	{
 		date: new Date('2024-07-14'),
 		Changes: () => <>Mark Grand Impact as a GCD</>,
 		contributors: [CONTRIBUTORS.HUGMEIR],

--- a/src/parser/jobs/rdm/index.tsx
+++ b/src/parser/jobs/rdm/index.tsx
@@ -15,8 +15,8 @@ export const RED_MAGE = new Meta({
 	</>,
 
 	supportedPatches: {
-		from: '✖',
-		to: '✖',
+		from: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [

--- a/src/parser/jobs/rdm/modules/Combos.tsx
+++ b/src/parser/jobs/rdm/modules/Combos.tsx
@@ -7,6 +7,9 @@ import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 
+/**
+ * Sample log for recording combo breaks with Manafication or channeling a spell: https://www.fflogs.com/reports/7LwvjFPKpCdq4kZG
+ */
 export class Combos extends CoreCombos {
 	// Overrides
 	override suggestionIcon = ACTIONS.ENCHANTED_REDOUBLEMENT.icon

--- a/src/parser/jobs/rdm/modules/Combos.tsx
+++ b/src/parser/jobs/rdm/modules/Combos.tsx
@@ -2,7 +2,7 @@ import {Plural, Trans} from '@lingui/react'
 import ACTIONS from 'data/ACTIONS'
 import {Event, Events} from 'event'
 import {filter} from 'parser/core/filter'
-import {Combos as CoreCombos} from 'parser/core/modules/Combos'
+import {ComboBreak, Combos as CoreCombos} from 'parser/core/modules/Combos'
 import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 import React from 'react'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
@@ -67,7 +67,7 @@ export class Combos extends CoreCombos {
 	}
 
 	//Overrides
-	override addJobSpecificSuggestions(comboBreakers: Array<Events['damage']>, uncomboedGcds: Array<Events['damage']>): boolean {
+	override addJobSpecificSuggestions(comboBreakers: ComboBreak[], uncomboedGcds: ComboBreak[]): boolean {
 		if (comboBreakers.length === 0 && uncomboedGcds.length === 0) {
 			return false
 		}


### PR DESCRIPTION
This PR supersedes #2014 and builds on @Cephid 's work there per feedback in the dev channels.

## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [X] This is a bugfix to existing functionality
- [X] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [ ] This is in response to a discussion or thread on Discord: *[Link to thread or start of discussion]*
- [X] The goal of this PR is detailed below:

In addition to the normal condition of breaking combos on using an instant GCD (which can be caught by the combo module's normal processing of damage events), RDM also breaks combos either when using Manafication (explicitly called out on that skill) or when they start channeling a spell.  This simplifies the handling of combo breakers in core Combos to allow better extensibility, and adds those breakers to RDM

<!-- If this PR is for a patch bump, please complete the section below.  For functionality additions or bug fixes, delete this comment and the section below -->
- [ ] The job(s) in this patch bump had no changes for this patch
- [ ] The job(s) in this patch bump had only potency changes for this patch, which do not effect analysis
  - [ ] I have updated the data files for all potency changes for this patch
  - [ ] The skills and jobs affected by these potency changes do not track potency for xivanaylsis purposes
- [X] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch

## Testing / Validation

<!-- If this PR contains any new functionality or bugfixes, please include log links that reviewers can use to help verify your changes.  Reviewers may also find additional logs to check your PR with, but having initial logs is important to speed the review process, especially for corner cases or hard to trigger analysis flags.  If this PR is a patch bump with no changes or potency only changes, you can delete this section. -->
- [x] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [X] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [ ] I used the log(s) listed below to develop and test this bugfix:

   *[Provide a list of log links - either direct to FFLogs or the xivanalysis log link for development or production]*

## Job Maintenance
- [ ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [X] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
