### PR TITLE
Fix DataLinks targeting items as actions

### DIFF
--- a/src/parser/jobs/ast/modules/Tincture.tsx
+++ b/src/parser/jobs/ast/modules/Tincture.tsx
@@ -41,7 +41,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="ast.tincture.suggestions.trackedActions.content">
 				Try to cover as much damage as possible with your Tinctures of Mind.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_MND" showIcon={false} />,
+			suggestionWindowName: <DataLink item="INFUSION_MND" showIcon={false} />,
 			severityTiers: {
 				1: SEVERITY.MINOR,
 				2: SEVERITY.MEDIUM,

--- a/src/parser/jobs/drk/modules/Tincture.tsx
+++ b/src/parser/jobs/drk/modules/Tincture.tsx
@@ -53,7 +53,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="gnb.tincture.suggestions.trackedActions.content">
 				Try to cover as much damage as possible with your Tinctures of Strength.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_STR" showIcon={false}/>,
+			suggestionWindowName: <DataLink item="INFUSION_STR" showIcon={false}/>,
 			severityTiers: {
 				1: SEVERITY.MINOR,
 				2: SEVERITY.MEDIUM,

--- a/src/parser/jobs/gnb/modules/Tincture.tsx
+++ b/src/parser/jobs/gnb/modules/Tincture.tsx
@@ -41,7 +41,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="gnb.tincture.suggestions.trackedActions.content">
 				Try to cover as much damage as possible with your Tinctures of Strength.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_STR" showIcon={false}/>,
+			suggestionWindowName: <DataLink item="INFUSION_STR" showIcon={false}/>,
 			severityTiers: {
 				1: SEVERITY.MINOR,
 				2: SEVERITY.MEDIUM,

--- a/src/parser/jobs/mch/modules/Tincture.tsx
+++ b/src/parser/jobs/mch/modules/Tincture.tsx
@@ -79,7 +79,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="mch.tincture.suggestions.trackedActions.content">
 				Try to cover as much damage as possible with your Tinctures of Dexterity.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_DEX" showIcon={false} />,
+			suggestionWindowName: <DataLink item="INFUSION_DEX" showIcon={false} />,
 			severityTiers: {
 				2: SEVERITY.MINOR,
 				4: SEVERITY.MEDIUM,
@@ -100,7 +100,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="mch.tincture.suggestions.blazingShot.content">
 				Try to fit at least two uses of <DataLink action="HYPERCHARGE" /> in every Tincture window after the opener.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_DEX" showIcon={false} />,
+			suggestionWindowName: <DataLink item="INFUSION_DEX" showIcon={false} />,
 			severityTiers: {
 				1: SEVERITY.MINOR,
 				2: SEVERITY.MEDIUM,

--- a/src/parser/jobs/pld/modules/Tincture.tsx
+++ b/src/parser/jobs/pld/modules/Tincture.tsx
@@ -15,14 +15,14 @@ export class Tincture extends CoreTincture {
 		super.initialise()
 
 		const suggestionIcon = this.data.actions.INFUSION_STR.icon
-		const suggestionWindowName = <DataLink action="INFUSION_STR" />
+		const suggestionWindowName = <DataLink item="INFUSION_STR" />
 		this.addEvaluator(new ExpectedGcdCountEvaluator({
 			expectedGcds: 12,
 			globalCooldown: this.globalCooldown,
 			hasStacks: false,
 			suggestionIcon,
 			suggestionContent: <Trans id="pld.tincture.suggestions.missedgcd.content">
-				Try to land 12 GCDs during every <DataLink action="INFUSION_STR" /> window.
+				Try to land 12 GCDs during every <DataLink item="INFUSION_STR" /> window.
 			</Trans>,
 			suggestionWindowName,
 			severityTiers: {
@@ -48,7 +48,7 @@ export class Tincture extends CoreTincture {
 				Try to land at least one cast of <DataLink action="EXPIACION" />, <DataLink action="CIRCLE_OF_SCORN" />
 				, <DataLink action="INTERVENE" />, <DataLink action="GORING_BLADE" />, <DataLink action="CONFITEOR" />
 				, <DataLink action="BLADE_OF_FAITH" />, <DataLink action="BLADE_OF_TRUTH" />, <DataLink action="BLADE_OF_VALOR" />
-				, and a <DataLink status="DIVINE_MIGHT" /> empowered <DataLink action ="HOLY_SPIRIT" /> during every <DataLink action="INFUSION_STR" /> window.
+				, and a <DataLink status="DIVINE_MIGHT" /> empowered <DataLink action ="HOLY_SPIRIT" /> during every <DataLink item="INFUSION_STR" /> window.
 			</Trans>,
 			suggestionWindowName,
 			severityTiers: {

--- a/src/parser/jobs/rpr/modules/Tincture.tsx
+++ b/src/parser/jobs/rpr/modules/Tincture.tsx
@@ -53,7 +53,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="rpr.tincture.suggestions.trackedActions.content">
 				Try to fit two uses of <DataLink action="COMMUNIO"/> while under the effects of a Tincture.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_STR" showIcon={false}/>,
+			suggestionWindowName: <DataLink item="INFUSION_STR" showIcon={false}/>,
 			severityTiers: COMMUNIO_SEVERITY,
 			adjustCount: this.adjustExpectedActionCount,
 		}))

--- a/src/parser/jobs/sge/modules/Tincture.tsx
+++ b/src/parser/jobs/sge/modules/Tincture.tsx
@@ -31,7 +31,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="sge.tincture.suggestions.trackedActions.content">
 				Try to cover as much damage as possible with your Tinctures of Mind.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_MND" showIcon={false}/>,
+			suggestionWindowName: <DataLink item="INFUSION_MND" showIcon={false}/>,
 			severityTiers: {
 				1: SEVERITY.MINOR,
 				2: SEVERITY.MEDIUM,

--- a/src/parser/jobs/vpr/modules/Tincture.tsx
+++ b/src/parser/jobs/vpr/modules/Tincture.tsx
@@ -51,7 +51,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="vpr.tincture.suggestions.trackedActions.content">
 				Try to fit two full uses of <DataLink action="REAWAKEN"/> while under the effects of a Tincture.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_DEX" showIcon={false}/>,
+			suggestionWindowName: <DataLink item="INFUSION_DEX" showIcon={false}/>,
 			severityTiers: SEVERITY_TIERS,
 			adjustCount: this.adjustExpectedActionCount,
 		}))

--- a/src/parser/jobs/whm/modules/Tincture.tsx
+++ b/src/parser/jobs/whm/modules/Tincture.tsx
@@ -34,7 +34,7 @@ export class Tincture extends CoreTincture {
 			suggestionContent: <Trans id="whm.tincture.suggestions.trackedActions.content">
 				Try to cover as much damage as possible with your Tinctures of Mind.
 			</Trans>,
-			suggestionWindowName: <DataLink action="INFUSION_MND" showIcon={false}/>,
+			suggestionWindowName: <DataLink item="INFUSION_MND" showIcon={false}/>,
 			severityTiers: {
 				1: SEVERITY.MINOR,
 				2: SEVERITY.MEDIUM,


### PR DESCRIPTION
Title. Old API returned `false` inline for these which errored out but didn't hard fail. New one (currently) 404s the entire request. I'll probably look into changing the API behavior, but these are still wrong and need to be fixed.