### PR TITLE
[BugFix] Pneuma's heal shouldn't affect weaving

### DIFF
--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2024-12-05'),
+		Changes: () => <>Ignore Pneuma's secondary heal effect when checking for weaving issues</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-11-16'),
 		Changes: () => <>Add checklist item for Kardia uptime</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/sge/modules/DISPLAY_ORDER.ts
+++ b/src/parser/jobs/sge/modules/DISPLAY_ORDER.ts
@@ -1,6 +1,7 @@
 export enum DISPLAY_ORDER {
 	TINCTURES = 1,
-	ZOE = 2,
-	SWIFTCAST = 3,
-	INTERRUPTS = 4,
+	WEAVING = 2,
+	ZOE = 3,
+	SWIFTCAST = 4,
+	INTERRUPTS = 5,
 }

--- a/src/parser/jobs/sge/modules/Weaving.ts
+++ b/src/parser/jobs/sge/modules/Weaving.ts
@@ -1,0 +1,9 @@
+import {Weaving as CoreWeaving} from 'parser/core/modules/Weaving'
+import {DISPLAY_ORDER} from './DISPLAY_ORDER'
+
+export default class Weaving extends CoreWeaving {
+	static override displayOrder = DISPLAY_ORDER.WEAVING
+
+	// Pneuma's cure isn't a real action, it can't hurt you
+	override ignoredActionIds = [this.data.actions.PNEUMA_HEAL.id]
+}

--- a/src/parser/jobs/sge/modules/index.ts
+++ b/src/parser/jobs/sge/modules/index.ts
@@ -8,6 +8,7 @@ import {Kardia} from './Kardia'
 import {Overheal} from './Overheal'
 import {Swiftcast} from './Swiftcast'
 import {Tincture} from './Tincture'
+import Weaving from './Weaving'
 import {Zoe} from './Zoe'
 
 export default [
@@ -21,5 +22,6 @@ export default [
 	Overheal,
 	Swiftcast,
 	Tincture,
+	Weaving,
 	Zoe,
 ]


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1313730248273039380
- [x] The goal of this PR is detailed below:

When I previously removed the GCD information from the action data for Pneuma's heal effect to fix Sage's uptime calculations, it unintentionally started including it in checks for bad Weaving behavior, now that it looks like a normal oGCD. This PR adds an exclusion to Sage's weaving calculations, modeled after the one we had to set for the similar heal additional effect of Pictomancer's Star Prism.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
 - https://xivanalysis.com/fflogs/Q6JHpmaPcXvYMk4d/15/62

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR