### PR TITLE
[BugFix] Fix Vicepit/Vicewinder status application data

### DIFF
--- a/src/data/ACTIONS/root/VPR.ts
+++ b/src/data/ACTIONS/root/VPR.ts
@@ -647,6 +647,7 @@ export const VPR = ensureActions({
 		name: 'Twinblood Bite',
 		icon: iconUrl(3732),
 		cooldown: 1000,
+		statusesApplied: ['SWIFTSKINS_VENOM'],
 	},
 
 	TWINBLOOD_THRESH: {
@@ -654,6 +655,7 @@ export const VPR = ensureActions({
 		name: 'Twinblood Thresh',
 		icon: iconUrl(3734),
 		cooldown: 1000,
+		statusesApplied: ['HUNTERS_VENOM'],
 	},
 
 	UNCOILED_TWINBLOOD: {
@@ -676,7 +678,7 @@ export const VPR = ensureActions({
 		name: 'Twinfang Bite',
 		icon: iconUrl(3731),
 		cooldown: 1000,
-		statusesApplied: ['SWIFTSKINS_VENOM'],
+		statusesApplied: ['FELLSKINS_VENOM'],
 	},
 
 	TWINFANG_THRESH: {
@@ -684,7 +686,7 @@ export const VPR = ensureActions({
 		name: 'Twinfang Thresh',
 		icon: iconUrl(3733),
 		cooldown: 1000,
-		statusesApplied: ['FELLSKINS_VENOM'],
+		statusesApplied: ['FELLHUNTERS_VENOM'],
 	},
 
 	UNCOILED_TWINFANG: {

--- a/src/data/ACTIONS/root/VPR.ts
+++ b/src/data/ACTIONS/root/VPR.ts
@@ -647,7 +647,7 @@ export const VPR = ensureActions({
 		name: 'Twinblood Bite',
 		icon: iconUrl(3732),
 		cooldown: 1000,
-		statusesApplied: ['SWIFTSKINS_VENOM'],
+		statusesApplied: ['HUNTERS_VENOM'],
 	},
 
 	TWINBLOOD_THRESH: {
@@ -655,7 +655,7 @@ export const VPR = ensureActions({
 		name: 'Twinblood Thresh',
 		icon: iconUrl(3734),
 		cooldown: 1000,
-		statusesApplied: ['HUNTERS_VENOM'],
+		statusesApplied: ['FELLHUNTERS_VENOM'],
 	},
 
 	UNCOILED_TWINBLOOD: {
@@ -678,7 +678,7 @@ export const VPR = ensureActions({
 		name: 'Twinfang Bite',
 		icon: iconUrl(3731),
 		cooldown: 1000,
-		statusesApplied: ['FELLSKINS_VENOM'],
+		statusesApplied: ['SWIFTSKINS_VENOM'],
 	},
 
 	TWINFANG_THRESH: {
@@ -686,7 +686,7 @@ export const VPR = ensureActions({
 		name: 'Twinfang Thresh',
 		icon: iconUrl(3733),
 		cooldown: 1000,
-		statusesApplied: ['FELLHUNTERS_VENOM'],
+		statusesApplied: ['FELLSKINS_VENOM'],
 	},
 
 	UNCOILED_TWINFANG: {

--- a/src/parser/jobs/vpr/changelog.tsx
+++ b/src/parser/jobs/vpr/changelog.tsx
@@ -4,6 +4,11 @@ import React from 'react'
 
 export const changelog = [
 	{
+		date: new Date('2025-01-29'),
+		Changes: () => <>Fix a data error that was causing phantom prepull uses of <DataLink action="VICEWINDER"/> and <DataLink action="VICEPIT"/> follow-up GCDs to be recorded.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-11-16'),
 		Changes: () => <>Add a table displaying timestamps when procs were dropped or overwritten, for better clarity around when those issues occurred.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [ ] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1334268079097516093
- [x] The goal of this PR is detailed below:

The `statusesApplied` arrays for VPR's Vicewinder/Vicepit followup GCD/double oGCD combos were:
- Only attributing the "which oGCD is the stronger one" Venom status effects for the single target actions to the GCD that lead into the oGCD combo, when they are also applied by the other oGCD, depending on which GCD lead into the pair
- Attributed the AoE oGCD Venom statuses to the wrong oGCD

The net effect of this is we were pretty much always synthing a prepull action of one of the two GCDs. The Gauge impact of this was hidden before #2165 moved the gauge initialization event, but it's become a more visible problem now.

Correcting the data now means that we have two matching actions that could apply each status effect, which will stop the `prepullStatuses` adapter from incorrectly synthesizing an action before the start of the pull

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
https://xivanalysis.com/fflogs/RxZqc14PGpyAvQk2/2/13

## Job Maintenance
- [x] I am active on the xivanalysis Discord