### PR TITLE
Sam 7.01 patch bump

### DIFF
--- a/src/data/ACTIONS/layers/patch7.01.ts
+++ b/src/data/ACTIONS/layers/patch7.01.ts
@@ -4,6 +4,7 @@ import {ActionRoot} from '../root'
 export const patch701: Layer<ActionRoot> = {
 	patch: '7.01',
 	data: {
-		// Patch 7.01 actions
+		TENDO_SETSUGEKKA: {gcdRecast: 2500},
+		TENDO_GOKEN: {gcdRecast: 2500},
 	},
 }

--- a/src/parser/jobs/sam/changelog.tsx
+++ b/src/parser/jobs/sam/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2024-07-21'),
+		Changes: () => <>7.01 support bump, Tendo recasts adjusted </>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
+	{
 		date: new Date('2024-07-02'),
 		Changes: () => <>Initial 7.0 SAM Support</>,
 		contributors: [CONTRIBUTORS.RYAN],

--- a/src/parser/jobs/sam/index.js
+++ b/src/parser/jobs/sam/index.js
@@ -17,7 +17,7 @@ export const SAMURAI = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.0',
+		to: '7.01',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [x ] This is a patch bump

## Pull request details
- [ x] The goal of this PR is detailed below:

Flag SAM for 7.01 support by adding changes to layer.

<!-- If this PR is for a patch bump, please complete the section below.  For functionality additions or bug fixes, delete this comment and the section below -->
  - [x ] I have updated the data files for all potency changes for this patch
 
## Testing / Validation

  https://www.fflogs.com/reports/yB24mXafWck9HLQ1#fight=1&type=damage-done
  
![image](https://github.com/user-attachments/assets/f3787853-5b14-4894-be7b-cbfc5190e5fc)
cooldowns are now standard GCD length instead of a GCD and a half

## Job Maintenance
- [ x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
