### PR TITLE
[GNB] 7.1 Support

### DIFF
--- a/src/parser/jobs/gnb/changelog.tsx
+++ b/src/parser/jobs/gnb/changelog.tsx
@@ -4,6 +4,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2024-11-14'),
+		Changes: () => <>GNB 7.1 Support added.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
+	{
 		date: new Date('2024-07-24'),
 		Changes: () => <> Updated Cooldown offsets for the updated 2.4X and 2.5 Openers and added allowed downtime to <DataLink action="BLOODFEST"/> to allow it to be delayed back under <DataLink action="NO_MERCY"/>.</>,
 		contributors: [CONTRIBUTORS.RYAN],

--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -20,7 +20,7 @@ export const GUNBREAKER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.05',
+		to: '7.1',
 	},
 
 	contributors: [

--- a/src/parser/jobs/gnb/modules/Ammo.tsx
+++ b/src/parser/jobs/gnb/modules/Ammo.tsx
@@ -18,6 +18,7 @@ const LEFTOVER_AMMO_SEVERITY_TIERS = {
 }
 
 const MAX_AMMO = 3
+let DoubleDownCost = 1
 
 export class Ammo extends CoreGauge {
 	static override handle = 'ammo'
@@ -48,12 +49,16 @@ export class Ammo extends CoreGauge {
 		[this.data.actions.BURST_STRIKE.id, {action: -1}],
 		[this.data.actions.FATED_CIRCLE.id, {action: -1}],
 		[this.data.actions.GNASHING_FANG.id, {action: -1}],
-		[this.data.actions.DOUBLE_DOWN.id, {action: -2}],
+		[this.data.actions.DOUBLE_DOWN.id, {action: -DoubleDownCost}],
 
 	])
 
 	override initialise() {
 		super.initialise()
+
+		if (this.parser.patch.before('7.1')) {
+			DoubleDownCost = 2
+		}
 
 		const ammoActions = Array.from(this.ammoModifiers.keys())
 


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [ ] This is a bugfix to existing functionality
- [x ] This is a patch bump


  - [x ] I have updated the data files for all potency changes for this patch

GNB's Double Down now costs 1 instead of 2.

## Testing / Validation


- [x ] I used the log(s) listed below to develop and test this bugfix:

  https://www.fflogs.com/reports/pDQbkzwng9ZXxqm2#fight=2&type=damage-done

## Job Maintenance
- [ x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

