### PR TITLE
[BUGFIX] only use combatTime for start of fight when it exists

### DIFF
--- a/src/reportSources/legacyFflogs/reportAdapter.ts
+++ b/src/reportSources/legacyFflogs/reportAdapter.ts
@@ -133,28 +133,32 @@ function resolveActorKind(id: number, guid: number) {
 	return guid.toString()
 }
 
-const convertFight = (
-	report: LegacyReport,
-	fight: Fight,
-	actors: Actor[],
-): Pull => ({
-	id: fight.id.toString(),
+function convertFight(report: LegacyReport, fight: Fight, actors: Actor[]): Pull {
+	let timestamp = report.start + fight.start_time
+	let duration = fight.end_time - fight.start_time
+	if (fight.combatTime != null) {
+		// If the pull has a combat time flag, adjust the start of pull timestamp to use that instead
+		// Dungeons and trash pulls don't have a combat time flag, so preserve the original behavior using fight.start_time for those
+		timestamp = report.start + (fight.end_time - fight.combatTime)
+		duration = fight.combatTime
+	}
 
-	timestamp: report.start + fight.end_time - fight.combatTime,
-	duration: fight.combatTime,
-	progress: getFightProgress(fight),
-
-	encounter: {
-		key: getEncounterKey('legacyFflogs', fight.boss.toString()),
-		name: fight.name,
-		duty: {
-			id: fight.zoneID,
-			name: fight.zoneName,
+	return {
+		id: fight.id.toString(),
+		timestamp,
+		duration,
+		progress: getFightProgress(fight),
+		encounter: {
+			key: getEncounterKey('legacyFflogs', fight.boss.toString()),
+			name: fight.name,
+			duty: {
+				id: fight.zoneID,
+				name: fight.zoneName,
+			},
 		},
-	},
-
-	actors: [...actors, UNKNOWN_ACTOR],
-})
+		actors: [...actors, UNKNOWN_ACTOR],
+	}
+}
 
 function getFightProgress(fight: Fight) {
 	// Always mark kills as 100% progress


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [X] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [X] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/441424599310270464/1269327401796501575
- [X] The goal of this PR is detailed below:

Don't break the pull list - only try to use combatTime for start of fight if it exists (doesn't exist for trash pulls or dungeons)

## Testing / Validation

<!-- If this PR contains any new functionality or bugfixes, please include log links that reviewers can use to help verify your changes.  Reviewers may also find additional logs to check your PR with, but having initial logs is important to speed the review process, especially for corner cases or hard to trigger analysis flags.  If this PR is a patch bump with no changes or potency only changes, you can delete this section. -->
- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [X] I used the log(s) listed below to develop and test this bugfix:

http://localhost:3000/fflogs/kBdt3L8ACgbWDhpY
See also sentry list on discord from 8/3/2024

## Job Maintenance
- [X] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
