### PR TITLE
[DRG] Enable suggestion output for procs

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -489,6 +489,7 @@
   "drg.lotd.suggestions.missedaction.content": "",
   "drg.lotd.suggestions.missedgcd.content": "",
   "drg.lotd.suggestions.window-name": "Drachengeist",
+  "drg.procs.suggestions.dropped.content": "",
   "drk.about.description": "<0>Dieses Modul versucht dir dabei zu helfen, deine innere Schattenseite zu finden. Der Kern von der Offensive eines Dunkelritters liegt auf der Maximierung von MP- und Blutbalkenmanagement, wenn möglich in Raidbuff-Fenstern. Dazu solltest du versuchen, jeweils fünf Treffer in jedem Blutwaffen- und Blutdeliriumfenster unterzubekommen.</0><1> Defensiv ist <2/> ein sehr starker Skill, der eingehenden Schaden entweder auf dir selbst oder auf einem Gruppenmitglied negieren kann, und dabei noch einen freien Nutzen von Schattenflut oder Schattenklinge ermöglicht, solange das Schild komplett aufgebraucht wird.</1>",
   "drk.bloodweapon.suggestions.missedgcd.content": "Während <0/> aktiv ist, solltest du 5 GCDs landen können und dies auch tunlichst versuchen. Ist das - trotz kompletter Uptime des Spells - nicht möglich ist, passe dein Equipment an um mehr in \"Schnelligkeit\" zu investieren.",
   "drk.bloodweapon.title": "Blutwaffe-Nutzung",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -489,6 +489,7 @@
   "drg.lotd.suggestions.missedaction.content": "Try to use as many of your oGCDs as possible during Life of the Dragon. Remember to keep your abilities on cooldown, when possible, to prevent them from drifting outside of your buff windows.",
   "drg.lotd.suggestions.missedgcd.content": "Try to land at least 8 GCDs during every Life of the Dragon window.",
   "drg.lotd.suggestions.window-name": "Life of the Dragon",
+  "drg.procs.suggestions.dropped.content": "Avoid lettings your procs fall off without using them, ideally while buffed. This might not always be possible, so remember to at least use your procs before they fall off.",
   "drk.about.description": "<0>This analyzer aims to help you unleash your inner edge. The core of Dark Knight offense focuses on maximizing blood and MP utilization, in raid buff windows where available. In addition, you should aim to land five hits in each Blood Weapon and Delirium window.</0><1>Defensively, <2/> is a powerful cooldown that can mitigate heavy damage on you or a target, and grants a free use of Edge of Shadow or Flood of Shadow as long as the shield is fully consumed.</1>",
   "drk.bloodweapon.suggestions.missedgcd.content": "Try to land 5 GCDs during every <0/> window.  If you cannot do this with full uptime and no clipping, consider adjusting your gearset for more Skill Speed.",
   "drk.bloodweapon.title": "Blood Weapon Usage",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -489,6 +489,7 @@
   "drg.lotd.suggestions.missedaction.content": "Essayez d'utiliser autant d'oGCD que possible pendant Vie du Dragon. Gardez vos aptitudes en rechargement autant que possible pour éviter de les sortir des fenêtres de buffs.",
   "drg.lotd.suggestions.missedgcd.content": "Essayez de lancer au moins 8 GCDs pendant chaque fenêtre de Vie du Dragon.",
   "drg.lotd.suggestions.window-name": "Vie du Dragon",
+  "drg.procs.suggestions.dropped.content": "",
   "drk.about.description": "<0> Cet analyseur a pour but de vous aider à libérer vos Ténèbres intérieures. Le cœur de l'attaque des Chevaliers noirs se concentre sur l'utilisation maximale du sang et des PM, dans les fenêtres de buff d'équipe où elles sont disponibles. De plus, vous devez viser à obtenir cinq coups dans chaque fenêtre d'Arme de sang et Délirium.</0><1>Défensivement, <2/> est un puissant rechargement qui peut atténuer les dégâts importants sur vous ou une cible, et permet d'utiliser gratuitement Déluge d'ombre ou Tranchant d'ombre une fois que le bouclier est entièrement consommé.</1>",
   "drk.bloodweapon.suggestions.missedgcd.content": "Essayez d'utiliser 5 GCDs à chaque fenêtre d'<0/> . Si vous ne pouvez pas le faire avec 100% d'uptime et sans clipper, pensez à ajuster votre stuff pour y ajouter plus de Vivacité.",
   "drk.bloodweapon.title": "Utilisations d'Arme de sang",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -489,6 +489,7 @@
   "drg.lotd.suggestions.missedaction.content": "",
   "drg.lotd.suggestions.missedgcd.content": "",
   "drg.lotd.suggestions.window-name": "紅の竜血",
+  "drg.procs.suggestions.dropped.content": "",
   "drk.about.description": "<0>このアナライザはあなたの内に眠る刃を開放する手助けをすることを目的としたものです。暗黒騎士に攻撃面で求められる行動は、最大限ブラッドゲージとMPを活用することです。特にレイドにおいてはシナジーの効果時間中にブラッドゲージとMPを使い切るほうがよいでしょう。加えて、ブラッドウェポンとブラッドデリリアムの効果時間中に攻撃を5回当てられるよう意識しましょう。</0><1>防御面においては、<2/>は非常に短いリキャストタイムで使用でき、かつ強力な攻撃を軽減可能なバリアを自分を含めたパーティーメンバー1人に対して付与することが出来ます。また、付与したバリアが効果時間中に消費された場合、漆黒の剣もしくは漆黒の波動を一度だけMP消費なしで撃つことが出来るようになります。</1>",
   "drk.bloodweapon.suggestions.missedgcd.content": "<0/>の効果時間中に5GCDを回すようにしてみましょう。食い込みなしでウェポンスキルを回しても5GCDを達成できない場合は、装備のスキルスピードを見直してみましょう。",
   "drk.bloodweapon.title": "ブラッドウェポンの使用状況",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -489,6 +489,7 @@
   "drg.lotd.suggestions.missedaction.content": "",
   "drg.lotd.suggestions.missedgcd.content": "",
   "drg.lotd.suggestions.window-name": "붉은 용혈",
