### PR TITLE
PCT - Ignore Star Prism's cure effect for Weaving

### DIFF
--- a/src/parser/core/modules/Weaving.tsx
+++ b/src/parser/core/modules/Weaving.tsx
@@ -67,6 +67,8 @@ export class Weaving extends Analyser {
 
 	protected severity = WEAVING_SEVERITY
 
+	protected ignoredActionIds: number[] = []
+
 	//used to synth a start and end in case there were no actions before the pull or close to when the pull ended. it's also used to ensure that leading and trailing gcd events are not nullable
 	private pullStart: Events['action'] = {
 		action: 0,
@@ -107,6 +109,11 @@ export class Weaving extends Analyser {
 
 		// If the action is an auto, just ignore it
 		if (!action || action.autoAttack) {
+			return
+		}
+
+		// Ignore actions we were told to ignore
+		if (this.ignoredActionIds.includes(action.id)) {
 			return
 		}
 

--- a/src/parser/jobs/pct/changelog.tsx
+++ b/src/parser/jobs/pct/changelog.tsx
@@ -10,6 +10,11 @@ export const changelog = [
 	// },
 	{
 		date: new Date('2024-08-10'),
+		Changes: () => <>Ignore the cure effect of <DataLink showIcon={false} action="STAR_PRISM" /> when looking for weaving issues.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
+		date: new Date('2024-08-10'),
 		Changes: () => <>Fix incorrect uptime calculations caused by erroneous <DataLink showIcon={false} status="INSPIRATION" /> and <DataLink showIcon={false} status="RAINBOW_BRIGHT"/> handling.</>,
 		contributors: [CONTRIBUTORS.ACKWELL],
 	},

--- a/src/parser/jobs/pct/modules/Weaving.ts
+++ b/src/parser/jobs/pct/modules/Weaving.ts
@@ -15,6 +15,9 @@ export default class Weaving extends CoreWeaving {
 		this.data.actions.RAINBOW_DRIP.id,
 	]
 
+	// Star Prism's cure isn't a real action, it can't hurt you
+	override ignoredActionIds = [this.data.actions.STAR_PRISM_CURE.id]
+
 	override getMaxWeaves(weave: Weave) {
 
 		// If this isn't one of the funky long GCDs, use the default Weaving behavior


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/470050747720138753/1271927715414409347
- [x] The goal of this PR is detailed below:

Star Prism has an associated cure effect that shows up as a separate action. It is currently being treated as an oGCD being weaved, which is causing incorrect weaving issue reports in some cases. It should be ignored since it's not a separate button the player is pressing.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
- http://localhost:3000/fflogs/2q93AYbnKCcRGjhZ/17/7

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

