### PR TITLE
temporarily removed cafemaker API due to compatibility issue with dawntrail

### DIFF
--- a/src/components/ui/DbLink.tsx
+++ b/src/components/ui/DbLink.tsx
@@ -28,13 +28,21 @@ export interface ProviderProps {
 export function Provider({children}: ProviderProps) {
 	const {i18nStore} = useContext(StoreContext)
 
+	/** 
+	 * Due to the temporary unavailability of Chinese services, English API will be used instead.
+	 * When the API adaptation is complete, it needs to be modified back.
+	 */
 	const baseUrl = i18nStore.gameLanguage === Language.CHINESE
-		? 'https://cafemaker.wakingsands.com'
+		? undefined /* 'https://cafemaker.wakingsands.com' */
 		: undefined
+
+	const gameLanguage = i18nStore.gameLanguage === Language.CHINESE
+		? Language.ENGLISH
+		: i18nStore.gameLanguage
 
 	return useObserver(() => (
 		<TooltipProvider
-			language={i18nStore.gameLanguage}
+			language={gameLanguage}
 			baseUrl={baseUrl}
 		>
 			{children}

--- a/src/components/ui/DbLink.tsx
+++ b/src/components/ui/DbLink.tsx
@@ -28,7 +28,7 @@ export interface ProviderProps {
 export function Provider({children}: ProviderProps) {
 	const {i18nStore} = useContext(StoreContext)
 
-	/** 
+	/**
 	 * Due to the temporary unavailability of Chinese services, English API will be used instead.
 	 * When the API adaptation is complete, it needs to be modified back.
 	 */


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details
Due to the temporary unavailability of Chinese services cafemaker.wakingsands.com, The cafemaker.wakingsands.com is not support dawntrail version, So English API will be used instead.

When the `cafemaker` API adaptation is complete, it needs to be modified back.

![image](https://github.com/user-attachments/assets/3472175d-b808-48eb-a5bf-94f5fa0983c0)

## Testing / Validation
- [x] I used the log(s) listed below to develop and test this bugfix:
- https://xivanalysis.com/fflogs/a:wk2x41rLtZcpqBmT/3/199

![image](https://github.com/user-attachments/assets/bd9963be-b6b2-4e8c-82b5-99e71c200ceb)
