### PR TITLE
fix: make sure firstEvent for a fight is UNIX time

### DIFF
--- a/src/reportSources/legacyFflogs/store.ts
+++ b/src/reportSources/legacyFflogs/store.ts
@@ -69,7 +69,8 @@ export class LegacyFflogsReportStore extends ReportStore {
 			legacyFight,
 		)
 
-		return adaptEvents(report, pull, legacyEvents, legacyFight.start_time)
+		const firstEvent = legacyReport.start + legacyFight.start_time
+		return adaptEvents(report, pull, legacyEvents, firstEvent)
 	}
 
 	override getReportLink(pullId?: Pull['id'], actorId?: Actor['id']) {


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [X] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [X] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/441424599310270464/1269340845031690312
- [X] The goal of this PR is detailed below:

I swear I really do development professionally.  Forgot when adjusting the way prepull events are synthesized that FFLogs fight timestamps including start_time are relative to the start of the report, and we need to add back the report start time to get the actual timestamp of the start of the fight.

## Testing / Validation

<!-- If this PR contains any new functionality or bugfixes, please include log links that reviewers can use to help verify your changes.  Reviewers may also find additional logs to check your PR with, but having initial logs is important to speed the review process, especially for corner cases or hard to trigger analysis flags.  If this PR is a patch bump with no changes or potency only changes, you can delete this section. -->
- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [X] I used the log(s) listed below to develop and test this bugfix:

http://localhost:3000/fflogs/J6XKP8pCyLQTm3V1/22/100

## Job Maintenance
- [X] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
