### PR TITLE
feat: adjust pull timestamp to account for events from pre-combat

### DIFF
--- a/src/parser/core/modules/EventsView/EventsView.tsx
+++ b/src/parser/core/modules/EventsView/EventsView.tsx
@@ -94,7 +94,7 @@ function EventItem({data: {events, pull}, index, style}: EventItemProps) {
 
 	const timestamp = formatDuration(
 		event.timestamp - pull.timestamp,
-		{secondPrecision: 3},
+		{secondPrecision: 3, showNegative: true},
 	)
 
 	const formatter = eventFormatters.get(event.type)

--- a/src/report.ts
+++ b/src/report.ts
@@ -53,8 +53,6 @@ export interface Pull {
 	 */
 	id: string
 
-	/** Unix timestamp (ms) of the first event for the pull */
-	firstEvent: number
 	/** Unix timestamp (ms) of the start of combat for the pull. */
 	timestamp: number
 	/** Duration of the pull (ms). */

--- a/src/report.ts
+++ b/src/report.ts
@@ -53,7 +53,9 @@ export interface Pull {
 	 */
 	id: string
 
-	/** Unix timestamp (ms) of the start of the pull. */
+	/** Unix timestamp (ms) of the first event for the pull */
+	firstEvent: number
+	/** Unix timestamp (ms) of the start of combat for the pull. */
 	timestamp: number
 	/** Duration of the pull (ms). */
 	duration: number

--- a/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
+++ b/src/reportSources/legacyFflogs/__tests__/__snapshots__/eventAdapter.ts.snap
@@ -22,7 +22,7 @@ Array [
     "source": "7",
     "status": 1001238,
     "target": "7",
-    "timestamp": 1599999999997,
+    "timestamp": 1599999999200,
     "type": "action",
   },
   Object {
@@ -79,7 +79,7 @@ Array [
     "action": 3554,
     "source": "1",
     "target": "3",
-    "timestamp": 1599999999999,
+    "timestamp": 1599999999400,
     "type": "action",
   },
   Object {
@@ -203,7 +203,7 @@ Array [
     "source": "16",
     "status": 1000727,
     "target": "15",
-    "timestamp": 1599999999997,
+    "timestamp": 1599999999200,
     "type": "action",
   },
   Object {
@@ -211,7 +211,7 @@ Array [
     "source": "20",
     "status": 1001218,
     "target": "15",
-    "timestamp": 1599999999997,
+    "timestamp": 1599999999200,
     "type": "action",
   },
   Object {
@@ -219,7 +219,7 @@ Array [
     "source": "20",
     "status": 1000158,
     "target": "15",
-    "timestamp": 1599999999997,
+    "timestamp": 1599999999200,
     "type": "action",
   },
   Object {
@@ -498,7 +498,7 @@ Array [
     "action": 9899,
     "source": "1957:4",
     "target": "1951",
-    "timestamp": 1599999999999,
+    "timestamp": 1599999999400,
     "type": "action",
   },
   Object {
@@ -608,7 +608,7 @@ Array [
     "source": "1",
     "status": 1001902,
     "target": "1",
-    "timestamp": 1599999999997,
+    "timestamp": 1599999999200,
     "type": "action",
   },
   Object {
@@ -616,7 +616,7 @@ Array [
     "source": "1",
     "status": 1001902,
     "target": "1",
-    "timestamp": 1599999999998,
+    "timestamp": 1599999999300,
     "type": "statusApply",
   },
   Object {
@@ -638,7 +638,7 @@ Array [
     "source": "7",
     "status": 1001238,
     "target": "7",
-    "timestamp": 1599999999997,
+    "timestamp": 1599999999200,
     "type": "action",
   },
   Object {
@@ -660,7 +660,7 @@ Array [
     "source": "9",
     "status": 1001221,
     "target": "2",
-    "timestamp": 1599999999997,
+    "timestamp": 1599999999200,
     "type": "action",
   },
   Object {
@@ -668,7 +668,7 @@ Array [
     "source": "9",
     "status": 1001221,
     "target": "2",
-    "timestamp": 1599999999998,
+    "timestamp": 1599999999300,
     "type": "statusApply",
   },
   Object {

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -28,10 +28,14 @@ const actor: Actor = {
 
 // Semi-arbitrary time during 5.3. Needs to be post-5.08 for code path purposes.
 const timestamp = 1600000000000
+// Set up tests to simulate 500ms worth of prepull events in the parse
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+const firstEvent = timestamp - 500
 
 const pull: Pull = {
 	id: '1',
 	timestamp,
+	firstEvent,
 	duration: 1,
 	encounter: {
 		name: 'test encounter',

--- a/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
+++ b/src/reportSources/legacyFflogs/__tests__/eventAdapter.ts
@@ -35,7 +35,6 @@ const firstEvent = timestamp - 500
 const pull: Pull = {
 	id: '1',
 	timestamp,
-	firstEvent,
 	duration: 1,
 	encounter: {
 		name: 'test encounter',
@@ -894,7 +893,7 @@ describe('Event adapter', () => {
 
 		Object.keys(fakeEvents).forEach(eventType => it(`adapts ${eventType}`, () => {
 			for (const event of fakeEvents[eventType as keyof typeof fakeEvents]) {
-				expect(adaptEvents(report, pull, [event])).toMatchSnapshot()
+				expect(adaptEvents(report, pull, [event], firstEvent)).toMatchSnapshot()
 			}
 		}))
 	})
@@ -918,7 +917,7 @@ describe('Event adapter', () => {
 				sourceID: 1,
 				ability: reassembleAbility,
 			} as CastEvent,
-		])
+		], firstEvent)
 
 		expect(result.map(event => event.type)).toEqual([
 			'action', // action first
@@ -938,7 +937,7 @@ describe('Event adapter', () => {
 
 			{...fakeEvents.begincast[0], ability: interruptedAbility, sourceID: 1, timestamp: 3} as CastEvent,
 			{...fakeEvents.begincast[0], ability: interruptingAbility, sourceID: 1, timestamp: interruptionTimestamp} as CastEvent,
-		])
+		], firstEvent)
 
 		expect(result.map(event => event.type)).toEqual([
 			'actorUpdate', // injected actor update with stats
@@ -964,7 +963,7 @@ describe('Event adapter', () => {
 		const result = adaptEvents(report, pull, [
 			fakeEvents.begincast[0],
 			fakeEvents.calculateddamage[0],
-		])
+		], firstEvent)
 		expect(result.map(event => event.type)).toEqual([
 			'action', // prepull synth
 			'prepare', // begincast
@@ -994,7 +993,7 @@ describe('Event adapter', () => {
 					abilityIcon: '012000-012848.png',
 				},
 			},
-		])
+		], firstEvent)
 		expect(result.map(event => event.type)).toEqual([
 			'action', // prepull synth
 			'prepare', // begincast
@@ -1008,7 +1007,7 @@ describe('Event adapter', () => {
 		const result = adaptEvents(report, pull, [
 			fakeEvents.begincast[0],
 			fakeEvents.removebuff[0],
-		])
+		], firstEvent)
 		expect(result.map(event => event.type)).toEqual([
 			'action', // prepull synth
 			'statusApply', // prepull synth
@@ -1037,7 +1036,7 @@ describe('Event adapter', () => {
 			targetIsFriendly: true,
 			ability: fakeAbility,
 			stack: statusData,
-		}])
+		}], firstEvent)
 
 		expect(result).toHaveLength(1)
 		expect(result[0].type).toBe('statusApply')
@@ -1073,7 +1072,7 @@ describe('Event adapter', () => {
 			targetIsFriendly: true,
 			ability: fakeAbility,
 			stack: 20,
-		}])
+		}], firstEvent)
 
 		expect(result).toHaveLength(2)
 		expect(result[0].type).toBe('statusApply')
@@ -1126,7 +1125,7 @@ describe('Event adapter', () => {
 				x: 150,
 				y: 50,
 			},
-		}])
+		}], firstEvent)
 
 		const updates = result.filter(event => true
 			&& event.type === 'actorUpdate'
@@ -1181,7 +1180,7 @@ describe('Event adapter', () => {
 			timestamp: 300,
 			skillSpeed: 100,
 			spellSpeed: 200,
-		}])
+		}], firstEvent)
 
 		/* eslint-disable @typescript-eslint/no-magic-numbers */
 		expect(result).toEqual([
@@ -1216,7 +1215,7 @@ describe('Event adapter', () => {
 		const result = adaptEvents(report, pull, [
 			fakeEvents.calculatedheal[0],
 			fakeEvents.heal[2],
-		])
+		], firstEvent)
 
 		const heal = result.filter((event): event is Events['heal'] => event.type === 'heal')
 		// eslint-disable-next-line @typescript-eslint/no-magic-numbers
@@ -1226,7 +1225,7 @@ describe('Event adapter', () => {
 	it('marks unmatched heal events as fully overheal', () => {
 		const result = adaptEvents(report, pull, [
 			fakeEvents.calculatedheal[0],
-		])
+		], firstEvent)
 
 		const heal = result.filter((event): event is Events['heal'] => event.type === 'heal')
 		// eslint-disable-next-line @typescript-eslint/no-magic-numbers
@@ -1256,7 +1255,7 @@ describe('Event adapter', () => {
 			},
 		]
 
-		const result = adaptEvents(report, pull, events)
+		const result = adaptEvents(report, pull, events, firstEvent)
 
 		expect(result.map(event => event.type))
 			.toEqual(expect.arrayContaining(['damage', 'execute']))

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -18,14 +18,14 @@ import {SpeedStatsAdapterStep} from './speedStat'
 import {TranslateAdapterStep} from './translate'
 
 /** Adapt an array of FFLogs APIv1 events to xiva representation. */
-export function adaptEvents(report: Report, pull: Pull, baseEvents: FflogsEvent[]): Event[] {
+export function adaptEvents(report: Report, pull: Pull, baseEvents: FflogsEvent[], firstEvent: number): Event[] {
 	const adapter = new EventAdapter({report, pull})
 
 	// Shallow clone to ensure top-level updates will not effect the base array.
 	// Child adapters are responsible for ensuring updates are copy-on-write.
 	const events = [...baseEvents]
 
-	return adapter.adaptEvents(events)
+	return adapter.adaptEvents(events, firstEvent)
 }
 
 class EventAdapter {
@@ -50,7 +50,7 @@ class EventAdapter {
 		]
 	}
 
-	adaptEvents(events: FflogsEvent[]): Event[] {
+	adaptEvents(events: FflogsEvent[], firstEvent: number): Event[] {
 		const adaptedEvents = events.flatMap(baseEvent =>
 			this.adaptionSteps.reduce(
 				(adaptedEvents, step) => {
@@ -68,7 +68,7 @@ class EventAdapter {
 		)
 
 		return this.adaptionSteps.reduce(
-			(processedEvents, step) => step.postprocess(processedEvents),
+			(processedEvents, step) => step.postprocess(processedEvents, firstEvent),
 			adaptedEvents,
 		)
 	}

--- a/src/reportSources/legacyFflogs/eventAdapter/base.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/base.ts
@@ -48,7 +48,7 @@ export abstract class AdapterStep extends Debuggable {
 	 * Perform postprocessing on the final array of adapted events. This will be
 	 * called once after all report source events have been adapted.
 	 */
-	postprocess(adaptedEvents: Event[]): Event[] {
+	postprocess(adaptedEvents: Event[], _firstEvent: number): Event[] {
 		return adaptedEvents
 	}
 }

--- a/src/reportSources/legacyFflogs/eventAdapter/base.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/base.ts
@@ -3,11 +3,12 @@ import {Debuggable} from 'parser/core/Debuggable'
 import {Pull, Report} from 'report'
 import {FflogsEvent} from '../eventTypes'
 
+// Time (in MS) to offset prepull synthesized events from the first event in the pull
 export const PREPULL_OFFSETS = {
-	ATTRIBUTE_UPDATE: -4,
-	STATUS_ACTION: -3,
-	STATUS_APPLY: -2,
-	PULL_ACTION: -1,
+	ATTRIBUTE_UPDATE: -400,
+	STATUS_ACTION: -300,
+	STATUS_APPLY: -200,
+	PULL_ACTION: -100,
 }
 
 // This stuff will probably be moved to a shared location for other sources to use

--- a/src/reportSources/legacyFflogs/eventAdapter/prepullAction.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepullAction.ts
@@ -14,7 +14,7 @@ export class PrepullActionAdapterStep extends AdapterStep {
 					action: event.cause.action,
 					source: event.source,
 					target: event.targets[0]?.target,
-					timestamp: this.pull.timestamp + PREPULL_OFFSETS.PULL_ACTION,
+					timestamp: this.pull.firstEvent + PREPULL_OFFSETS.PULL_ACTION,
 				})
 			} else if (event.type === 'action') {
 				// Stop once we hit the first real action event post-pull

--- a/src/reportSources/legacyFflogs/eventAdapter/prepullAction.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepullAction.ts
@@ -2,7 +2,7 @@ import {Event} from 'event'
 import {AdapterStep, PREPULL_OFFSETS} from './base'
 
 export class PrepullActionAdapterStep extends AdapterStep {
-	override postprocess(adaptedEvents: Event[]): Event[] {
+	override postprocess(adaptedEvents: Event[], firstEvent: number): Event[] {
 		const precastEvents: Event[] = []
 
 		for (const event of adaptedEvents) {
@@ -14,7 +14,7 @@ export class PrepullActionAdapterStep extends AdapterStep {
 					action: event.cause.action,
 					source: event.source,
 					target: event.targets[0]?.target,
-					timestamp: this.pull.firstEvent + PREPULL_OFFSETS.PULL_ACTION,
+					timestamp: firstEvent + PREPULL_OFFSETS.PULL_ACTION,
 				})
 			} else if (event.type === 'action') {
 				// Stop once we hit the first real action event post-pull

--- a/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
@@ -17,7 +17,7 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 
 	static override debug = false
 
-	override postprocess(adaptedEvents: Event[]): Event[] {
+	override postprocess(adaptedEvents: Event[], firstEvent: number): Event[] {
 		for (const event of adaptedEvents) {
 			if (event.type !== 'statusApply' && event.type !== 'statusRemove') {
 				if (event.type === 'action') {
@@ -34,7 +34,7 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 				}
 
 				this.debug(`Timestamp ${event.timestamp}: Saw first statusApply for status ${event.status} on target ${event.target}`)
-				this.synthesizeActionIfNew(event)
+				this.synthesizeActionIfNew(event, firstEvent)
 
 				// If the first observed instance of a status that is applied
 				// with stacks has fewer than the applied value, synth an apply
@@ -42,7 +42,7 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 				const applied = getDataBy(getStatuses(this.report), 'id', event.status)
 				if (applied != null && applied.stacksApplied != null && applied.stacksApplied > 0 &&
 					event.data != null && event.data < applied.stacksApplied) {
-					this.synthesizeStatusApply(event, applied.stacksApplied)
+					this.synthesizeStatusApply(event, firstEvent, applied.stacksApplied)
 				}
 
 				this.observeStatus(event.status, event.target)
@@ -53,8 +53,8 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 					// If we've already seen a matching apply event, skip
 					continue
 				}
-				this.synthesizeActionIfNew(event)
-				this.synthesizeStatusApply(event)
+				this.synthesizeActionIfNew(event, firstEvent)
+				this.synthesizeStatusApply(event, firstEvent)
 				this.observeStatus(event.status, event.target)
 			}
 		}
@@ -82,7 +82,7 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 		statuses.add(statusId)
 	}
 
-	private synthesizeActionIfNew(event: StatusEvent) {
+	private synthesizeActionIfNew(event: StatusEvent, firstEvent: number) {
 		const statusKey = _.findKey(getStatuses(this.report), status => status.id === event.status) as StatusKey | undefined
 		if (!statusKey) {
 			// This shouldn't be possible, but let's be safe and bail if there's no key
@@ -110,18 +110,18 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 			...event,
 			type: 'action',
 			action: action.id,
-			timestamp: this.pull.firstEvent + PREPULL_OFFSETS.STATUS_ACTION,
+			timestamp: firstEvent + PREPULL_OFFSETS.STATUS_ACTION,
 		}
 
 		this.precastEvents.push(actionEvent)
 		this.observeAction(action.id, event.source)
 	}
 
-	private synthesizeStatusApply(event: StatusEvent, stacks?: number) {
+	private synthesizeStatusApply(event: StatusEvent, firstEvent: number, stacks?: number) {
 		const applyEvent: Events['statusApply'] = {
 			...event,
 			type: 'statusApply',
-			timestamp: this.pull.firstEvent + PREPULL_OFFSETS.STATUS_APPLY,
+			timestamp: firstEvent + PREPULL_OFFSETS.STATUS_APPLY,
 		}
 		if (stacks != null) {
 			applyEvent.data = stacks

--- a/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/prepullStatus.ts
@@ -110,7 +110,7 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 			...event,
 			type: 'action',
 			action: action.id,
-			timestamp: this.pull.timestamp + PREPULL_OFFSETS.STATUS_ACTION,
+			timestamp: this.pull.firstEvent + PREPULL_OFFSETS.STATUS_ACTION,
 		}
 
 		this.precastEvents.push(actionEvent)
@@ -121,7 +121,7 @@ export class PrepullStatusAdapterStep extends AdapterStep {
 		const applyEvent: Events['statusApply'] = {
 			...event,
 			type: 'statusApply',
-			timestamp: this.pull.timestamp + PREPULL_OFFSETS.STATUS_APPLY,
+			timestamp: this.pull.firstEvent + PREPULL_OFFSETS.STATUS_APPLY,
 		}
 		if (stacks != null) {
 			applyEvent.data = stacks

--- a/src/reportSources/legacyFflogs/eventAdapter/speedStat.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/speedStat.ts
@@ -230,7 +230,7 @@ export class SpeedStatsAdapterStep extends AdapterStep {
 			return {
 				type: 'actorUpdate',
 				actor: actorId,
-				timestamp: this.pull.timestamp + PREPULL_OFFSETS.ATTRIBUTE_UPDATE,
+				timestamp: this.pull.firstEvent + PREPULL_OFFSETS.ATTRIBUTE_UPDATE,
 				attributes,
 			}
 		}

--- a/src/reportSources/legacyFflogs/eventAdapter/speedStat.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/speedStat.ts
@@ -60,7 +60,7 @@ export class SpeedStatsAdapterStep extends AdapterStep {
 		return adaptedEvents
 	}
 
-	override postprocess(adaptedEvents: Event[]): Event[] {
+	override postprocess(adaptedEvents: Event[], firstEvent: number): Event[] {
 		adaptedEvents.forEach((event) => {
 			if (
 				!('source' in event)
@@ -84,7 +84,7 @@ export class SpeedStatsAdapterStep extends AdapterStep {
 
 		const eventsToAdd: Array<Events['actorUpdate']> = []
 		this.actorActions.forEach((gcds, actorId) => {
-			const speedStatUpdate = this.estimateActorSpeedStat(gcds, actorId)
+			const speedStatUpdate = this.estimateActorSpeedStat(gcds, actorId, firstEvent)
 			if (speedStatUpdate != null) { eventsToAdd.push(speedStatUpdate) }
 		})
 
@@ -173,7 +173,7 @@ export class SpeedStatsAdapterStep extends AdapterStep {
 		windowMap[windowMap.length-1].end = event.timestamp
 	}
 
-	private estimateActorSpeedStat(gcds: GCD[], actorId: string): Events['actorUpdate'] | undefined {
+	private estimateActorSpeedStat(gcds: GCD[], actorId: string, firstEvent: number): Events['actorUpdate'] | undefined {
 		const speedAttributeKeys = [Attribute.SKILL_SPEED, Attribute.SPELL_SPEED] as const
 		const intervals: Record<Attribute, number[]> = {
 			[Attribute.SKILL_SPEED]: [],
@@ -230,7 +230,7 @@ export class SpeedStatsAdapterStep extends AdapterStep {
 			return {
 				type: 'actorUpdate',
 				actor: actorId,
-				timestamp: this.pull.firstEvent + PREPULL_OFFSETS.ATTRIBUTE_UPDATE,
+				timestamp: firstEvent + PREPULL_OFFSETS.ATTRIBUTE_UPDATE,
 				attributes,
 			}
 		}

--- a/src/reportSources/legacyFflogs/eventTypes.ts
+++ b/src/reportSources/legacyFflogs/eventTypes.ts
@@ -21,6 +21,7 @@ export interface Fight {
 
 	start_time: number
 	end_time: number
+	combatTime: number
 }
 
 export interface Phase {

--- a/src/reportSources/legacyFflogs/reportAdapter.ts
+++ b/src/reportSources/legacyFflogs/reportAdapter.ts
@@ -140,7 +140,6 @@ const convertFight = (
 ): Pull => ({
 	id: fight.id.toString(),
 
-	firstEvent: report.start + fight.start_time,
 	timestamp: report.start + fight.end_time - fight.combatTime,
 	duration: fight.combatTime,
 	progress: getFightProgress(fight),

--- a/src/reportSources/legacyFflogs/reportAdapter.ts
+++ b/src/reportSources/legacyFflogs/reportAdapter.ts
@@ -140,8 +140,9 @@ const convertFight = (
 ): Pull => ({
 	id: fight.id.toString(),
 
-	timestamp: report.start + fight.start_time,
-	duration: fight.end_time - fight.start_time,
+	firstEvent: report.start + fight.start_time,
+	timestamp: report.start + fight.end_time - fight.combatTime,
+	duration: fight.combatTime,
 	progress: getFightProgress(fight),
 
 	encounter: {

--- a/src/reportSources/legacyFflogs/store.ts
+++ b/src/reportSources/legacyFflogs/store.ts
@@ -69,7 +69,7 @@ export class LegacyFflogsReportStore extends ReportStore {
 			legacyFight,
 		)
 
-		return adaptEvents(report, pull, legacyEvents)
+		return adaptEvents(report, pull, legacyEvents, legacyFight.start_time)
 	}
 
 	override getReportLink(pullId?: Pull['id'], actorId?: Actor['id']) {


### PR DESCRIPTION
## Pull request type

- [x] This is new functionality or an addition to existing functionality
- [ ] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/441414116914233366/1266513815143583908
- [x] The goal of this PR is detailed below:

Since FFLogs has refined their rules for determining start of combat and started including some pre-pull events in their timeline with a negative relative timestamp, our timeline and the relative times we show in most areas in the analysis are now out of sync with the relative timestamps in the FFLogs timeline.  This adjusts that handling accordingly.

- Adjusts our prepull synth offsets to be based on the first event in the timeline, not the start of combat
- Adjusts our "timestamp" value to match the start of combat
- Adjusts the debug Event Viewer to show negative timestamps

## Testing / Validation

<!-- If this PR contains any new functionality or bugfixes, please include log links that reviewers can use to help verify your changes.  Reviewers may also find additional logs to check your PR with, but having initial logs is important to speed the review process, especially for corner cases or hard to trigger analysis flags.  If this PR is a patch bump with no changes or potency only changes, you can delete this section. -->
- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:

https://www.fflogs.com/reports/VNJxHbhMFkaPptXB#fight=10

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
