### PR TITLE
[BugFix] Reset Paradox gauge on death, and retain Polyglot count on Enochian drop

### DIFF
--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -9,8 +9,8 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
-		date: new Date('2024-08-23'),
-		Changes: () => <>Make sure the <DataLink action="PARADOX" /> gauge marker is reset on death.</>,
+		date: new Date('2024-10-10'),
+		Changes: () => <>Make sure the <DataLink action="PARADOX" /> gauge marker is reset on death, and Polyglot count is not reset when Enochian is dropped.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 	{

--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-08-23'),
+		Changes: () => <>Make sure the <DataLink action="PARADOX" /> gauge marker is reset on death.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-07-31'),
 		Changes: () => <>Revive support for Umbral Ice <DataLink action="PARADOX" />, and handle the new timer pause functionality from <DataLink action="UMBRAL_SOUL" />.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -588,6 +588,7 @@ export class Gauge extends CoreGauge {
 		// Not counting the loss towards the rest of the gauge loss, that'll just double up on the suggestions
 		this.onAstralUmbralEnd(false)
 		this.paradoxGauge.reset()
+		this.polyglotGauge.reset()
 	}
 
 	private onComplete() {

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -521,7 +521,6 @@ export class Gauge extends CoreGauge {
 
 		this.umbralHeartsGauge.reset()
 
-		this.polyglotGauge.reset()
 		this.astralSoulGauge.reset()
 
 		this.addEvent()

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -588,6 +588,7 @@ export class Gauge extends CoreGauge {
 	override onDeath() {
 		// Not counting the loss towards the rest of the gauge loss, that'll just double up on the suggestions
 		this.onAstralUmbralEnd(false)
+		this.paradoxGauge.reset()
 	}
 
 	private onComplete() {


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] The goal of this PR is detailed below:

BLM's Gauge module overrides the onDeath function to keep the dropped gauge from double counting against suggestions. However, this means we didn't forcibly reset the Paradox gauge, since technically that one can exist without an Astral or Umbral state. We did reset it on raise, but it looks goofy and doesn't line up with in-game state.

Update: Added a related fix for the issue reported here: https://discord.com/channels/441414116914233364/1293852827986169866
The Polyglot counter was incorrectly getting reset when Enochian dropped. The timer portion of that gauge should reset, but the counters are retained.  

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
- https://xivanalysis.com/fflogs/VMhWDHBy1rZt74Qj/1/44
  - Check the timeline gauge graphs just after the 6 minute mark, I died there twice on this pull, both times with Paradox available
- https://xivanalysis.com/fflogs/DLGr4BPVRAakpwXY/16/5
  - Enochian drops around the 5:27 mark here, make sure Polyglot doesn't reset, but the Polyglot timer does

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

