### PR TITLE
7.1 Patch Bump for SGE, DNC, and PCT

### DIFF
--- a/src/data/ACTIONS/layers/patch7.1.ts
+++ b/src/data/ACTIONS/layers/patch7.1.ts
@@ -66,5 +66,19 @@ export const patch710: Layer<ActionRoot> = {
 		FLARE: {
 			castTime: 3000,
 		},
+
+		// SGE MP cost changes
+		PROGNOSIS: {
+			mpCost: 700,
+		},
+		EUKRASIAN_DIAGNOSIS: {
+			mpCost: 800,
+		},
+		EUKRASIAN_PROGNOSIS: {
+			mpCost: 800,
+		},
+		EUKRASIAN_PROGNOSIS_II: {
+			mpCost: 800,
+		},
 	},
 }

--- a/src/data/ACTIONS/layers/patch7.1.ts
+++ b/src/data/ACTIONS/layers/patch7.1.ts
@@ -67,6 +67,11 @@ export const patch710: Layer<ActionRoot> = {
 			castTime: 3000,
 		},
 
+		// Esuna Role action is now instant
+		ESUNA: {
+			castTime: 0,
+		},
+
 		// SGE MP cost changes
 		PROGNOSIS: {
 			mpCost: 700,

--- a/src/data/ACTIONS/root/ROLE.ts
+++ b/src/data/ACTIONS/root/ROLE.ts
@@ -55,6 +55,7 @@ export const ROLE = ensureActions({
 		name: 'Esuna',
 		icon: iconUrl(884),
 		onGcd: true,
+		castTime: 1000,
 		cooldown: 2500,
 		mpCost: 600,
 		mpCostFactor: 5,

--- a/src/parser/jobs/dnc/index.tsx
+++ b/src/parser/jobs/dnc/index.tsx
@@ -25,7 +25,7 @@ export const DANCER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.05',
+		to: '7.1',
 	},
 
 	contributors: [

--- a/src/parser/jobs/pct/index.tsx
+++ b/src/parser/jobs/pct/index.tsx
@@ -20,7 +20,7 @@ export const PICTOMANCER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.05',
+		to: '7.1',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sge/index.tsx
+++ b/src/parser/jobs/sge/index.tsx
@@ -18,7 +18,7 @@ export const SAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.05',
+		to: '7.1',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

SGE had a few MP cost changes that are updated but otherwise don't affect analysis. DNC and PCT had no changes that affect our analysis, since PCT Gauge was already assuming the player had all three motifs at the start of the pull.

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
