### PR TITLE
[SAM] Bugfix: Tendo skills not giving meditation stacks

### DIFF
--- a/src/parser/jobs/sam/changelog.tsx
+++ b/src/parser/jobs/sam/changelog.tsx
@@ -4,6 +4,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2024-10-20'),
+		Changes: () => <>Fixed an issue where the resource timeline did not reflect Meditation stacks gained from <DataLink action="TENDO_GOKEN"/> and <DataLink action="TENDO_SETSUGEKKA"/>. </>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
+	{
 		date: new Date('2024-09-08'),
 		Changes: () => <>Updated <DataLink action="HAGAKURE"/> feedback to no longer suggest using it during a fight</>,
 		contributors: [CONTRIBUTORS.RYAN],

--- a/src/parser/jobs/sam/modules/Shoha.tsx
+++ b/src/parser/jobs/sam/modules/Shoha.tsx
@@ -48,6 +48,8 @@ export class Shoha extends CoreGauge {
 		[this.data.actions.TENKA_GOKEN.id, {action: 1}],
 		[this.data.actions.MIDARE_SETSUGEKKA.id, {action: 1}],
 		[this.data.actions.OGI_NAMIKIRI.id, {action: 1}],
+		[this.data.actions.TENDO_GOKEN.id, {action: 1}],
+		[this.data.actions.TENDO_SETSUGEKKA.id, {action: 1}],
 
 		// Spenders
 		[this.data.actions.SHOHA.id, {action: -3}],


### PR DESCRIPTION
## Pull request type

- [x ] This is a bugfix to existing functionality

## Pull request details

This PR adds Tendo Goken and Tendo Setsugekka to the meditation stack granting actions.

## Testing / Validation

Before: 

![image](https://github.com/user-attachments/assets/9b64de84-e01e-41f4-b3c2-23bfa0daf530)


After:
![image](https://github.com/user-attachments/assets/4169b738-4128-4eca-ae0e-8732c91e689a)

https://www.fflogs.com/reports/1aZVbnCW4KQ9Pg7v#fight=13&source=9

## Job Maintenance
- [ x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

