### PR TITLE
[Core] [RPR] Draft Implement considerEvent for OnProcGained to handle a Reaper Bug

### DIFF
--- a/src/parser/core/modules/Procs.tsx
+++ b/src/parser/core/modules/Procs.tsx
@@ -322,6 +322,13 @@ export abstract class Procs extends Analyser {
 		return false
 	}
 
+	/**
+	 * May be overriden by Subclasses. Called by OnProcGained to allow jobs to implment job-specific logic for evaluting a proc when it is gained
+	 * @param event The event to check
+	 * @returns False by default. Jobs may override to return true, allowing them to implement job-specific logic to consider an event
+	 */
+	protected jobSpecificOnProcGainedConsiderEvent(_event: Events['statusApply']): boolean { return true }
+
 	private onCast(event: Events['action']): void {
 		const procGroups = this.getTrackedGroupsByAction(event.action)
 
@@ -345,6 +352,7 @@ export abstract class Procs extends Analyser {
 	private onProcGained(event: Events['statusApply']): void {
 		const procGroup = this.getTrackedGroupByStatus(event.status)
 
+		if (!this.jobSpecificOnProcGainedConsiderEvent(event)) { return }
 		if (procGroup == null) { return }
 
 		if (this.currentWindows.has(procGroup)) {


### PR DESCRIPTION
## Pull request type

- [ x] This is new functionality or an addition to existing functionality
- [x ] This is a bugfix to existing functionality

## Pull request details
- [x ] This is in response to a discussion or thread on Discord:  https://discord.com/channels/441414116914233364/470050640005955605/1266818820568518767
- [ ] The goal of this PR is detailed below:

Adds a new ConsiderEvent function that is called during onProcGained for Core Procs in order to handle a bug for Reaper where the buff is applied and refreshed with a single cast for Executioners Gallow.

Jobs can override this function to implement logic to ignore events for onProcGained Processing.

## Testing / Validation
- [x ] I used the log(s) listed below to develop and test this bugfix:

http://localhost:3000/fflogs/6yNcHD7vhJFdnWPV/16/5
http://localhost:3000/fflogs/2zgkpKjYnNZF19Py/1/2

## Job Maintenance
- [x ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

