### PR TITLE
[RPR] Bugfix, Soul & Shroud gauge modifiers were incorrect

### DIFF
--- a/src/parser/jobs/rpr/modules/OtherGauges.tsx
+++ b/src/parser/jobs/rpr/modules/OtherGauges.tsx
@@ -21,9 +21,11 @@ const SUGGESTION_TIERS = {
 
 const SHROUD_ACTIONS: ActionKey[] = [
 	'GIBBET',
+	'EXECUTIONERS_GIBBET',
 	'GALLOWS',
+	'EXECUTIONERS_GALLOWS',
 	'GUILLOTINE',
-	'PLENTIFUL_HARVEST',
+	'EXECUTIONERS_GUILLOTINE',
 	'ENSHROUD',
 ]
 
@@ -112,10 +114,6 @@ export class OtherGauges extends CoreGauge {
 		switch (action.id) {
 		case this.data.actions.ENSHROUD.id:
 			this.shroudGauge.spend(HIGH_SHROUD_MOD)
-			break
-
-		case this.data.actions.PLENTIFUL_HARVEST.id:
-			this.shroudGauge.generate(HIGH_SHROUD_MOD)
 			break
 
 		default:

--- a/src/parser/jobs/rpr/modules/OtherGauges.tsx
+++ b/src/parser/jobs/rpr/modules/OtherGauges.tsx
@@ -84,8 +84,6 @@ export class OtherGauges extends CoreGauge {
 		// Soul Gauge
 		const soulActions = Array.from(this.soulGaugeModifiers.keys())
 		this.addEventHook(playerFilter.type(oneOf(['action', 'combo'])).action(oneOf(soulActions)), this.onSoulModifier)
-		this.addEventHook(playerFilter.type('statusApply').status(this.data.statuses.IDEAL_HOST.id), () => this.IsIdealHost = true)
-		this.addEventHook(playerFilter.type('statusRemove').status(this.data.statuses.IDEAL_HOST.id), () => this.IsIdealHost = false)
 		this.addEventHook(foeFilter.type('death'), this.onFoeDeath)
 
 		// Shroud Gauge
@@ -116,7 +114,7 @@ export class OtherGauges extends CoreGauge {
 
 		switch (action.id) {
 		case this.data.actions.ENSHROUD.id:
-			if (this.IsIdealHost === false) { this.shroudGauge.spend(HIGH_SHROUD_MOD) }
+			if (!this.actors.current.hasStatus(this.data.statuses.IDEAL_HOST.id)) { this.shroudGauge.spend(HIGH_SHROUD_MOD) }
 			break
 
 		default:

--- a/src/parser/jobs/rpr/modules/OtherGauges.tsx
+++ b/src/parser/jobs/rpr/modules/OtherGauges.tsx
@@ -41,6 +41,7 @@ export class OtherGauges extends CoreGauge {
 	@dependency private actors!: Actors
 	@dependency private suggestions!: Suggestions
 
+	IsIdealHost = false
 	// Initialise our gauges - default max is 100 so yolo it is
 	private soulGauge = this.add(new CounterGauge({
 		graph: {
@@ -83,6 +84,8 @@ export class OtherGauges extends CoreGauge {
 		// Soul Gauge
 		const soulActions = Array.from(this.soulGaugeModifiers.keys())
 		this.addEventHook(playerFilter.type(oneOf(['action', 'combo'])).action(oneOf(soulActions)), this.onSoulModifier)
+		this.addEventHook(playerFilter.type('statusApply').status(this.data.statuses.IDEAL_HOST.id), () => this.IsIdealHost = true)
+		this.addEventHook(playerFilter.type('statusRemove').status(this.data.statuses.IDEAL_HOST.id), () => this.IsIdealHost = false)
 		this.addEventHook(foeFilter.type('death'), this.onFoeDeath)
 
 		// Shroud Gauge
@@ -113,7 +116,7 @@ export class OtherGauges extends CoreGauge {
 
 		switch (action.id) {
 		case this.data.actions.ENSHROUD.id:
-			this.shroudGauge.spend(HIGH_SHROUD_MOD)
+			if (this.IsIdealHost === false) { this.shroudGauge.spend(HIGH_SHROUD_MOD) }
 			break
 
 		default:


### PR DESCRIPTION
## Pull request type

- [x ] This is a bugfix to existing functionality


## Pull request details

Plentiful harvest no longer generates gauge and has been removed from the gauge modifiers
Added Executioner skills as generators for gauge

## Testing / Validation

- [x ] I used the log(s) listed below to develop and test this bugfix:

Pre-Fix: 
![image](https://github.com/user-attachments/assets/acb1fc06-4487-4655-855a-8d36e5df28d4)

Post-Fix:
![image](https://github.com/user-attachments/assets/57134d10-474a-4d66-af25-8f05e2c06f11)

https://www.fflogs.com/reports/6yNcHD7vhJFdnWPV#fight=16&source=5

## Job Maintenance
- [x ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
