### PR TITLE
Overheal fine tuning

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -359,7 +359,7 @@
   "core.lucid-dreaming.suggestion.why": "{usesMissed, plural, one {# use} other {# uses}} of Lucid Dreaming {usesMissed, plural, one {was} other {were}} missed by holding it for at least a total of {0}.",
   "core.overheal.abilities-direct.name": "Direct Healing Abilities",
   "core.overheal.abilities-other.name": "Other Healing Abilities",
-  "core.overheal.gcd-hot.name": "GCD Heals (including Healing over Time)",
+  "core.overheal.gcd-hot.name": "Healing over Time from GCD Spells",
   "core.overheal.header.content": "\nOverhealing is unavoidable even with optimized usage of your actions, but it can\nalso be a result of poor planning. As such, overhealing must be analyzed on a\ncase-by-case basis.\n\nThe below tables will show you which actions overhealed. Focus on reducing the\noverheal percentage of the categories included in the checklist first. The other\ncategories typically have secondary purposes, or may overheal as an incidental\npart of a complete defensive plan.\n",
   "core.overheal.requirement.all": "Overall",
   "core.overheal.rule.description": "Avoid healing your party for more than is needed. Cut back on unnecessary heals and coordinate with your co-healer to plan resources efficiently.",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -359,7 +359,7 @@
   "core.lucid-dreaming.suggestion.why": "{usesMissed, plural, one {# utilisation} other {# utilisations}} de Rêve lucide {usesMissed, plural, one {a été manquée} other {ont été manquées}} en le laissant disponible pendant au moins {0}.",
   "core.overheal.abilities-direct.name": "Aptitudes de Soin Direct",
   "core.overheal.abilities-other.name": "Autres aptitudes de Soin",
-  "core.overheal.gcd-hot.name": "GCD de Soin (en incluant le soin sur la durée)",
+  "core.overheal.gcd-hot.name": "",
   "core.overheal.header.content": "\nL'overheal est impossible à éviter, même avec une utilisation optimisée de vos actions, mais peut aussi être induit par une mauvaise planification de vos soins. Par conséquent, l'overhealing doit être analysé au cas par cas.\n\nLes tableaux ci-dessous montrent quelles actions ont provoqué du overheal. Essayez de réduire le pourcentage d'overheal dans les catégories de la checklist en priorité. Les actions présentes dans les autres catégories ont généralement d'autres utilités, et leur action de soin n'est généralement pas le principal effet recherché lors de leur utilisation.\n",
   "core.overheal.requirement.all": "Généralités",
   "core.overheal.rule.description": "Ne soignez pas votre équipe davantage que nécessaire. Coordonnez-vous avec votre co-healer pour diminuer la quantité de soins effectués et planifier vos ressources de façon efficace.",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -359,7 +359,7 @@
   "core.lucid-dreaming.suggestion.why": "因为CD空转了至少 {0}，你大约少用了 {usesMissed, plural, other {#}} {usesMissed, plural, other {次}}醒梦。",
   "core.overheal.abilities-direct.name": "直接治疗能力技",
   "core.overheal.abilities-other.name": "其他治疗能力技",
-  "core.overheal.gcd-hot.name": "GCD治疗 (包括持续治疗)",
+  "core.overheal.gcd-hot.name": "",
   "core.overheal.header.content": "\n过量治疗在最优和不佳的治疗技能规划下均会存在，因此必须逐例分析，不能一概而论。\n\n下表中列出了你的技能过量治疗数据。优先减少列表中第一类的过量治疗比例，其他类别中的治疗可能存在预防措施之类的其他用途。\n",
   "core.overheal.requirement.all": "总览",
   "core.overheal.rule.description": "注意避免过量治疗你的队伍，减少不必要的治疗，并和你的搭档沟通协调，最大化利用治疗资源。",