+  "drg.procs.suggestions.dropped.content": "",
   "drk.about.description": "<0>이 분석기는 당신 내면의 간지를 이끌어내게끔 도와드릴 것입니다. 암흑기사의 핵심은 흑혈과 MP 활용, 그리고 파티 버프 구간 활용입니다. 또한, 피의 열광 및 피의 칼날을 쓸 때마다 글쿨 기술을 최소 5회 사용해야 합니다. </0><1>방어 면에서 <2/> 기술은 본인 또는 파티원을 강한 피해에서 지켜내는 강력한 경감기입니다. 보호막이 완전히 소모되면 칠흑검 및 칠흑의 파동 프록을 MP 소모 없이 사용할 수 있습니다.</1>",
   "drk.bloodweapon.suggestions.missedgcd.content": "매 <0/> 구간마다 글쿨 기술을 5개 사용하십시오. 논글쿨 기술을 과도하게 끼워넣지 않았고 공격을 놓치지 않았는데도 시간이 모자랐다면 장비 또는 마테리아를 조절하여 기술 시전 속도를 높이십시오.",
   "drk.bloodweapon.title": "피의 칼날 사용",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -489,6 +489,7 @@
   "drg.lotd.suggestions.missedaction.content": "",
   "drg.lotd.suggestions.missedgcd.content": "尽可能在红莲龙血期间打出至少8个GCD。",
   "drg.lotd.suggestions.window-name": "红莲龙血",
+  "drg.procs.suggestions.dropped.content": "",
   "drk.about.description": "<0>这个分析工具旨在帮助你释放你的潜力。暗黑骑士进攻的核心在于，在团辅buff存在期间，最大程度地利用你的暗血和MP。此外，你应该注意在每个血乱和嗜血期间打出5个技能。</0><1>在防御方面，<2/>可以减轻你或一个队友受到的大伤害，并且拥有极短的冷却时间。如果盾值被完全消耗，它还能让你免费试用一次暗影锋或者暗影波动。</1>",
   "drk.bloodweapon.suggestions.missedgcd.content": "每次<0/>时间里要打5个GCD技能，如果你的GCD完全没有空转也打不出5个的话，请考虑提高技速。",
   "drk.bloodweapon.title": "嗜血的使用记录",

--- a/src/parser/jobs/drg/changelog.tsx
+++ b/src/parser/jobs/drg/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2024-07-28'),
+		Changes: () => <>Enable suggestion output for unused procs.</>,
+		contributors: [CONTRIBUTORS.FALINDRITH],
+	},
+	{
 		date: new Date('2024-07-21'),
 		Changes: () => <>Added table displaying timeline links to when the Firstminds' Focus gauge was overcapped.</>,
 		contributors: [CONTRIBUTORS.FALINDRITH],

--- a/src/parser/jobs/drg/modules/Procs.tsx
+++ b/src/parser/jobs/drg/modules/Procs.tsx
@@ -1,6 +1,17 @@
 import {Procs as CoreProcs} from 'parser/core/modules/Procs'
+import {SEVERITY} from 'parser/core/modules/Suggestions'
 
 export default class Procs extends CoreProcs {
+	protected override showDroppedProcSuggestion = true
+	// DRG wants to use every proc, and dropping any of them is a major issue
+	protected override droppedProcSeverityTiers = {
+		1: SEVERITY.MEDIUM,
+		2: SEVERITY.MAJOR,
+	}
+
+	// we'll show invuln stuff too, though some of the drg actions are cleaves so will have to monitor for spurious suggestions
+	protected override showInvulnProcSuggestion = true
+
 	trackedProcs = [
 		{
 			procStatus: this.data.statuses.NASTROND_READY,

--- a/src/parser/jobs/drg/modules/Procs.tsx
+++ b/src/parser/jobs/drg/modules/Procs.tsx
@@ -1,16 +1,20 @@
+import {Trans} from '@lingui/react'
+import {iconUrl} from 'data/icon'
 import {Procs as CoreProcs} from 'parser/core/modules/Procs'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
+import React from 'react'
+
+const ICON_STARCROSS = 2078
 
 export default class Procs extends CoreProcs {
 	protected override showDroppedProcSuggestion = true
 	// DRG wants to use every proc, and dropping any of them is a major issue
+	protected override droppedProcIcon = iconUrl(ICON_STARCROSS)
+	protected override droppedProcContent = <Trans id="drg.procs.suggestions.dropped.content">Avoid lettings your procs fall off without using them, ideally while buffed. This might not always be possible, so remember to at least use your procs before they fall off.</Trans>
 	protected override droppedProcSeverityTiers = {
 		1: SEVERITY.MEDIUM,
 		2: SEVERITY.MAJOR,
 	}
-
-	// we'll show invuln stuff too, though some of the drg actions are cleaves so will have to monitor for spurious suggestions
-	protected override showInvulnProcSuggestion = true
 
 	trackedProcs = [
 		{


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1267146030005227602
- [x] The goal of this PR is detailed below:
  - Enable output for dropped procs. DRG procs can't be overwritten due to the CD between proc granting casts being longer than the proc duration. Because of this, any drop is at least medium severity, with more than one dropping off being marked as major.

## Testing / Validation
- [x] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [x] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:
  - https://www.fflogs.com/reports/6zHNFQRG3tjkMh2d#fight=1

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
