### PR TITLE
[RPR] Add Executioner Skills to Positionals

### DIFF
--- a/src/parser/core/modules/Positionals.tsx
+++ b/src/parser/core/modules/Positionals.tsx
@@ -89,7 +89,7 @@ export abstract class Positionals extends Analyser {
 	// things such as DRG's 5th hit combo buff and RPR's reaver buff.
 	// Luckily, assessing misses is easy and sufficient for the purposes
 	// of detecting positional hits.
-	private missedPositionalBonusPercents(action: Action) {
+	protected missedPositionalBonusPercents(action: Action) {
 		const missedPositionalBonusPercents = [NO_BONUS_PERCENT]
 
 		if (!action.potencies) {
@@ -124,7 +124,7 @@ export abstract class Positionals extends Analyser {
 
 	// Currently just checks that you didn't miss. Checking for hits would
 	// otherwise be more complex.
-	private positionalHit(action: Action, bonusPercent: number) {
+	protected positionalHit(action: Action, bonusPercent: number) {
 		return !this.missedPositionalBonusPercents(action).includes(bonusPercent)
 	}
 

--- a/src/parser/jobs/rpr/modules/Positionals.ts
+++ b/src/parser/jobs/rpr/modules/Positionals.ts
@@ -1,11 +1,46 @@
+import {Action} from 'data/ACTIONS'
 import {Positionals as CorePositionals} from 'parser/core/modules/Positionals'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 
+// Explaination for Jank:
+// Reaper's bonus postionals as of patch 7.05 are as follows:
+// No Buffs + no positionals = 0 %
+// Buffs +positional = 7%
+// Buffs + no positional = 0%
+// No Buffs + positional = 7%
+
+// To combat the fact that a buff postional and a non buff positional share the same bonusPercent,
+// I have override postionalhit to compare the bonus percent to POSTIONAL_HIT_BONUS_PERCENTS and return true false.
+// The Reaver module will cover the missed potency from the missing buff.
+
+const POSITIONAL_HIT_BONUS_PERCENTS = 7
 export class Positionals extends CorePositionals {
 	static override displayOrder = DISPLAY_ORDER.POSITIONALS
 
 	positionals = [
 		this.data.actions.GIBBET,
 		this.data.actions.GALLOWS,
+		this.data.actions.EXECUTIONERS_GIBBET,
+		this.data.actions.EXECUTIONERS_GALLOWS,
 	]
+
+	protected override positionalHit(action: Action, bonusPercent: number): boolean {
+		//Check Executioner versions if they match the hit bonus
+		if (action === this.data.actions.EXECUTIONERS_GALLOWS) {
+			if (bonusPercent === POSITIONAL_HIT_BONUS_PERCENTS) {
+				return true
+			}
+			return false
+
+		}
+		if (action === this.data.actions.EXECUTIONERS_GIBBET) {
+			if (bonusPercent === POSITIONAL_HIT_BONUS_PERCENTS) {
+				return true
+			}
+			return false
+
+		}
+		//Everything Else
+		return !this.missedPositionalBonusPercents(action).includes(bonusPercent)
+	}
 }


### PR DESCRIPTION
## Pull request type

- [x ] This is new functionality or an addition to existing functionality

## Pull request details

- [ x] The goal of this PR is detailed below:
changes positional core code to have missedPositionalBonusPercents and postionalHit change from private methods to protected methods in order to allow postionalHits to be overridden to hard code success checks for Executioner Skills and still be able to call missedPositonalBonusPercents for all other skills.

## Testing / Validation
- [x ] I used the log(s) listed below to develop and test this bugfix:

https://www.fflogs.com/reports/CvbPxT47qNRgdLXf#fight=2&view=events&type=damage-done

Log order:
No Buffs + no positionals = 0 %
Buffs +positional = 7%
Buffs + no positional = 0%
No Buffs + positional = 7%

## Job Maintenance
- [x ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

