### PR TITLE
[BigFix] Fix End of Fight instant cast GCD uptime calculation

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,11 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-11-10'),
+		Changes: () => <>Fixed an issue causing GCD uptime calculation to be overly generous when a pull ended on an instant-casted spell that normally has a cast time.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-08-27'),
 		Changes: () => <>Added blurb and feature for defensives with charges.</>,
 		contributors: [CONTRIBUTORS.OTOCEPHALY],

--- a/src/parser/core/modules/AlwaysBeCasting.tsx
+++ b/src/parser/core/modules/AlwaysBeCasting.tsx
@@ -88,7 +88,7 @@ export class AlwaysBeCasting extends Analyser {
 					gcdUptime: Math.max(0, gcdUptime),
 				})
 			} else if (relativeEndTime > this.parser.pull.duration) {
-				const gcdUptime = relativeEndTime - this.parser.pull.duration
+				const gcdUptime = this.parser.pull.timestamp + this.parser.pull.duration - event.timestamp
 				this.debug(`GCD Uptime for end-of-fight ${action.name} at ${this.parser.formatEpochTimestamp(event.timestamp, 1)} - Cast time: ${castTime} | Recast time: ${recastTime} | In-combat uptime ${gcdUptime}`)
 				this.gcdUptimeEvents.push({
 					time: event.timestamp,


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a GitHub issue: https://github.com/xivanalysis/xivanalysis/issues/2135

When the last GCD of a fight was a spell that normally has a cast time, but was made instant cast by way of Swiftcast, Triplecast, or other effects, the GCD uptime calculation for that spell was ending up as a negative value due to how it was being calulated. This produced an overly generous result which could cause the overall uptime percentage to exceed 100%, especially for jobs like Pictomancer that try to end on a swiftcasted Rainbow Drip.

Now we'll calculate the GCD uptime for that spell correctly as the portion of the GCD that actually occurred before the end of the fight.

Note that this only fixed point 3 of the linked issue. #2136 fixes point 1, and a future PR will be needed to fix point 2.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix: https://xivanalysis.com/fflogs/a:NKCQgknYTM8zJx2H/5/321

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
