### PR TITLE
Patch and layer definitions for 7.1

### DIFF
--- a/src/data/ACTIONS/layers/index.ts
+++ b/src/data/ACTIONS/layers/index.ts
@@ -2,6 +2,7 @@ import {Layer} from 'data/layer'
 import {ActionRoot} from '../root'
 import {patch701} from './patch7.01'
 import {patch705} from './patch7.05'
+import {patch710} from './patch7.1'
 
 export const layers: Array<Layer<ActionRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -9,4 +10,5 @@ export const layers: Array<Layer<ActionRoot>> = [
 	// {patch: '5.05', data: {ATTACK: {id: 9001}}},
 	patch701,
 	patch705,
+	patch710,
 ]

--- a/src/data/ACTIONS/layers/patch7.1.ts
+++ b/src/data/ACTIONS/layers/patch7.1.ts
@@ -1,0 +1,9 @@
+import {Layer} from 'data/layer'
+import {ActionRoot} from '../root'
+
+export const patch710: Layer<ActionRoot> = {
+	patch: '7.1',
+	data: {
+
+	},
+}

--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -72,6 +72,11 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 			[GameEdition.GLOBAL]: 1722333600, // 30/07/24 10:00:00 GMT
 		},
 	},
+	'7.1': {
+		date: {
+			[GameEdition.GLOBAL]: 1731398400, // 12/11/24 8:00:00 GMT
+		},
+	},
 })
 
 export type PatchNumber = keyof typeof PATCHES

--- a/src/data/STATUSES/layers/index.ts
+++ b/src/data/STATUSES/layers/index.ts
@@ -2,6 +2,7 @@ import {Layer} from 'data/layer'
 import {StatusRoot} from '../root'
 import {patch701} from './patch7.01'
 import {patch705} from './patch7.05'
+import {patch710} from './patch7.1'
 
 export const layers: Array<Layer<StatusRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -9,4 +10,5 @@ export const layers: Array<Layer<StatusRoot>> = [
 	// {patch: '5.05', data: {BIO_II: {id: 9001}}}}
 	patch701,
 	patch705,
+	patch710,
 ]

--- a/src/data/STATUSES/layers/patch7.1.ts
+++ b/src/data/STATUSES/layers/patch7.1.ts
@@ -1,0 +1,9 @@
+import {Layer} from 'data/layer'
+import {StatusRoot} from '../root'
+
+export const patch710: Layer<StatusRoot> = {
+	patch: '7.1',
+	data: {
+
+	},
+}


### PR DESCRIPTION
Patch 7.1 housekeeping to let devs get started on job updates. Added patch definition and action/status layer files. Core updates to happen on a separate PR after we have game data files and some early parses to check for odd invuln stuff.

Technically okay to merge before the servers go down. It won't change anything immediately other than starting to display the "xivanalysis supports up to patch 7.05 of 7.1" message on the home page a bit early.