### PR TITLE
[DRG] 7.1 adjustments

### DIFF
--- a/src/data/ACTIONS/layers/patch7.1.ts
+++ b/src/data/ACTIONS/layers/patch7.1.ts
@@ -4,6 +4,54 @@ import {ActionRoot} from '../root'
 export const patch710: Layer<ActionRoot> = {
 	patch: '7.1',
 	data: {
-
+		// drg is not the same :o
+		ELUSIVE_JUMP: {
+			statusesApplied: ['ENHANCED_PIERCING_TALON'],
+		},
+		PIERCING_TALON: {
+			potencies: [
+				{
+					value: 200,
+					bonusModifiers: [],
+				},
+				{
+					value: 350,
+					bonusModifiers: [],
+					baseModifiers: ['ENHANCED_PIERCING_TALON'],
+				},
+			],
+		},
+		MIRAGE_DIVE: {
+			potencies: [
+				{
+					value: 380,
+					bonusModifiers: [],
+				},
+			],
+		},
+		NASTROND: {
+			potencies: [
+				{
+					value: 720,
+					bonusModifiers: [],
+				},
+			],
+		},
+		STARDIVER: {
+			potencies: [
+				{
+					value: 720,
+					bonusModifiers: [],
+				},
+			],
+		},
+		STARCROSS: {
+			potencies: [
+				{
+					value: 1000,
+					bonusModifiers: [],
+				},
+			],
+		},
 	},
 }

--- a/src/data/STATUSES/layers/patch7.1.ts
+++ b/src/data/STATUSES/layers/patch7.1.ts
@@ -1,9 +1,15 @@
+import {iconUrl} from 'data/icon'
 import {Layer} from 'data/layer'
 import {StatusRoot} from '../root'
 
 export const patch710: Layer<StatusRoot> = {
 	patch: '7.1',
 	data: {
-
+		ENHANCED_PIERCING_TALON: {
+			id: 1870,
+			name: 'Enhanced Piercing Talon',
+			icon: iconUrl(212590),
+			duration: 15000,
+		},
 	},
 }

--- a/src/data/STATUSES/root/DRG.ts
+++ b/src/data/STATUSES/root/DRG.ts
@@ -1,5 +1,6 @@
 import {iconUrl} from 'data/icon'
 import {ensureStatuses} from '../type'
+import {SHARED} from './SHARED'
 
 export const DRG = ensureStatuses({
 	BATTLE_LITANY: {
@@ -78,4 +79,6 @@ export const DRG = ensureStatuses({
 		icon: iconUrl(18151),
 		duration: 20000,
 	},
+
+	ENHANCED_PIERCING_TALON: SHARED.UNKNOWN,
 })

--- a/src/parser/jobs/drg/changelog.tsx
+++ b/src/parser/jobs/drg/changelog.tsx
@@ -3,6 +3,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2024-11-14'),
+		Changes: () => <>Adjust number of expected uses of Nastrond from 3 to 1 for each buff window. Updated data for patch 7.1.</>,
+		contributors: [CONTRIBUTORS.FALINDRITH],
+	},
+	{
 		date: new Date('2024-07-28'),
 		Changes: () => <>Enable suggestion output for unused procs.</>,
 		contributors: [CONTRIBUTORS.FALINDRITH],

--- a/src/parser/jobs/drg/modules/BattleLitany.tsx
+++ b/src/parser/jobs/drg/modules/BattleLitany.tsx
@@ -11,7 +11,7 @@ import React from 'react'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 const BL_GCD_TARGET = 8
-const NASTRONDS_PER_WINDOW = 3
+const NASTRONDS_PER_WINDOW = 1
 
 export class BattleLitany extends RaidBuffWindow {
 	static override handle = 'battlelitany'

--- a/src/parser/jobs/drg/modules/BloodOfTheDragon.tsx
+++ b/src/parser/jobs/drg/modules/BloodOfTheDragon.tsx
@@ -14,7 +14,7 @@ import DISPLAY_ORDER from './DISPLAY_ORDER'
 import {DfdTracker} from './LanceCharge'
 
 const DRAGON_DURATION_MILLIS = 20000
-const EXPECTED_NASTRONDS_PER_WINDOW = 3
+const EXPECTED_NASTRONDS_PER_WINDOW = 1
 
 // we can massively simplify this analyzer from Endwalker. It now functions like a standard timed window
 // and we fold in all the analysis of what actions were missed and what were expected into standard formats.

--- a/src/parser/jobs/drg/modules/LanceCharge.tsx
+++ b/src/parser/jobs/drg/modules/LanceCharge.tsx
@@ -15,7 +15,7 @@ import {Message} from 'semantic-ui-react'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
 
 const LC_DURATION = 20000
-const EXPECTED_NASTRONDS_PER_WINDOW = 3
+const EXPECTED_NASTRONDS_PER_WINDOW = 1
 
 export interface DfdTracker {
 	start: number


### PR DESCRIPTION
## Pull request type
- [x] This is a patch bump

## Pull request details
DRG has a minor change where we now only expect 1 Nastrond use per buff window. All three windows (battle litany, lance charge, and life of the dragon) have been updated with the new number of expected uses.

Data files have also been updated. DRG mostly doesn't use the potency values but I figured I could put them in while I was there. New statuses have also been added (let me know if i put that in wrong, based it off of stuff in the viper status layers). Enhanced piercing talon icon added, existing status icon codes have not been changed (pending in #2141).

- [ ] The job(s) in this patch bump had only potency changes for this patch, which do not effect analysis
  - [x] I have updated the data files for all potency changes for this patch
- [x] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch

## Testing / Validation
- [x] I used the log(s) listed below to develop and test this bugfix: https://www.fflogs.com/reports/9cgDxKpyTMkjGYFP (just my static's reclears for the week)

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
