### PR TITLE
Fix xivapi not support language zh

### DIFF
--- a/src/components/ui/DbLink.tsx
+++ b/src/components/ui/DbLink.tsx
@@ -34,8 +34,8 @@ export function Provider({children}: ProviderProps) {
 
 	// fix for xivapi not support language zh
 	const gameLanguage = i18nStore.gameLanguage === Language.CHINESE
-	? Language.ENGLISH
-	: i18nStore.gameLanguage
+		? Language.ENGLISH
+		: i18nStore.gameLanguage
 
 	return useObserver(() => (
 		<TooltipProvider

--- a/src/components/ui/DbLink.tsx
+++ b/src/components/ui/DbLink.tsx
@@ -9,6 +9,7 @@ import {
 } from '@xivanalysis/tooltips'
 import {useDataContext} from 'components/DataContext'
 import {ActionKey, ITEM_ID_OFFSET} from 'data/ACTIONS'
+import {Language} from 'data/LANGUAGES'
 import {StatusKey, STATUS_ID_OFFSET} from 'data/STATUSES'
 import {useObserver} from 'mobx-react'
 import React, {CSSProperties, memo, ReactNode, useContext, useState} from 'react'
@@ -31,9 +32,14 @@ export function Provider({children}: ProviderProps) {
 	// 	? 'https://cafemaker.wakingsands.com'
 	// 	: undefined
 
+	// fix for xivapi not support language zh
+	const gameLanguage = i18nStore.gameLanguage === Language.CHINESE
+	? Language.ENGLISH
+	: i18nStore.gameLanguage
+
 	return useObserver(() => (
 		<TooltipProvider
-			language={i18nStore.gameLanguage}
+			language={gameLanguage}
 			// baseUrl={baseUrl}
 		>
 			{children}


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

if only set `language={i18nStore.gameLanguage}` it will lead to xivapi `language=zh`, which is not supported by xivapi.

```
{"code":400,"message":"invalid request: Failed to deserialize query string: invalid or unsupported language \"zh\""}
```

Add a redirect to EN when using Chinese Client
```ts
const gameLanguage = i18nStore.gameLanguage === Language.CHINESE
	? Language.ENGLISH
	: i18nStore.gameLanguage
```

![image](https://github.com/user-attachments/assets/a1dc6cd6-f967-4817-8a79-250940e1f552)

