### PR TITLE
[DRK] Fixed a Delirium window bug caused by incorrect status duration

### DIFF
--- a/src/data/STATUSES/root/DRK.ts
+++ b/src/data/STATUSES/root/DRK.ts
@@ -66,7 +66,7 @@ export const DRK = ensureStatuses({
 		id: 3836,
 		name: 'Delirium',
 		icon: iconUrl(217147),
-		duration: 10000,
+		duration: 15000,
 		stacksApplied: 3,
 	},
 	OBLATION: {


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1326269203988090951
- [ ] The goal of this PR is detailed below:

## Testing / Validation

- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:

https://www.fflogs.com/reports/jvPXJhybFYAKR13B#fight=56&source=871 (provided by the reporting user)

## Job Maintenance
- [ ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
