### PR TITLE
[Core] [Rpr] Add ConsiderEvent Filter option to onProcGained

### DIFF
--- a/src/parser/core/modules/Procs.tsx
+++ b/src/parser/core/modules/Procs.tsx
@@ -334,7 +334,7 @@ export abstract class Procs extends Analyser {
 	/**
 	 * May be overriden by Subclasses. Called by OnProcGained to allow jobs to implment job-specific logic for evaluting a proc when it is gained
 	 * @param event The event to check
-	 * @returns False by default. Jobs may override to return true, allowing them to implement job-specific logic to consider an event
+	 * @returns True by default. Jobs may override to return false, allowing them to implement job-specific logic to ignore a proc gain
 	 */
 	protected jobSpecificOnProcGainedConsiderEvent(_event: Events['statusApply']): boolean { return true }
 	/**

--- a/src/parser/core/modules/Procs.tsx
+++ b/src/parser/core/modules/Procs.tsx
@@ -25,8 +25,6 @@ interface CurrentProcBuffWindow {
 	nonConsumingEvents: Array<Events['action']>,
 	overwritten: boolean,
 	overwriteEvent?: Event
-	dropped: boolean,
-	dropEvent?: Event
 }
 
 export interface ProcBuffWindow extends CurrentProcBuffWindow {
@@ -218,17 +216,6 @@ export abstract class Procs extends Analyser {
 	}
 
 	/**
-	 * Get an array of dropped events for a given proc status
-	 * @param status The status, as an ID number or ProcGroup object
-	 * @returns The array of dropped Events
-	 */
-	protected getDroppedProcsForStatus(status: number | ProcGroup): ProcBuffWindow[] {
-		const procGroup = this.getTrackedGroupByStatus(status)
-		if (procGroup == null) { return [] }
-		return this.getHistoryForStatus(status).filter(window => window.overwritten)
-	}
-
-	/**
 	 * Gets the number of times a proc was allowed to fall off
 	 * @param status The status, as an ID number or ProcGroup object
 	 * @returns The number of times the proc was dropped (removals - usages)
@@ -407,7 +394,6 @@ export abstract class Procs extends Analyser {
 			consumingInvulnEvents: [],
 			nonConsumingEvents: [],
 			overwritten: false,
-			dropped: false,
 		})
 	}
 


### PR DESCRIPTION
This is a redo of PR# 2054, now that stackedProcs has landed.

## Pull request type

- [ x] This is new functionality or an addition to existing functionality
- [x ] This is a bugfix to existing functionality

## Pull request details
- [x ] This is in response to a discussion or thread on Discord:  https://discord.com/channels/441414116914233364/470050640005955605/1266818820568518767
- [ ] The goal of this PR is detailed below:

Adds a new ConsiderEvent function that is called during onProcGained for Core Procs in order to handle a bug for Reaper where the buff is applied and refreshed with a single cast for Executioners Gallow.

Jobs can override this function to implement logic to ignore events for onProcGained Processing.

## Testing / Validation
- [x ] I used the log(s) listed below to develop and test this bugfix:

http://localhost:3000/fflogs/6yNcHD7vhJFdnWPV/16/5
http://localhost:3000/fflogs/2zgkpKjYnNZF19Py/1/2

## Job Maintenance
- [x ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

