### PR TITLE
DNC - Add Tinctures display

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-07-23'),
+		Changes: () => <>Add an informational Tinctures module.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-07-14'),
 		Changes: () => <>Fix a bug in the logic that allows a single Last Dance if no GCD weaker than Saber Dance is used under Technical Finish</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/dnc/modules/index.ts
+++ b/src/parser/jobs/dnc/modules/index.ts
@@ -1,3 +1,4 @@
+import {Tincture} from 'parser/core/modules/Tincture'
 import {AoEUsages} from './AoEUsages'
 import {Combos} from './Combos'
 import {Defensives} from './Defensives'
@@ -16,4 +17,5 @@ export default [
 	OGCDDowntime,
 	Technicalities,
 	Gauge,
+	Tincture,
 ]


### PR DESCRIPTION
## Pull request type

- [x] This is new functionality or an addition to existing functionality

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1265104489803677786
- [x] The goal of this PR is detailed below:

Add Core Tinctures to the list of modules loaded by DNC, to give an informational display of the actions used under the potion.

## Testing / Validation

- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix: http://localhost:3000/fflogs/VKYC1ZNt3ydvjWbm/39/928

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

