### PR TITLE
[BugFix] - Fix Pneuma counting twice for GCD uptime

### DIFF
--- a/src/data/ACTIONS/root/SGE.ts
+++ b/src/data/ACTIONS/root/SGE.ts
@@ -341,16 +341,10 @@ export const SGE = ensureActions({
 		mpCost: 700,
 		statusesApplied: ['PNEUMA'],
 	},
-	// The heal from Pneuma is technically a different action source because reasons apparently. Unsure how much of this data should stay around but at least removing the statusesApplied array...
+	// The heal from Pneuma is technically a different action source because reasons
 	PNEUMA_HEAL: {
 		id: 27524,
 		name: 'Pneuma',
 		icon: iconUrl(3686),
-		onGcd: true,
-		speedAttribute: Attribute.SPELL_SPEED,
-		castTime: 1500,
-		gcdRecast: 2500,
-		cooldown: 120000,
-		mpCost: 700,
 	},
 })

--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-11-10'),
+		Changes: () => <>Fixed a data issue causing Pneuma's heal effect to be treated as second simultaneous GCD use</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-08-23'),
 		Changes: () => <>Fix Philosophia overheal ignoring to correctly attribute its healing to the Eudaimonia status effect</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a GitHub issue: https://github.com/xivanalysis/xivanalysis/issues/2135

Pneuma's heal effect is technically a second action, so when I originally created the SGE data modules for Endwalker, I cloned the Pneuma damage action and updated the IDs. However, since I didn't remove the GCD-related properties, casting Pneuma was double-counting the GCD uptime, leading to incorrect results, as well as showing it twice in the timeline. This PR fixes both of those issues.

Note that this only resolves point 1 of the linked GH issue. Other PRs will address the other points.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix: https://xivanalysis.com/fflogs/pGvYbkW7yPQLrw1j/4/4

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
