### PR TITLE
Removed the allowed GCDs for MagickedSwordPlay eval

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -825,7 +825,6 @@
   "rdm.meleecombos.table.header.starting-procs": "",
   "rdm.meleecombos.table.header.time": "Zeit",
   "rdm.meleecombos.title": "",
-  "rdm.ms.suggestions.badgcd.content": "",
   "rdm.ms.suggestions.missedgcd.content": "",
   "rdm.ms.title": "",
   "rdm.prefulgence.suggestions.dropped.content": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -825,7 +825,6 @@
   "rdm.meleecombos.table.header.starting-procs": "Starting Procs",
   "rdm.meleecombos.table.header.time": "Time",
   "rdm.meleecombos.title": "Melee Combos",
-  "rdm.ms.suggestions.badgcd.content": "GCDs used during <0/> should be limited to combo skills.",
   "rdm.ms.suggestions.missedgcd.content": "Try to land a full Enchanted Single Target or Enchanted AE combo during every <0/> window.",
   "rdm.ms.title": "Magicked Swordplay Windows",
   "rdm.prefulgence.suggestions.dropped.content": "Try to consume <0/> before it expires as <1/> is your strongest skill.",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -825,7 +825,6 @@
   "rdm.meleecombos.table.header.starting-procs": "Procs de départ",
   "rdm.meleecombos.table.header.time": "Temps",
   "rdm.meleecombos.title": "Combos mélée",
-  "rdm.ms.suggestions.badgcd.content": "",
   "rdm.ms.suggestions.missedgcd.content": "",
   "rdm.ms.title": "",
   "rdm.prefulgence.suggestions.dropped.content": "",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -825,7 +825,6 @@
   "rdm.meleecombos.table.header.starting-procs": "開始時のプロック",
   "rdm.meleecombos.table.header.time": "タイム",
   "rdm.meleecombos.title": "メレーコンボ",
-  "rdm.ms.suggestions.badgcd.content": "",
   "rdm.ms.suggestions.missedgcd.content": "",
   "rdm.ms.title": "",
   "rdm.prefulgence.suggestions.dropped.content": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -825,7 +825,6 @@
   "rdm.meleecombos.table.header.starting-procs": "전투 시작시 프록",
   "rdm.meleecombos.table.header.time": "시간",
   "rdm.meleecombos.title": "근접 콤보",
-  "rdm.ms.suggestions.badgcd.content": "",
   "rdm.ms.suggestions.missedgcd.content": "",
   "rdm.ms.title": "",
   "rdm.prefulgence.suggestions.dropped.content": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -825,7 +825,6 @@
   "rdm.meleecombos.table.header.starting-procs": "初始触发",
   "rdm.meleecombos.table.header.time": "时间",
   "rdm.meleecombos.title": "近战连",
-  "rdm.ms.suggestions.badgcd.content": "",
   "rdm.ms.suggestions.missedgcd.content": "",
   "rdm.ms.title": "",
   "rdm.prefulgence.suggestions.dropped.content": "",

--- a/src/parser/jobs/rdm/modules/MagickedSwordplay.tsx
+++ b/src/parser/jobs/rdm/modules/MagickedSwordplay.tsx
@@ -2,7 +2,7 @@ import {t, Trans} from '@lingui/macro'
 import {StatusLink} from 'components/ui/DbLink'
 import {ActionKey} from 'data/ACTIONS'
 import {dependency} from 'parser/core/Injectable'
-import {AllowedGcdsOnlyEvaluator, BuffWindow, EvaluatedAction, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
+import {BuffWindow, EvaluatedAction, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
 import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
 import {EndOfWindowHandlingMode} from 'parser/core/modules/ActionWindow/windows/BuffWindow'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
@@ -60,37 +60,6 @@ export class MagickedSwordplay extends BuffWindow {
 				suggestionIcon,
 				suggestionContent: <Trans id="rdm.ms.suggestions.missedgcd.content">
 					Try to land a full Enchanted Single Target or Enchanted AE combo during every <StatusLink status="MAGICKED_SWORDPLAY" /> window.
-				</Trans>,
-				suggestionWindowName,
-				severityTiers: {
-					1: SEVERITY.MAJOR,
-				},
-				adjustCount: this.adjustExpectedGcdCount.bind(this),
-			}))
-		this.addEvaluator(
-			new AllowedGcdsOnlyEvaluator({
-				expectedGcdCount: MAGICK_GCDS,
-				allowedGcds: [
-					// Single Target
-					this.data.actions.ENCHANTED_RIPOSTE.id,
-					this.data.actions.ENCHANTED_ZWERCHHAU.id,
-					this.data.actions.ENCHANTED_REDOUBLEMENT.id,
-
-					// AoE
-					this.data.actions.ENCHANTED_MOULINET.id,
-					this.data.actions.ENCHANTED_MOULINET_DEUX.id,
-					this.data.actions.ENCHANTED_MOULINET_TROIS.id,
-
-					// Finishers
-					this.data.actions.VERHOLY.id,
-					this.data.actions.VERFLARE.id,
-					this.data.actions.SCORCH.id,
-					this.data.actions.RESOLUTION.id,
-				],
-				globalCooldown: this.globalCooldown,
-				suggestionIcon,
-				suggestionContent: <Trans id="rdm.ms.suggestions.badgcd.content">
-					GCDs used during <StatusLink status="MAGICKED_SWORDPLAY"/> should be limited to combo skills.
 				</Trans>,
 				suggestionWindowName,
 				severityTiers: {


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [X] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [X] This is in response to a discussion or thread on Discord: *https://discord.com/channels/441414116914233364/470050747720138753/1265041468821602396*
- [X] The goal of this PR is detailed below:

		- This PR just makes a modification to the Magicked Swordplay module to remove the Allowed GCD Evaluator to function similarly to the PCT Hyperphantasia module given it has spawned confusion in people using XIVA for EX-1/2 logs.  This does not however address the 3/2 6/5 tracking that's a result of GCD differences.

- [ ] The job(s) in this patch bump had no changes for this patch
- [ ] The job(s) in this patch bump had only potency changes for this patch, which do not effect analysis
  - [ ] I have updated the data files for all potency changes for this patch
  - [ ] The skills and jobs affected by these potency changes do not track potency for xivanaylsis purposes
- [ ] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch

## Testing / Validation

- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [X] I used the log(s) listed below to develop and test this bugfix:

   I just ran a log through it to ensure everything still ran as normal when I removed the evaluator, the log I used is the one from the Feedback thread that triggered the discussion - https://xivanalysis.com/fflogs/rLVQ4jnpPRBDzkZW/4/8

## Job Maintenance
- [X] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [X] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
