### PR TITLE
[BugFix] BLM - Update Gauge errors header text

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -66,7 +66,7 @@
   "ast.tincture.suggestions.trackedActions.content": "Try to cover as much damage as possible with your Tinctures of Mind.",
   "blm.about.description": "This analyser aims to identify how you're not actually casting <0/> as much as you think you are.",
   "blm.gage.suggestions.overwritten-paradox.why": "<0/> got overwritten {0, plural, one {# time} other {# times}}.",
-  "blm.gauge.error.content": "Reaching Umbral Ice III and gaining 3 Umbral Hearts then swapping to the opposite element generates a <0/> marker.<1/>Using <2/> also generates a <3/> marker.<4/>Maintaining Enochian for 30 seconds or using <5/> generates a Polyglot charge, allowing the casting of <6/> or <7/>. You can have up to 2 Polyglot charges.<8/>This module displays when these gauge effects were overwritten.",
+  "blm.gauge.error.content": "Reaching Umbral Ice III and gaining 3 Umbral Hearts then swapping to the opposite element generates a <0/> marker.<1/>Using <2/> also generates a <3/> marker.<4/>Maintaining Enochian for 30 seconds or using <5/> generates a Polyglot charge, allowing the casting of <6/> or <7/>. You can have up to {POLYGLOT_MAX_STACKS, plural, one {# Polyglot charge} other {# Polyglot charges}}.<8/>This module displays when these gauge effects were overwritten.",
   "blm.gauge.error.paradox": "<0/>",
   "blm.gauge.error.polyglot": "<0/> / <1/>",
   "blm.gauge.error.unknown": "Unknown error",

--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-07-22'),
+		Changes: () => <>Fix some text in the Gauge errors output header to specify the correct maximum number of Polyglot charges.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-07-19'),
 		Changes: () => <>Update suggestion to avoid using <DataLink action="FIRE_I" />, add evaluation for the usage of <DataLink status="FIRESTARTER" />, and mark as supported for Dawntrail.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -677,7 +677,7 @@ export class Gauge extends CoreGauge {
 						Reaching Umbral Ice III and gaining 3 Umbral Hearts then swapping to the opposite element generates a <DataLink action="PARADOX"/> marker.<br/>
 						Using <DataLink action="MANAFONT" /> also generates a <DataLink action="PARADOX" /> marker.<br/>
 						Maintaining Enochian for 30 seconds or using <DataLink action="AMPLIFIER"/> generates a Polyglot charge, allowing
-						the casting of <DataLink action="XENOGLOSSY"/> or <DataLink action="FOUL"/>. You can have up to 2 Polyglot charges.<br/>
+						the casting of <DataLink action="XENOGLOSSY"/> or <DataLink action="FOUL"/>. You can have up to <Plural value={POLYGLOT_MAX_STACKS} one="# Polyglot charge" other="# Polyglot charges"/>.<br/>
 						This module displays when these gauge effects were overwritten.
 					</Trans>
 				</Message>


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1265037981237117111
- [x] The goal of this PR is detailed below:
The header text for the gauge errors output was still referencing 2 polyglot stacks, when this is now 3 in Dawntrail. Switching this to a Plural tag off the value of the constant used in the module, so I don't have to remember to update that text again in the future.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix: https://xivanalysis.com/fflogs/zQYMh9aZfkGJqXTA/49/1

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
