### PR TITLE
[GNB] Gnashing Fang Module BugFix

### DIFF
--- a/src/parser/jobs/gnb/modules/Lionheart.tsx
+++ b/src/parser/jobs/gnb/modules/Lionheart.tsx
@@ -54,6 +54,7 @@ export class Lionheart extends Analyser {
 	override initialise() {
 		super.initialise()
 		const playerFilter = filter<Event>().source(this.parser.actor.id)
+		this.addEventHook(playerFilter.type('action'), this.onCast)
 		this.addEventHook(playerFilter.type('statusApply').status(this.data.statuses.READY_TO_REIGN.id), () => this.ReadyToReigns++)
 		this.addEventHook('complete', this.onComplete)
 	}
@@ -64,7 +65,7 @@ export class Lionheart extends Analyser {
 		if (action) { //If it ain't defined I don't want it
 
 			// If ain't a combo or a breaker IDGAF
-			if (!this.COMBO_ACTIONS.includes(action.id)  || (!this.COMBO_BREAKERS.includes(action.id))) {
+			if (!this.COMBO_ACTIONS.includes(action.id)  && (!this.COMBO_BREAKERS.includes(action.id))) {
 				return
 			}
 


### PR DESCRIPTION
## Pull request type
- [ x] This is a bugfix to existing functionality

## Pull request details

- [x ] The goal of this PR is detailed below:

Fixes a bug that prevented modules from ever having output

This is probably the worst bug I've ever implemented, and I have no idea how it made thru during endwalker.
GnashingFang, formerly known as AmmoCombo never had the event hook set up properly for OnCast.

Furthermore, the OnCast event logic had an OR flag for checking if the event action was not in either COMBO_ACTIONS or COMBO_BREAKERS, and since it would always not be in 1 of those 2 groups, this statement was always true.

This bug was then replicated a 2nd time when copying the module to implement LionHeart.

## Testing / Validation

Took this log: https://www.fflogs.com/reports/jPJc7FXNWntgKbRr#fight=12&source=27 and ran it thru the updated logic

Pre-Fix: 
![image](https://github.com/user-attachments/assets/6df8b38d-66ca-459a-bf78-d6cc70456caa)

Post-Fix:
![image](https://github.com/user-attachments/assets/64c95f0a-746c-4431-8a08-c75a9c4651a0)


## Job Maintenance
- [x ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR