### PR TITLE
[BugFix] Philosophia's healing comes from the Eudaimonia status

### DIFF
--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-08-23'),
+		Changes: () => <>Fix Philosophia overheal ignoring to correctly attribute its healing to the Eudaimonia status effect</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-07-10'),
 		Changes: () => <>Update Defensives and Tincture tracking, and mark as supported for Dawntrail</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/sge/modules/Overheal.tsx
+++ b/src/parser/jobs/sge/modules/Overheal.tsx
@@ -26,7 +26,7 @@ export class Overheal extends CoreOverheal {
 			name: 'Kardia/Philosophia',
 			trackedHealIds: [
 				this.data.statuses.KARDIA.id,
-				this.data.statuses.PHILOSOPHIA.id,
+				this.data.statuses.EUDAIMONIA.id,
 			],
 			ignore: true,
 		},


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1276731065678954497
- [x] The goal of this PR is detailed below:

Overheal from Philosophia is supposed to be ignored, since the player should not just stop doing DPS once the party is topped off to avoid overhealing with it. However, the tracked heal category that was meant to set this ignore up was tracking the Philosophia status effect, which is the increased healing received effect, not Eudaimonia, which is the actual Kardia-like status.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
- https://xivanalysis.com/fflogs/Yh42tNRGpvzA3BbM/1/12

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
