### PR TITLE
Disable 7.05 modules for pre 7.05 parses

### DIFF
--- a/src/parser/jobs/vpr/changelog.tsx
+++ b/src/parser/jobs/vpr/changelog.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 export const changelog = [
 	{
 		date: new Date('2024-10-20'),
-		Changes: () => <>Disabled feedback modules that require 7.05 skills for Viper parses before 7.0.</>,
+		Changes: () => <>Disabled feedback modules that were implmented for 7.05 Viper Changes</>,
 		contributors: [CONTRIBUTORS.RYAN],
 	},
 	{

--- a/src/parser/jobs/vpr/changelog.tsx
+++ b/src/parser/jobs/vpr/changelog.tsx
@@ -4,6 +4,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2024-10-20'),
+		Changes: () => <>Disabled feedback modules that require 7.05 skills for Viper parses before 7.0.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
+	{
 		date: new Date('2024-10-02'),
 		Changes: () => <>Expand <DataLink action="SERPENTS_TAIL"/> checklist and add <DataLink action="VICEWINDER"/> and <DataLink action="VICEPIT"/> checklist.</>,
 		contributors: [CONTRIBUTORS.RYAN],

--- a/src/parser/jobs/vpr/modules/HonedProcs.tsx
+++ b/src/parser/jobs/vpr/modules/HonedProcs.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import {t} from '@lingui/macro'
 import {Trans} from '@lingui/react'
 import {DataLink, StatusLink} from 'components/ui/DbLink'
@@ -47,6 +46,10 @@ export class HonedProcs extends CoreProcs {
 
 	]
 	override addJobSpecificSuggestions() {
+		if (this.parser.patch.before('7.05')) {
+			return //NOT SUPPORTED
+		}
+
 		const DroppedHoneds= this.getDropCountForStatus(this.data.statuses.HONED_STEEL.id) + this.getDropCountForStatus(this.data.statuses.HONED_REAVERS.id)
 		const OverwroteHoneds = this.getOverwriteCountForStatus(this.data.statuses.HONED_STEEL.id) + this.getOverwriteCountForStatus(this.data.statuses.HONED_REAVERS.id)
 

--- a/src/parser/jobs/vpr/modules/OGCDDowntime.tsx
+++ b/src/parser/jobs/vpr/modules/OGCDDowntime.tsx
@@ -16,12 +16,18 @@ export default class OGCDDowntime extends CooldownDowntime {
 			],
 			firstUseOffset: FIRSTUSEOFFSET_IRE,
 		},
-		{
+		...(this.parser.patch.after('7.01') ? [{
 			cooldowns: [
 				this.data.actions.VICEWINDER,
 				this.data.actions.VICEPIT,
 			],
 			firstUseOffset: FIRSTUSEOFFSET_DREAD,
-		},
+		}] : [{
+			cooldowns: [
+				this.data.actions.DREADWINDER,
+				this.data.actions.PIT_OF_DREAD,
+			],
+			firstUseOffset: FIRSTUSEOFFSET_DREAD,
+		}]),
 	]
 }

--- a/src/parser/jobs/vpr/modules/Vices.tsx
+++ b/src/parser/jobs/vpr/modules/Vices.tsx
@@ -99,6 +99,9 @@ export class Vices extends Analyser {
 	}
 
 	private onComplete() {
+		if (this.parser.patch.before('7.05')) { //NOT SUPPORTED
+			return
+		}
 
 		const Counters = {
 			viceWinders: {action: this.data.actions.VICEWINDER, ready: this.viceWinders, done: this.viceWinders},


### PR DESCRIPTION
## Pull request type

- [x ] This is disabling alerts

## Pull request details

VPRs using pre-7.05 parses generate sentry alerts because the skills for feedback don't exist yet,

This PR disables all 7.05 feedback modules for pre-7.05 parses

## Testing / Validation

Before: 

![image](https://github.com/user-attachments/assets/02793121-5f3f-4860-8649-99661baaf967)


After: 

![image](https://github.com/user-attachments/assets/911fac41-cc5c-4737-8f94-60c266628628)

https://www.fflogs.com/reports/pKXHmGLcd2NR8tYA#fight=2&source=5

## Job Maintenance
- [x ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

