### PR TITLE
Prevent desync of game language from valid game editions

### DIFF
--- a/src/components/ui/DbLink.tsx
+++ b/src/components/ui/DbLink.tsx
@@ -33,7 +33,7 @@ export function Provider({children}: ProviderProps) {
 
 	return useObserver(() => (
 		<TooltipProvider
-			language={i18nStore.gameLanguage}
+			language={i18nStore.safeGameLanguage}
 			// baseUrl={baseUrl}
 		>
 			{children}

--- a/src/components/ui/I18nMenu.js
+++ b/src/components/ui/I18nMenu.js
@@ -55,8 +55,9 @@ class I18nMenu extends Component {
 
 	render() {
 		const {i18nStore} = this.context
+		const gameLanguageKey = i18nStore.safeGameLanguage
 		const siteLang = LANGUAGES[i18nStore.siteLanguage]
-		const gameLang = LANGUAGES[i18nStore.gameLanguage]
+		const gameLang = LANGUAGES[gameLanguageKey]
 
 		return <div className={styles.container}>
 			{/* Site language */}
@@ -110,7 +111,7 @@ class I18nMenu extends Component {
 					{this.gameLanguageOptions.map(options => (
 						<Dropdown.Item
 							key={options.value}
-							active={i18nStore.gameLanguage === options.value}
+							active={gameLanguageKey === options.value}
 							onClick={this.handleChangeGame}
 							{...options}
 							className={styles.menuItem}

--- a/src/store/i18n.ts
+++ b/src/store/i18n.ts
@@ -1,6 +1,6 @@
 import {GameEdition} from 'data/EDITIONS'
 import {Language, LANGUAGES} from 'data/LANGUAGES'
-import {action, observable} from 'mobx'
+import {action, computed, observable} from 'mobx'
 import {getUserLanguage} from 'utilities'
 
 export const gameLanguageEditions: GameEdition[] = [
@@ -19,9 +19,27 @@ function getGameLanguage(language: Language): Language {
 export class I18nStore {
 	@observable siteLanguage: Language = getUserLanguage()
 	@observable siteSet: boolean = false
-	@observable gameLanguage: Language = getGameLanguage(this.siteLanguage)
 	@observable gameSet: boolean = false
 	@observable overlay: boolean = false
+
+	/**
+	 * Get the raw game language as defined by the user or derived from site-wide language.
+	 *
+	 * @deprecated **DO NOT USE DIRECTLY:** this property exists for compatibility with
+	 * localstorage user configuration. Use `safeGameLanguage` instead.
+	 */
+	@observable gameLanguage: Language = getGameLanguage(this.siteLanguage)
+
+	/**
+	 * Get the user-specified game language if valid, falling back to English if
+	 * the game language targets an unsupported game edition.
+	 *
+	 * This is an unfortunate side effect of the old mobx+localstorage persistence
+	 * setup, and is a bandaid at best.
+	 */
+	@computed get safeGameLanguage() {
+		return getGameLanguage(this.gameLanguage)
+	}
 
 	@action
 	setSiteLanguage(language: Language) {


### PR DESCRIPTION
Sentry reset for the month and yeah it's still on fire.

Dug into it, as mentioned on that other PR, looks like it's localstorage. Whoever wrote this whole localstorage via mobx setup needs a swift kick up the rear, it's fucking atrocious.

Oh wait, that was me.

---

This PR just adds a computed wrapper around the concrete value that performs the same validation check that is done when manually set with the dropdown on the sidebar.

It's a bandaid, but it's about as good as we can do without migrations of localstorage values and so on. This also has the benefit of not resetting user's localstorage unless they interact with the dropdown; so if we can re-support cn in future, that'll be a nice win