### PR TITLE
PCT - Allow CMYK Starry Muse windows instead of requiring KMYK

### DIFF
--- a/src/parser/jobs/pct/changelog.tsx
+++ b/src/parser/jobs/pct/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-08-02'),
+		Changes: () => <>Relax the expectation for <DataLink showIcon={false} action="COMET_IN_BLACK" /> usage in <DataLink showIcon={false} action="STARRY_MUSE" /> buff windows.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-07-19'),
 		Changes: () => <>Add analysis for the contents of the <DataLink showIcon={false} action="STARRY_MUSE" /> buff windows.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/pct/modules/StarryMuse.tsx
+++ b/src/parser/jobs/pct/modules/StarryMuse.tsx
@@ -53,11 +53,11 @@ export class StarryMuse extends RaidBuffWindow {
 				},
 				{
 					actions: [this.data.actions.COMET_IN_BLACK],
-					expectedPerWindow: 2, // Default to 2, adjust to 1 for the opener
+					expectedPerWindow: 1,
 				},
 				{
 					actions: this.subtractiveActions,
-					expectedPerWindow: 2, // Default to 2, adjust to 3 for the opener
+					expectedPerWindow: 3,
 					overrideHeader: <DataLink showName={false} status="SUBTRACTIVE_PALETTE" />,
 				},
 				{
@@ -104,28 +104,20 @@ export class StarryMuse extends RaidBuffWindow {
 
 	private adjustExpectedActionGroupCounts(window: HistoryEntry<EvaluatedAction[]>, action: TrackedActionGroup): number {
 		const motifsPainted = this.countActionsUsed(window, this.creatureMotifs)
-		const firstWindow = this.history.entries.length > 0 ? this.history.entries[0].start === window.start : false
-
-		if (action.actions.includes(this.data.actions.COMET_IN_BLACK)) {
-			// If they had carried-over gauge we couldn't see, let 'em
-			if (this.countUsed(window, action) >= action.expectedPerWindow) { return 0 }
-
-			// If this is the opener window, or they're doing a multi-muse window, expect that they'll only fit one comet
-			if (firstWindow || motifsPainted > 0) {
-				return -1
-			}
-		}
 
 		if (action.actions.some(action => this.subtractiveActions.includes(action))) {
+			let adjustment = 0
 			// Only one subtractive spell can normally be fit into a multi-muse window
 			if (motifsPainted > 0) {
-				return -1
+				adjustment -= 2
 			}
 
-			// The opener window, with no carried over gauge, should replace the second comet with a third subtractive spell
-			if (firstWindow && this.countActionsUsed(window, [this.data.actions.COMET_IN_BLACK]) < 2) {
-				return 1
+			// Carrying a comet into the window (commonly referred to as KMYK) means pushing the third Subtractive spell out of the window
+			if (this.countActionsUsed(window, [this.data.actions.COMET_IN_BLACK]) > 1) {
+				adjustment--
 			}
+
+			return adjustment
 		}
 
 		// A multi-muse burst pushes Rainbow Drip out of the window


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/470050747720138753/1268917934005157939
- [x] The goal of this PR is detailed below:

While KMYK burst windows (ie, carry a Comet into the window, and use the Comet and two subtractive spells from the freebie use of Subtractive Palette) is the most optimal form of the Starry Muse burst window, setting that up consistently is a higher-level optimization than we generally target for our analysis. It's also not a huge potency increase overall, so CMYK windows should also be treated as acceptable (such as they already are for the opener).

Adjusted the Starry Muse window expectations to expect 1 Comet and 3 Subtractive spells by default, and to drop one subtractive spell if they did in fact set up for two Comets.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
  - KMYK: http://localhost:3000/fflogs/VRB8va9n6HGCrLFW/30/292
  - CMYK: http://localhost:3000/fflogs/9PGbyzrN46gAVcB3/10/57

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR