### PR TITLE
Support browser launching for developers on Linux and Mac systems

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,6 +12,17 @@ import {calculateLocaleCompletion} from './config/locale'
 
 import './config/loadDotenv'
 
+function browserOpenCommand() {
+	switch (os.platform()) {
+	case 'win32': // Windows systems
+		return 'explorer'
+	case 'darwin': // Mac Systems
+		return 'open'
+	default: // Linux and other Unix-compliant systems
+		return 'xdg-open'
+	}
+}
+
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 
 interface Environment {
@@ -44,7 +55,7 @@ export default (env: Environment, {
 	devServer: {
 		host: 'localhost',
 		port: 3000,
-		open: os.platform() === 'win32' ? 'explorer' : 'xdg-open',
+		open: browserOpenCommand(),
 		openPage: 'http://localhost:3000',
 		historyApiFallback: true,
 		overlay: true,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -2,6 +2,7 @@ import {CleanWebpackPlugin} from 'clean-webpack-plugin'
 import CopyWebpackPlugin from 'copy-webpack-plugin'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
 import MiniCssExtractPlugin from 'mini-css-extract-plugin'
+import os from 'os'
 import path from 'path'
 import webpack from 'webpack'
 import WebpackBar from 'webpackbar'
@@ -43,7 +44,8 @@ export default (env: Environment, {
 	devServer: {
 		host: 'localhost',
 		port: 3000,
-		open: 'http://localhost:3000',
+		open: os.platform() === 'win32' ? 'explorer' : 'xdg-open',
+		openPage: 'http://localhost:3000',
 		historyApiFallback: true,
 		overlay: true,
 		liveReload: false,


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] The goal of this PR is detailed below:

We previously updated the webpack devServer configuration to handle some change on Windows systems that was preventing the "open the browser to localhost:3000" behavior of `yarn start` from working. That change was causing `yarn start` to crash on Linux systems however, which wasn't immediately apparent until I started migrating my desktop over to Fedora.

I found an example that recommended changing the `open` property of the devServer config from the localhost URI to the OS command that should be used to launch the browser, and moving the URI to the `openPage` property instead.

I haven't yet tested if this change retains the expected behavior on Windows, but it does resolve the problem on my Linux system.

## Testing / Validation

Verify that `yarn start` correctly opens the default browser to localhost:3000 on Window systems.
