### PR TITLE
[Bugfix] Update BuffWindow target filters to better handle raid buffs

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,11 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-08-23'),
+		Changes: () => <>Resolve an issue that could cause raid buff analysis to report fewer players buffed than there actually were.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-08-10'),
 		Changes: () => <>Fix uptime calculations for precast and end-of-fight actions.</>,
 		contributors: [CONTRIBUTORS.ACKWELL],

--- a/src/parser/core/modules/ActionWindow/windows/BuffWindow.ts
+++ b/src/parser/core/modules/ActionWindow/windows/BuffWindow.ts
@@ -64,15 +64,19 @@ export abstract class BuffWindow extends ActionWindow {
 	override initialise() {
 		super.initialise()
 
-		// buff windows are either active on the parser's actor
+		// buff windows are either active on the parser's actor,
+		// another actor in the parser's party (raid buffs),
 		// or on an enemy actor (trick attack)
 		// enemies are not on the same team as the parser actor
 		const enemyTargets = this.parser.pull.actors
 			.filter(actor => actor.team !== this.parser.actor.team &&
 				actor.team !== Team.UNKNOWN) // Ignore actors with an 'unknown' team
 			.map(actor => actor.id)
+		const partyMembers = this.parser.pull.actors
+			.filter(actor => actor.playerControlled)
+			.map(actor => actor.id)
 
-		const targets = [this.parser.actor.id, ...enemyTargets]
+		const targets = [...partyMembers, ...enemyTargets]
 		const playerOwnedIds = this.parser.pull.actors
 			.filter(actor => (actor.owner === this.parser.actor) || actor === this.parser.actor)
 			.map(actor => actor.id)


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1270933828927750145
- [x] The goal of this PR is detailed below:

Brotherhood was reported as occasionally showing fewer players receiving the buff than there actually were based on review of the log on fflogs. Inspecting the event order on one of these showed that a couple players in the parser's party were receiving the buff before the player was, so the raid buff applications we tracked for calculating the application counts fell outside the window that the underlying BuffWindow code opened for that buff.

Updated the target filter on BuffWindow to allow for opening a window once any actor in the player's party is affected by a buff sourced from the player, rather than only the player or an enemy. This should not adversely impact any of the normal buff windows, but will ensure that raid buff application ordering shenanigans don't mess with the players affected counting.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
- https://xivanalysis.com/fflogs/a:YcgMmdt3G67kb1fZ/22/412
- https://xivanalysis.com/fflogs/a:ZhM2ty6PdJ4RF8Lf/20/1

## Job Maintenance
- [x] I am active on the xivanalysis Discord ~~and part of the job maintainers group for the job(s) in this PR~~
