### PR TITLE
[BugFix] Fix Overheal divide by zero error

### DIFF
--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -339,7 +339,7 @@ export class Overheal extends Analyser {
 				overhealtotal += x.overheal
 			}
 		})
-		const overallOverhealPercent: number = 100 * overhealtotal / healtotal
+		const overallOverhealPercent: number = (healtotal === 0) ? 0 : 100 * overhealtotal / healtotal
 
 		if (this.displayChecklist) {
 			const requirements: InvertedRequirement[] = []


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] The goal of this PR is detailed below:

Thanks to the narrowing of what overheal buckets get checklisted, a hyper-optimized log actually stands a decent chance of not having any heals at all in the checklisted buckets. If this happens, the overall overheal percentage gets calculated as `NaN` due to a divide by zero error, which causes the checklist to present it as a 100% overheal/0% checklist requirement value... :facepalm: 

![image](https://github.com/user-attachments/assets/c3a5cc6a-1d38-4a71-85fe-5e2b38ddb56f)

This PR just guards against that possibility by setting the overheal percentage to 0 if no total healing from the checklisted buckets occurs.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
https://xivanalysis.com/fflogs/w34CWt2KjPrzTamq/5/75

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR