### PR TITLE
Update Core to 7.1

### DIFF
--- a/src/generated/unableToActStatusIds.ts
+++ b/src/generated/unableToActStatusIds.ts
@@ -251,4 +251,9 @@ export const UNABLE_TO_ACT_STATUS_IDS = [
 	4066, // The Narwhal's Lullaby (lockActions, lockControl)
 	4132, // Down for the Count (lockActions)
 	4150, // Deep Freeze (lockActions)
+	4185, // Bonds of Loathing (lockControl)
+	4350, // Down for the Count (lockActions)
+	4374, // Stun (lockActions)
+	4378, // Stun (lockActions)
+	4433, // Stun (lockActions)
 ]

--- a/src/parser/core/index.tsx
+++ b/src/parser/core/index.tsx
@@ -15,7 +15,7 @@ export const CORE = new Meta({
 	// Read `docs/patch-checklist.md` before editing the following values.
 	supportedPatches: {
 		from: '7.0',
-		to: '7.05',
+		to: '7.1',
 	},
 })
 


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

Updated the unableToAct status list via `yarn generate`
Checked a couple Ex3 parses and nothing looked sketchy for Invuln
We've already updated the Esuna role action, so we're good to bump core

## Testing / Validation

Pick your favorite Ex3 parse to double-check invuln if you wish

## Job Maintenance
- [x] I am active on the xivanalysis Discord
