### PR TITLE
Swap CN tooltips back to EN for now

### DIFF
--- a/src/components/ui/DbLink.tsx
+++ b/src/components/ui/DbLink.tsx
@@ -9,7 +9,6 @@ import {
 } from '@xivanalysis/tooltips'
 import {useDataContext} from 'components/DataContext'
 import {ActionKey, ITEM_ID_OFFSET} from 'data/ACTIONS'
-import {Language} from 'data/LANGUAGES'
 import {StatusKey, STATUS_ID_OFFSET} from 'data/STATUSES'
 import {useObserver} from 'mobx-react'
 import React, {CSSProperties, memo, ReactNode, useContext, useState} from 'react'
@@ -28,14 +27,14 @@ export interface ProviderProps {
 export function Provider({children}: ProviderProps) {
 	const {i18nStore} = useContext(StoreContext)
 
-	const baseUrl = i18nStore.gameLanguage === Language.CHINESE
-		? 'https://cafemaker.wakingsands.com'
-		: undefined
+	// const baseUrl = i18nStore.gameLanguage === Language.CHINESE
+	// 	? 'https://cafemaker.wakingsands.com'
+	// 	: undefined
 
 	return useObserver(() => (
 		<TooltipProvider
 			language={i18nStore.gameLanguage}
-			baseUrl={baseUrl}
+			// baseUrl={baseUrl}
 		>
 			{children}
 		</TooltipProvider>

--- a/src/store/i18n.ts
+++ b/src/store/i18n.ts
@@ -5,7 +5,7 @@ import {getUserLanguage} from 'utilities'
 
 export const gameLanguageEditions: GameEdition[] = [
 	GameEdition.GLOBAL,
-	GameEdition.CHINESE, // Cafemaker
+	// GameEdition.CHINESE, // Cafemaker
 ]
 
 function getGameLanguage(language: Language): Language {


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [ ] This is in response to a discussion or thread on Discord: *[Link to thread or start of discussion]*
- [x] The goal of this PR is detailed below:

Got some emails from sentry about being rate limited, there's been a significant number of `Failed to fetch` errors that are consuming our entire error budget. While fetch errors are hardly abnormal, there's been a significant spike from CN language page loads, which seem to primarily be stemming from CafeMaker no longer matching the expected xivapi url structure (because we're using the beta for the global site).

This is just disabling usage of cafemaker as a tooltip data provider - how to resolve this with actual CN data is left as a problem for another time.
