### PR TITLE
[DRG] bugfix: correct base potency of chaotic spring

### DIFF
--- a/src/data/ACTIONS/root/DRG.ts
+++ b/src/data/ACTIONS/root/DRG.ts
@@ -118,10 +118,10 @@ export const DRG = ensureActions({
 			from: [87, 36955],
 		},
 		potencies: [{
-			value: 100,
+			value: 140,
 			bonusModifiers: [],
 		}, {
-			value: 140,
+			value: 180,
 			bonusModifiers: [BonusModifier.POSITIONAL],
 		}, {
 			value: 300,


### PR DESCRIPTION
## Pull request type
- [x] This is a bugfix to existing functionality

## Pull request details
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1277573145464668170/1277573145464668170
- [x] The goal of this PR is detailed below:
  - This PR fixes positional detection for Chaotic Spring. The base potencies were incorrect, causing some missed positionals to be incorrectly marked as correct. Changes were made to the root DRG actions file due to this potency being the base value when 7.0 was released.

## Testing / Validation
- [x] I used the log(s) listed below to develop and test this bugfix: https://xivanalysis.com/fflogs/a:LWrKvRMnZdJ4afBq/1/4

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
