### PR TITLE
7.05 patch bumps for MNK, MCH, SMN, and BLU

### DIFF
--- a/src/data/ACTIONS/layers/patch7.05.ts
+++ b/src/data/ACTIONS/layers/patch7.05.ts
@@ -93,5 +93,24 @@ export const patch705: Layer<ActionRoot> = {
 			}],
 		},
 
+		PHANTOM_RUSH: {
+			potencies: [{
+				value: 1500,
+				bonusModifiers: [],
+			}],
+		},
+		WINDS_REPLY: {
+			potencies: [{
+				value: 900,
+				bonusModifiers: [],
+			}],
+		},
+		FIRES_REPLY: {
+			potencies: [{
+				value: 1200,
+				bonusModifiers: [],
+			}],
+		},
+
 	},
 }

--- a/src/parser/jobs/blu/index.tsx
+++ b/src/parser/jobs/blu/index.tsx
@@ -20,7 +20,7 @@ export const BLUE_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.01',
+		to: '7.05',
 	},
 
 	contributors: [

--- a/src/parser/jobs/mch/index.tsx
+++ b/src/parser/jobs/mch/index.tsx
@@ -25,7 +25,7 @@ export const MACHINIST = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.01',
+		to: '7.05',
 	},
 
 	contributors: [

--- a/src/parser/jobs/mnk/index.tsx
+++ b/src/parser/jobs/mnk/index.tsx
@@ -20,7 +20,7 @@ export const MONK = new Meta({
 
 	supportedPatches: {
 		from: '7.01',
-		to: '7.01',
+		to: '7.05',
 	},
 
 	contributors: [

--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -22,7 +22,7 @@ export const SUMMONER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.01',
+		to: '7.05',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

- [x] The job(s) in this patch bump had no changes for this patch
- [x] The job(s) in this patch bump had only potency changes for this patch, which do not effect analysis
  - [x] I have updated the data files for all potency changes for this patch
  - [x] The skills and jobs affected by these potency changes do not track potency for xivanaylsis purposes
- [x] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch

- MNK had a few potency changes, which have been updated in the 7.05 layer but do not affect analysis
- MCH and SMN had potency changes which are not tracked in our data, nor do they affect analysis
- BLU didn't change this patch

## Job Maintenance
- [x] I am active on the xivanalysis Discord ~~and part of the job maintainers group for the job(s) in this PR~~
