### PR TITLE
[VPR] Uncoiled Fury checklist bugfix

### DIFF
--- a/src/parser/jobs/vpr/changelog.tsx
+++ b/src/parser/jobs/vpr/changelog.tsx
@@ -4,6 +4,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2024-10-21'),
+		Changes: () => <> Fixed Bug with <DataLink action="UNCOILED_FURY" /> not being tracked correctly in the checklist.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
+	{
 		date: new Date('2024-10-20'),
 		Changes: () => <>Disabled feedback modules that were implmented for 7.05 Viper Changes</>,
 		contributors: [CONTRIBUTORS.RYAN],

--- a/src/parser/jobs/vpr/modules/RattlingCoil.tsx
+++ b/src/parser/jobs/vpr/modules/RattlingCoil.tsx
@@ -128,7 +128,7 @@ export class RattlingCoil extends CoreGauge {
 					name: <Trans id="vpr.rattlingcoil.checklist.requirement.waste.name">
 						<DataLink action="UNCOILED_FURY"/>
 					</Trans>,
-					value: this.coilGauge.totalGenerated - (this.coilGauge.overCap + this.coilGauge.value),
+					value: this.coilGauge.totalSpent,
 					target: this.coilGauge.totalGenerated,
 				}),
 				new Requirement({


### PR DESCRIPTION
## Pull request type
- [x ] This is a bugfix to existing functionality


## Pull request details

Viper's UncoiledFury checklist has the wrong value, as the value component uses TotalGenerated instead of TotalSpent to judge the player, resulting in inaccurate feedback

## Testing / Validation
- [x ] I used the log(s) listed below to develop and test this bugfix:
https://www.fflogs.com/reports/C4vqbnQc2K6kVx8f#fight=19&source=2&type=casts

Before:
![image](https://github.com/user-attachments/assets/1b16ebeb-5efe-4f06-b78c-949491f4f59e)

After: 
![image](https://github.com/user-attachments/assets/91582f81-802f-48c8-b0e8-080179215e35)



## Job Maintenance
- [ x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR