### PR TITLE
[BugFix] Firestarter does not consume Umbral Hearts, plus three Proc-related bugxies

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -10,6 +10,11 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-12-03'),
+		Changes: () => <>Fixed an issue causing initial hits on newly spawned adds to sometimes be treated as hits against an invulnerable target.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-11-21'),
 		Changes: () => <>Fixed prepull actions for defensives for duplicates, weird counts, and missing suggested available times. </>,
 		contributors: [CONTRIBUTORS.AKAIRYU, CONTRIBUTORS.AZARIAH, CONTRIBUTORS.OTOCEPHALY],

--- a/src/parser/core/modules/Invulnerability.tsx
+++ b/src/parser/core/modules/Invulnerability.tsx
@@ -461,7 +461,9 @@ export class Invulnerability extends Analyser {
 			return
 		}
 
-		this.addEndEdge(targetId, timestamp)
+		// Set the end edge to 1ms prior to the event that first hit the target, to prevent
+		// later data from assuming that first hit was itself an invulnerable hit
+		this.addEndEdge(targetId, timestamp - 1)
 	}
 
 	private addStartEdge = (actorId: Actor['id'], timestamp: number) =>

--- a/src/parser/core/modules/Procs.tsx
+++ b/src/parser/core/modules/Procs.tsx
@@ -259,7 +259,7 @@ export abstract class Procs extends Analyser {
 		const stacksPerWindow = procGroup.procStatus.stacksApplied ?? 1
 
 		return this.getHistoryForStatus(status)
-			.filter(window => window.overwritten === false && window.consumingEvents.length < stacksPerWindow && this.considerDroppedProcs(window))
+			.filter(window => window.overwritten === false && (window.consumingEvents.length + window.consumingInvulnEvents.length) < stacksPerWindow && this.considerDroppedProcs(window))
 	}
 
 	/**
@@ -274,7 +274,7 @@ export abstract class Procs extends Analyser {
 
 		return this.getDroppedWindowsForStatus(status)
 			.reduce((dropped, window) => {
-				dropped += Math.max(0, stacksPerWindow - window.consumingEvents.length)
+				dropped += Math.max(0, stacksPerWindow - (window.consumingEvents.length + window.consumingInvulnEvents.length))
 				return dropped
 			}, 0)
 	}

--- a/src/parser/core/modules/Procs.tsx
+++ b/src/parser/core/modules/Procs.tsx
@@ -134,7 +134,8 @@ export abstract class Procs extends Analyser {
 		const procGroup = this.getTrackedGroupByStatus(status)
 		if (procGroup == null) { return 0 }
 		const stacksPerWindow = procGroup.procStatus.stacksApplied ?? 1
-		return this.getHistoryForStatus(status).length * stacksPerWindow
+		const currentWindow = this.currentWindows.get(procGroup)
+		return (this.getHistoryForStatus(status).length + (currentWindow ? 1 : 0)) * stacksPerWindow
 	}
 
 	/**
@@ -145,7 +146,12 @@ export abstract class Procs extends Analyser {
 	protected getUsagesForStatus(status: number | ProcGroup): Array<Events['action']> {
 		const procGroup = this.getTrackedGroupByStatus(status)
 		if (procGroup == null) { return [] }
-		return this.getHistoryForStatus(status).reduce((usageEvents, window) => usageEvents.concat(window.consumingEvents), [] as Array<Events['action']>)
+		const usageEvents = this.getHistoryForStatus(status).reduce((usageEvents, window) => usageEvents.concat(window.consumingEvents), [] as Array<Events['action']>)
+		const currentWindow = this.currentWindows.get(procGroup)
+		if (currentWindow) {
+			usageEvents.push(...currentWindow.consumingEvents)
+		}
+		return usageEvents
 	}
 	/**
 	 * Get the number of times a proc was used
@@ -224,7 +230,12 @@ export abstract class Procs extends Analyser {
 	protected getInvulnsForStatus(status: number | ProcGroup): Array<Events['action']> {
 		const procGroup = this.getTrackedGroupByStatus(status)
 		if (procGroup == null) { return [] }
-		return this.getHistoryForStatus(status).reduce((invulnEvents, window) => invulnEvents.concat(window.consumingInvulnEvents), [] as Array<Events['action']>)
+		const invulnerableEvents = this.getHistoryForStatus(status).reduce((invulnEvents, window) => invulnEvents.concat(window.consumingInvulnEvents), [] as Array<Events['action']>)
+		const currentWindow = this.currentWindows.get(procGroup)
+		if (currentWindow) {
+			invulnerableEvents.push(...currentWindow.consumingInvulnEvents)
+		}
+		return invulnerableEvents
 	}
 	/**
 	 * Get the number of times a proc was used on an invulnerable target

--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-12-02'),
+		Changes: () => <>Fixed a gauge tracking bug that caused Umbral Hearts to be consumed by <DataLink status="FIRESTARTER" /> procs.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-11-16'),
 		Changes: () => <>Add a table displaying timestamps when procs were dropped, for better clarity around when those issues occurred.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -279,10 +279,12 @@ export class Gauge extends CoreGauge {
 		case this.data.actions.FIRE_I.id:
 		case this.data.actions.FIRE_II.id:
 		case this.data.actions.HIGH_FIRE_II.id:
-		case this.data.actions.FIRE_III.id:
 		case this.data.actions.FIRE_IV.id:
+			this.tryConsumeUmbralHearts(1)
+			break
+		case this.data.actions.FIRE_III.id:
 			// Firestarters don't cost MP and so don't consume Umbral Hearts
-			if (!(abilityId === this.data.actions.FIRE_III.id && this.procs.checkEventWasProc(event))) {
+			if (!this.procs.checkEventWasProc(event)) {
 				this.tryConsumeUmbralHearts(1)
 			}
 			break
@@ -298,6 +300,9 @@ export class Gauge extends CoreGauge {
 			break
 		case this.data.actions.PARADOX.id:
 			this.paradoxGauge.spend(1)
+			break
+		case this.data.actions.AMPLIFIER.id:
+			this.onGeneratePolyglot()
 			break
 		case this.data.actions.FLARE_STAR.id:
 			this.astralSoulGauge.reset()
@@ -550,6 +555,8 @@ export class Gauge extends CoreGauge {
 		this.polyglotTimer.refresh()
 
 		this.onGeneratePolyglot()
+
+		this.addEvent()
 	}
 
 	private onGeneratePolyglot() {

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -20,6 +20,7 @@ import React, {Fragment} from 'react'
 import {Message, Table, Button} from 'semantic-ui-react'
 import {isSuccessfulHit} from 'utilities'
 import {FIRE_SPELLS, ICE_SPELLS_TARGETED, ICE_SPELLS_UNTARGETED} from './Elements'
+import Procs from './Procs'
 
 /** Configuration */
 const POLYGLOT_DURATION_REQUIRED = 30000
@@ -103,6 +104,7 @@ export class Gauge extends CoreGauge {
 	@dependency private suggestions!: Suggestions
 	@dependency private unableToAct!: UnableToAct
 	@dependency private castTime!: CastTime
+	@dependency private procs!: Procs
 
 	private gaugeErrors: BLMGaugeError[] = []
 	private droppedEnoTimestamps: number[] = []
@@ -279,7 +281,10 @@ export class Gauge extends CoreGauge {
 		case this.data.actions.HIGH_FIRE_II.id:
 		case this.data.actions.FIRE_III.id:
 		case this.data.actions.FIRE_IV.id:
+			// Firestarters don't cost MP and so don't consume Umbral Hearts
+			if (!(abilityId === this.data.actions.FIRE_III.id && this.procs.checkEventWasProc(event))) {
 				this.tryConsumeUmbralHearts(1)
+			}
 			break
 		case this.data.actions.FLARE.id:
 			this.tryConsumeUmbralHearts(FLARE_MAX_HEART_CONSUMPTION, true)

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -45,6 +45,7 @@ const AFFECTS_GAUGE_ON_DAMAGE: ActionKey[] = [
 ]
 
 const AFFECTS_GAUGE_ON_CAST: ActionKey[] = [
+	...FIRE_SPELLS,
 	...ICE_SPELLS_UNTARGETED,
 	'TRANSPOSE',
 	'FOUL',
@@ -230,10 +231,11 @@ export class Gauge extends CoreGauge {
 
 		// The action event is sufficient for actions that don't need to do damage to affect gauge state (ie. Transpose, Enochian, Umbral Soul)
 		// Foul, Xenoglossy, and Paradox also fall into this category since they consume their gauge markers on execution
+		// Fire spells also consume Umbral Hearts whether or not they actually do damage
 		this.addEventHook(playerFilter.type('action').action(this.data.matchActionId(AFFECTS_GAUGE_ON_CAST)), this.onCast)
 
 		// The rest of the fire and ice spells must do damage in order to affect gauge state, so hook that event instead.
-		this.addEventHook(playerFilter.type('damage').cause(this.data.matchCauseActionId(this.affectsGaugeOnDamage)), this.onCast)
+		this.addEventHook(playerFilter.type('damage').cause(this.data.matchCauseActionId(this.affectsGaugeOnDamage)), this.onDamage)
 
 		this.addEventHook('complete', this.onComplete)
 	}
@@ -258,20 +260,65 @@ export class Gauge extends CoreGauge {
 	}
 
 	//#region onCast and gauge state modification
-	private onCast(event: Events['damage'] | Events['action']) {
+
+	// Actions that modify gauge state on cast, such as spending Umbral Hearts, or Amplifier granting Polyglot
+	private onCast(event: Events['action']) {
+		const abilityId = event.action
+
+		switch (abilityId) {
+		case this.data.actions.UMBRAL_SOUL.id:
+			this.onGainUmbralIceStacks(1)
+			this.tryGainUmbralHearts(1)
+			// Patch 7.05 updated Umbral Soul such that it pauses the Umbral Ice timer, but the Polyglot timer keeps rolling
+			if (!this.parser.patch.before('7.05')) {
+				this.umbralIceTimer.pause()
+			}
+			break
+		case this.data.actions.FIRE_I.id:
+		case this.data.actions.FIRE_II.id:
+		case this.data.actions.HIGH_FIRE_II.id:
+		case this.data.actions.FIRE_III.id:
+		case this.data.actions.FIRE_IV.id:
+				this.tryConsumeUmbralHearts(1)
+			break
+		case this.data.actions.FLARE.id:
+			this.tryConsumeUmbralHearts(FLARE_MAX_HEART_CONSUMPTION, true)
+			break
+		case this.data.actions.XENOGLOSSY.id:
+		case this.data.actions.FOUL.id:
+			this.onConsumePolyglot()
+			break
+		case this.data.actions.TRANSPOSE.id:
+			this.onTransposeStacks()
+			break
+		case this.data.actions.PARADOX.id:
+			this.paradoxGauge.spend(1)
+			break
+		case this.data.actions.FLARE_STAR.id:
+			this.astralSoulGauge.reset()
+			break
+		case this.data.actions.MANAFONT.id:
+			this.onGainAstralFireStacks(ASTRAL_UMBRAL_MAX_STACKS, false)
+			this.gainUmbralHearts(UMBRAL_HEARTS_MAX_STACKS)
+			this.onGainParadox()
+			break
+		}
+	}
+
+	// Actions that must do damage to affect gauge state, such as gaining/refreshing AF/UI stacks
+	private onDamage(event: Events['damage']) {
 		let abilityId
 		if ('cause' in event && 'action' in event.cause) {
 			abilityId = event.cause.action
-		} else if ('action' in event) {
-			abilityId = event.action
 		}
 
 		// If we couldn't figure out what ability this is (somehow wound up here because of a DoT?), bail
 		if (abilityId == null) { return }
 
-		// Bail out if the event didn't do damage and the action needs to in order to affect gauge state
-		if (this.affectsGaugeOnDamage.includes(abilityId) && event.type === 'damage' && !isSuccessfulHit(event)) { return }
+		// Bail out if the event didn't do damage
+		if (!isSuccessfulHit(event)) { return }
 
+		// Modify the gauge state based on this successful hit
 		switch (abilityId) {
 		case this.data.actions.BLIZZARD_I.id:
 			this.onGainUmbralIceStacks(1)
@@ -287,61 +334,37 @@ export class Gauge extends CoreGauge {
 				this.onGainUmbralIceStacks(1, false)
 			}
 			this.umbralHeartsGauge.set(UMBRAL_HEARTS_MAX_STACKS)
-			this.addEvent()
-			break
-		case this.data.actions.UMBRAL_SOUL.id:
-			this.onGainUmbralIceStacks(1)
-			this.tryGainUmbralHearts(1)
-			// Patch 7.05 updated Umbral Soul such that it pauses the Umbral Ice timer, but the Polyglot timer keeps rolling
-			if (!this.parser.patch.before('7.05')) {
-				this.umbralIceTimer.pause()
-			}
 			break
 		case this.data.actions.FIRE_I.id:
-			this.tryConsumeUmbralHearts(1)
 			this.onGainAstralFireStacks(1)
 			break
 		case this.data.actions.FIRE_II.id:
 		case this.data.actions.HIGH_FIRE_II.id:
 		case this.data.actions.FIRE_III.id:
-			this.tryConsumeUmbralHearts(1)
 			this.onGainAstralFireStacks(ASTRAL_UMBRAL_MAX_STACKS, false)
 			break
 		case this.data.actions.FIRE_IV.id:
 			if (this.astralUmbralGauge.getCountAt(ASTRAL_FIRE_HANDLE) === 0) {
 				this.onGainAstralFireStacks(1, false)
 			}
-			this.tryConsumeUmbralHearts(1)
 			this.onGainAstralSoul(1)
 			break
 		case this.data.actions.DESPAIR.id:
 			this.onGainAstralFireStacks(ASTRAL_UMBRAL_MAX_STACKS, false)
 			break
 		case this.data.actions.FLARE.id:
-			this.tryConsumeUmbralHearts(FLARE_MAX_HEART_CONSUMPTION, true)
 			this.onGainAstralFireStacks(ASTRAL_UMBRAL_MAX_STACKS, false)
 			this.onGainAstralSoul(FLARE_SOUL_GENERATION)
 			break
-		case this.data.actions.XENOGLOSSY.id:
-		case this.data.actions.FOUL.id:
-			this.onConsumePolyglot()
-			break
-		case this.data.actions.TRANSPOSE.id:
-			this.onTransposeStacks()
-			break
 		case this.data.actions.PARADOX.id:
-			this.handleParadox(event)
-			break
-		case this.data.actions.AMPLIFIER.id:
-			this.onGeneratePolyglot()
-			break
-		case this.data.actions.FLARE_STAR.id:
-			this.astralSoulGauge.reset()
-			break
-		case this.data.actions.MANAFONT.id:
-			this.onGainAstralFireStacks(ASTRAL_UMBRAL_MAX_STACKS, false)
-			this.gainUmbralHearts(UMBRAL_HEARTS_MAX_STACKS)
-			this.onGainParadox()
+			// Add a stack for whichever timer isn't expired
+			// Because it was physically impossible to cast UI Paradox before patch 7.05, we don't need an extra patch level check here
+			if (!this.umbralIceTimer.expired) {
+				this.onGainUmbralIceStacks(1)
+			}
+			if (!this.astralFireTimer.expired) {
+				this.onGainAstralFireStacks(1)
+			}
 			break
 		}
 	}
@@ -561,28 +584,6 @@ export class Gauge extends CoreGauge {
 		return Math.floor(time / POLYGLOT_DURATION_REQUIRED)
 	}
 	//#endregion
-
-	/**
-	 * Handles the effects of each kind of event for Paradox:
-	 * - action: Paradox gauge is spent when the action is executed, whether it does damage or not
-	 * - damage: Paradox refreshes the active AF/UI timer when it registers a successful damage event
-	 * @param event The Paradox event
-	 */
-	private handleParadox(event: Events['action'] | Events['damage']) {
-		if (event.type === 'action') {
-			this.paradoxGauge.spend(1)
-		} else if (event.type === 'damage') {
-			// We checked isSuccessfulHit back in onCast, so we don't need to check it again here
-			// Add a stack for whichever timer isn't expired
-			// Because it was physically impossible to cast UI Paradox before patch 7.05, we don't need an extra patch level check here
-			if (!this.umbralIceTimer.expired) {
-				this.onGainUmbralIceStacks(1)
-			}
-			if (!this.astralFireTimer.expired) {
-				this.onGainAstralFireStacks(1)
-			}
-		}
-	}
 
 	override onDeath() {
 		// Not counting the loss towards the rest of the gauge loss, that'll just double up on the suggestions

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -308,6 +308,8 @@ export class Gauge extends CoreGauge {
 			this.onGainParadox()
 			break
 		}
+
+		this.addEvent()
 	}
 
 	// Actions that must do damage to affect gauge state, such as gaining/refreshing AF/UI stacks
@@ -372,6 +374,8 @@ export class Gauge extends CoreGauge {
 			}
 			break
 		}
+
+		this.addEvent()
 	}
 
 	private addEvent() {
@@ -474,8 +478,6 @@ export class Gauge extends CoreGauge {
 
 			this.astralFireTimer.start()
 			this.astralUmbralGauge.generate(ASTRAL_FIRE_HANDLE, stackCount)
-
-			this.addEvent()
 		}
 	}
 
@@ -491,8 +493,6 @@ export class Gauge extends CoreGauge {
 
 			this.paradoxGauge.reset()
 			this.astralSoulGauge.reset()
-
-			this.addEvent()
 		}
 	}
 
@@ -506,8 +506,6 @@ export class Gauge extends CoreGauge {
 		} else { // Otherwise, we're swapping to fire
 			this.onGainAstralFireStacks(1, false)
 		}
-
-		this.addEvent()
 	}
 	//#endregion
 
@@ -520,16 +518,12 @@ export class Gauge extends CoreGauge {
 
 	private gainUmbralHearts(count: number) {
 		this.umbralHeartsGauge.generate(count)
-
-		this.addEvent()
 	}
 
 	private tryConsumeUmbralHearts(count:  number, force: boolean = false) {
 		if (this.umbralHeartsGauge.empty || (this.astralUmbralGauge.getCountAt(ASTRAL_FIRE_HANDLE) === 0 && !force)) { return }
 
 		this.umbralHeartsGauge.spend(count)
-
-		this.addEvent()
 	}
 	//#endregion
 
@@ -550,8 +544,6 @@ export class Gauge extends CoreGauge {
 		this.umbralHeartsGauge.reset()
 
 		this.astralSoulGauge.reset()
-
-		this.addEvent()
 	}
 
 	private onPolyglotTimerComplete() {
@@ -567,8 +559,6 @@ export class Gauge extends CoreGauge {
 		}
 
 		this.polyglotGauge.generate(1)
-
-		this.addEvent()
 	}
 
 	private onConsumePolyglot() {
@@ -581,8 +571,6 @@ export class Gauge extends CoreGauge {
 		}
 
 		this.polyglotGauge.spend(1)
-
-		this.addEvent()
 	}
 
 	private countLostPolyglots(time: number) {
@@ -595,6 +583,8 @@ export class Gauge extends CoreGauge {
 		this.onAstralUmbralEnd(false)
 		this.paradoxGauge.reset()
 		this.polyglotGauge.reset()
+
+		this.addEvent()
 	}
 
 	private onComplete() {


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a GitHub issue: https://github.com/xivanalysis/xivanalysis/issues/2163
- [x] The goal of this PR is detailed below:

Fire 3 when cast with the Firestarter proc available does not consume MP, so it also does not consume an Umbral Heart. BLM's Gauge tracking did not account for this, so it lead to incorrect gauge state information in the timeline, and incorrect Rotation Watchdog suggestions based on the assumed gauge state upon reaching full Astral Fire.

In trying to fix this, I found a bug with the `checkEventWasProc` method in core Procs. #2052 changed the underlying way we tracked proc usages that did worked fine for after-the-fact "was this event a proc?" checks, but didn't account for currently active windows if checked by other modules hooking the event. Adding a check against this return in BLM's Gauge to stop Umbral Heart consumption didn't work until the consuming events for the currently open window were added back into the return. I also made this change for the related functions that check for invulnerable hits.

The only case of this prior to this PR was Reaper refunding Hell's Ingress cooldown, which had no other downstream effects and went unnoticed.

While validating the above Proc bug fix, I noted yet another problem displayed in the Proc Issues table: the High Thunder at 6:10 was being treated as _both_ an invulnerable hit, and a dropped proc.

To fix the second, I updated the check for dropped procs to include invulnerable hits as a "usage" of the proc, so we don't double-ding players if they legitimately hit an invulnerable target...

Unfortunately, on further inspection I found that this _wasn't_ a legitimate invulnerable hit. That High Thunder was the initial hit on one of the FRU intermission crystal adds, which means that hit added a "First Targeted" untargetable end edge at that timestamp. This had the effect of the Invulnerability module treating that hit as an invulnerable hit, respite it dealing damage. To fix this, I modified the "First Targeted" hit hook to put the end edge at the ms prior to the hit.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix: https://xivanalysis.com/fflogs/HwzRZQrPxcnVYfDg/19/35

The things you're looking for:
- Firestarter uses should never cause an Umbral Heart to be consumed on the timeline graph
- The Proc Issues table should not treat the 6:10 High Thunder as either an Invulnerable hit or a Dropped proc.

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