--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -348,7 +348,7 @@ export class Overheal extends Analyser {
 
 	// Treat events before the pull or when the boss is untargetable as downtime events
 	protected isDowntimeEvent(event: Event) {
-		return this.parser.currentEpochTimestamp < this.parser.pull.timestamp || this.invulnerability.isActive({timestamp: event.timestamp, types: ['untargetable']})
+		return event.timestamp < this.parser.pull.timestamp || this.invulnerability.isActive({timestamp: event.timestamp, types: ['untargetable']})
 	}
 
 	private onComplete() {

--- a/src/parser/core/modules/Overheal.tsx
+++ b/src/parser/core/modules/Overheal.tsx
@@ -16,6 +16,7 @@ import {Accordion, Icon, Message, Table} from 'semantic-ui-react'
 import {isDefined} from 'utilities'
 import {Actors} from './Actors'
 import DISPLAY_ORDER from './DISPLAY_ORDER'
+import {Invulnerability} from './Invulnerability'
 
 export interface TrackedOverhealOpts {
 	bucketId?: number
@@ -168,6 +169,7 @@ export class Overheal extends Analyser {
 	@dependency private checklist!: Checklist
 	@dependency protected data!: Data
 	@dependency protected actors!: Actors
+	@dependency private invulnerability!: Invulnerability
 
 	// Overall tracking options
 
@@ -179,7 +181,7 @@ export class Overheal extends Analyser {
 	protected defaultCategoryNames = {
 		// Yes this is from SGE since I didn't want to force re-translation after this update
 		DIRECT_GCD_HEALS: <Trans id="sge.overheal.direct.name">GCD Heals</Trans>,
-		DIRECT_AND_REGEN_GCD_HEALS: <Trans id="core.overheal.gcd-hot.name">GCD Heals (including Healing over Time)</Trans>,
+		OVER_TIME_GCD_HEALS: <Trans id="core.overheal.gcd-hot.name">Healing over Time from GCD Spells</Trans>,
 		DIRECT_HEALING_ABILITIES: <Trans id="core.overheal.abilities-direct.name">Direct Healing Abilities</Trans>,
 		// Similarly snitched from AST
 		HEALING_OVER_TIME: <Trans id="ast.overheal.hot.name">Healing over Time</Trans>,
@@ -244,6 +246,8 @@ export class Overheal extends Analyser {
 		return <Trans id="core.overheal.suggestion.why">You had an overheal of { overhealPercent.toFixed(2) }%</Trans>
 	}
 
+	protected statusAppliedInDowntime: Map<Status['id'], boolean> = new Map()
+
 	override initialise() {
 		this.uncategorized = new TrackedOverheal({
 			name: this.uncategorizedOverheals,
@@ -259,6 +263,15 @@ export class Overheal extends Analyser {
 			.filter(actor => actor.owner != null && actor.owner.id === this.parser.actor.id)
 			.map(pet => pet.id)
 		this.addEventHook(filter<Event>().type('heal').source(oneOf(actorPets)), this.onPetHeal)
+
+		const healStatuses = this.trackedHealCategories.reduce<number[]>((acc, category) => {
+			const categoryStatusHeals = (category.trackedHealIds ?? []).filter((healId) => getDataBy(this.data.statuses, 'id', healId))
+			acc.push(...categoryStatusHeals)
+			return acc
+		}, [])
+		this.addEventHook(filter<Event>().type('statusApply').source(this.parser.actor.id)
+			.status(oneOf(healStatuses)), this.onHealStatusApply)
+
 		this.addEventHook('complete', this.onComplete)
 	}
 
@@ -327,6 +340,15 @@ export class Overheal extends Analyser {
 
 	private onPetHeal(event: Events['heal']) {
 		this.onHeal(event, true)
+	}
+
+	private onHealStatusApply(event: Events['statusApply']) {
+		this.statusAppliedInDowntime.set(event.status, this.isDowntimeEvent(event))
+	}
+
+	// Treat events before the pull or when the boss is untargetable as downtime events
+	protected isDowntimeEvent(event: Event) {
+		return this.parser.currentEpochTimestamp < this.parser.pull.timestamp || this.invulnerability.isActive({timestamp: event.timestamp, types: ['untargetable']})
 	}
 
 	private onComplete() {

--- a/src/parser/jobs/ast/changelog.tsx
+++ b/src/parser/jobs/ast/changelog.tsx
@@ -3,6 +3,11 @@ import CONTRIBUTORS from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2025-02-07'),
+		Changes: () => <>Split the direct healing effects of GCDs up from the regen effects they apply, and ignore them if they were applied before the pull or during downtime.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-08-24'),
 		Changes: () => <>Added <DataLink action={'LIGHTSPEED'} /> and <DataLink action={'SWIFTCAST'} /> to defensives. </>,
 		contributors: [CONTRIBUTORS.OTOCEPHALY],

--- a/src/parser/jobs/ast/modules/Overheal.tsx
+++ b/src/parser/jobs/ast/modules/Overheal.tsx
@@ -18,18 +18,27 @@ export class Overheal extends CoreOverheal {
 
 	protected override trackedHealCategories: TrackedOverhealOpts[] = [
 		{
-			name: this.defaultCategoryNames.DIRECT_AND_REGEN_GCD_HEALS,
+			name: this.defaultCategoryNames.DIRECT_GCD_HEALS,
 			trackedHealIds: [
 				// Single-Target
 				this.data.actions.BENEFIC.id,
 				this.data.actions.ASPECTED_BENEFIC.id,
-				this.data.statuses.ASPECTED_BENEFIC.id,
 
 				// AoE
 				this.data.actions.HELIOS.id,
 				this.data.actions.ASPECTED_HELIOS.id,
-				this.data.statuses.ASPECTED_HELIOS.id,
 				this.data.actions.HELIOS_CONJUNCTION.id,
+			],
+			includeInChecklist: true,
+		},
+		{
+			name: this.defaultCategoryNames.OVER_TIME_GCD_HEALS,
+			trackedHealIds: [
+				// Single-Target
+				this.data.statuses.ASPECTED_BENEFIC.id,
+
+				// AoE
+				this.data.statuses.ASPECTED_HELIOS.id,
 				this.data.statuses.HELIOS_CONJUNCTION.id,
 			],
 			includeInChecklist: true,

--- a/src/parser/jobs/ast/modules/Overheal.tsx
+++ b/src/parser/jobs/ast/modules/Overheal.tsx
@@ -89,6 +89,24 @@ export class Overheal extends CoreOverheal {
 		},
 	]
 
+	protected override considerHeal(event: Events['heal'], pet?: boolean): boolean {
+		// Default consideration for heals from actions and pet effects (ie. Star)
+		if (event.cause.type === 'action' || pet) { return true }
+
+		// If this heal status effect was not part of the GCD regen group, consider it like normal
+		if (!this.trackedHealCategories.find((group) =>
+			group.name === this.defaultCategoryNames.OVER_TIME_GCD_HEALS)?.trackedHealIds?.includes(event.cause.status)) {
+			return true
+		}
+
+		// If the status effect was last applied during downtime, we'll ignore it
+		if (this.statusAppliedInDowntime.get(event.cause.status)) {
+			return false
+		}
+
+		return true
+	}
+
 	protected override overrideHealBucket(event: Events['heal'], petHeal?: boolean): number {
 		// Star heals don't need re-bucketing
 		if (petHeal) { return -1 }

--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -7,6 +7,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2025-02-07'),
+		Changes: () => <>Ignore overheal from Eukrasian Diagnosis cast during downtime since it can impact Addersting generation</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-12-05'),
 		Changes: () => <>Ignore Pneuma's secondary heal effect when checking for weaving issues</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/sge/modules/Overheal.tsx
+++ b/src/parser/jobs/sge/modules/Overheal.tsx
@@ -93,10 +93,12 @@ export class Overheal extends CoreOverheal {
 		// Ignore Eukrasian Diagnosis heals when no targets were available
 		// They are probably overwriting for Addersting generation
 		// Do consider it if the target already had a Eukrasian Diagnosis shield though, since that's a waste of time MP to re-apply it
-		if (event.cause.type === 'action' &&
+		if (
+			event.cause.type === 'action' &&
 			event.cause.action === this.data.actions.EUKRASIAN_DIAGNOSIS.id &&
-			event.targets.filter((targetEvent) => this.actors.get(targetEvent.target).hasStatus(this.data.statuses.EUKRASIAN_DIAGNOSIS.id)).length === 0 &&
-			this.isDowntimeEvent(event)) {
+			!event.targets.some((targetEvent) => this.actors.get(targetEvent.target).hasStatus(this.data.statuses.EUKRASIAN_DIAGNOSIS.id)) &&
+			this.isDowntimeEvent(event)
+		) {
 			return false
 		}
 

--- a/src/parser/jobs/sge/modules/Overheal.tsx
+++ b/src/parser/jobs/sge/modules/Overheal.tsx
@@ -89,6 +89,21 @@ export class Overheal extends CoreOverheal {
 		},
 	]
 
+	protected override considerHeal(event: Events['heal'], _pet?: boolean): boolean {
+		// Ignore Eukrasian Diagnosis heals when no targets were available
+		// They are probably overwriting for Addersting generation
+		// Do consider it if the target already had a Eukrasian Diagnosis shield though, since that's a waste of time MP to re-apply it
+		if (event.cause.type === 'action' &&
+			event.cause.action === this.data.actions.EUKRASIAN_DIAGNOSIS.id &&
+			event.targets.filter((targetEvent) => this.actors.get(targetEvent.target).hasStatus(this.data.statuses.EUKRASIAN_DIAGNOSIS.id)).length === 0 &&
+			this.isDowntimeEvent(event)) {
+			return false
+		}
+
+		// Consider all other heals
+		return true
+	}
+
 	protected override overrideHealBucket(event: Events['heal'], petHeal?: boolean): number {
 		// SGE doesn't have pet heals, but if they did, we wouldn't re-bucket
 		if (petHeal) { return -1 }

--- a/src/parser/jobs/whm/changelog.tsx
+++ b/src/parser/jobs/whm/changelog.tsx
@@ -2,6 +2,11 @@ import CONTRIBUTORS from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2025-02-07'),
+		Changes: () => <>Split the direct healing effects of GCDs up from the regen effects they apply.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2024-07-22'),
 		Changes: () => <>Added tracking for unused Divine Caress procs</>,
 		contributors: [CONTRIBUTORS.INNI],

--- a/src/parser/jobs/whm/modules/Overheal.tsx
+++ b/src/parser/jobs/whm/modules/Overheal.tsx
@@ -1,4 +1,5 @@
 import {Trans} from '@lingui/react'
+import {Events} from 'event'
 import {Overheal as CoreOverheal, TrackedOverhealOpts} from 'parser/core/modules/Overheal'
 
 export class Overheal extends CoreOverheal {
@@ -70,4 +71,22 @@ export class Overheal extends CoreOverheal {
 			],
 		},
 	]
+
+	protected override considerHeal(event: Events['heal'], pet?: boolean): boolean {
+		// Default consideration for heals from actions and pet effects (ie. Star)
+		if (event.cause.type === 'action' || pet) { return true }
+
+		// If this heal status effect was not part of the GCD regen group, consider it like normal
+		if (!this.trackedHealCategories.find((group) =>
+			group.name === this.defaultCategoryNames.OVER_TIME_GCD_HEALS)?.trackedHealIds?.includes(event.cause.status)) {
+			return true
+		}
+
+		// If the status effect was last applied during downtime, we'll ignore it
+		if (this.statusAppliedInDowntime.get(event.cause.status)) {
+			return false
+		}
+
+		return true
+	}
 }

--- a/src/parser/jobs/whm/modules/Overheal.tsx
+++ b/src/parser/jobs/whm/modules/Overheal.tsx
@@ -4,20 +4,29 @@ import {Overheal as CoreOverheal, TrackedOverhealOpts} from 'parser/core/modules
 export class Overheal extends CoreOverheal {
 	protected override trackedHealCategories: TrackedOverhealOpts[] = [
 		{
-			name: this.defaultCategoryNames.DIRECT_AND_REGEN_GCD_HEALS,
+			name: this.defaultCategoryNames.DIRECT_GCD_HEALS,
 			trackedHealIds: [
 				// Single-Target
 				this.data.actions.CURE.id,
 				this.data.actions.CURE_II.id,
-				this.data.statuses.REGEN.id,
 
 				// AoE
 				this.data.actions.MEDICA.id,
 				this.data.actions.MEDICA_II.id,
-				this.data.statuses.MEDICA_II.id,
 				this.data.actions.MEDICA_III.id,
-				this.data.statuses.MEDICA_III.id,
 				this.data.actions.CURE_III.id,
+			],
+			includeInChecklist: true,
+		},
+		{
+			name: this.defaultCategoryNames.OVER_TIME_GCD_HEALS,
+			trackedHealIds: [
+				// Single-Target
+				this.data.statuses.REGEN.id,
+
+				// AoE
+				this.data.statuses.MEDICA_II.id,
+				this.data.statuses.MEDICA_III.id,
 			],
 			includeInChecklist: true,
 		},


### PR DESCRIPTION
## Pull request type

- [x] This is new functionality or an addition to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1335039127309123624
- [x] The goal of this PR is detailed below:

- Splits Healing over Time effects applied by GCD actions into a separate bucket, to make it easier to distinguish whether overheal was coming directly from the action itself, or from the HoT after the fact
  - Affects WHM and AST
- Add functionality to track whether a HoT status effect was most recently applied by a cast during downtime, and ignore ticks associated with that application
  - Affects WHM and AST
- Ignore Eukrasian Diagnosis casts during downtime, when the target did not already have Eukrasian Diagnosis applied (Addersting generation)
  - Affects SGE

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
  - AST: http://localhost:3000/fflogs/w34CWt2KjPrzTamq/5/95
  - WHM: http://localhost:3000/fflogs/LYAjxvBPpz9tVKC4/3/115
  - SGE: http://localhost:3000/fflogs/91RhxFWmYXcbvgPa/40/4
    - At minimum, the EDiag at ~43s counts as a downtime shield, I didn't check beyond that

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
