### PR TITLE
Set and check for explicit permissible prepull time window for events

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -355,6 +355,8 @@
   "core.interrupts.table.cast": "Anwendungen",
   "core.interrupts.table.time": "Zeit",
   "core.interrupts.title": "Unterbrochene Anwendungen",
+  "core.invalid-event.title": "",
+  "core.invalid-event.trigger.invalid-timestamp": "",
   "core.lucid-dreaming.suggestion.content": "",
   "core.lucid-dreaming.suggestion.why": "",
   "core.overheal.abilities-direct.name": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -355,6 +355,8 @@
   "core.interrupts.table.cast": "Cast",
   "core.interrupts.table.time": "Time",
   "core.interrupts.title": "Interrupted Casts",
+  "core.invalid-event.title": "Invalid Event",
+  "core.invalid-event.trigger.invalid-timestamp": "An event occured outside the permissible time window for the pull.",
   "core.lucid-dreaming.suggestion.content": "Try to keep <0/> on cooldown for better MP management.",
   "core.lucid-dreaming.suggestion.why": "{usesMissed, plural, one {# use} other {# uses}} of Lucid Dreaming {usesMissed, plural, one {was} other {were}} missed by holding it for at least a total of {0}.",
   "core.overheal.abilities-direct.name": "Direct Healing Abilities",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -355,6 +355,8 @@
   "core.interrupts.table.cast": "Incantation",
   "core.interrupts.table.time": "Temps",
   "core.interrupts.title": "Incantations interrompues",
+  "core.invalid-event.title": "",
+  "core.invalid-event.trigger.invalid-timestamp": "",
   "core.lucid-dreaming.suggestion.content": "Essayer de garder <0/> en rechargement pour une meilleure gestion de votre mana.",
   "core.lucid-dreaming.suggestion.why": "{usesMissed, plural, one {# utilisation} other {# utilisations}} de Rêve lucide {usesMissed, plural, one {a été manquée} other {ont été manquées}} en le laissant disponible pendant au moins {0}.",
   "core.overheal.abilities-direct.name": "Aptitudes de Soin Direct",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -355,6 +355,8 @@
   "core.interrupts.table.cast": "キャスト",
   "core.interrupts.table.time": "タイム",
   "core.interrupts.title": "詠唱中断",
+  "core.invalid-event.title": "",
+  "core.invalid-event.trigger.invalid-timestamp": "",
   "core.lucid-dreaming.suggestion.content": "MP管理を良くするために、<0/>をリキャストごとに使いましょう。",
   "core.lucid-dreaming.suggestion.why": "",
   "core.overheal.abilities-direct.name": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -355,6 +355,8 @@
   "core.interrupts.table.cast": "시전",
   "core.interrupts.table.time": "시간",
   "core.interrupts.title": "중단된 시전 기술",
+  "core.invalid-event.title": "",
+  "core.invalid-event.trigger.invalid-timestamp": "",
   "core.lucid-dreaming.suggestion.content": "",
   "core.lucid-dreaming.suggestion.why": "",
   "core.overheal.abilities-direct.name": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -355,6 +355,8 @@
   "core.interrupts.table.cast": "咏唱",
   "core.interrupts.table.time": "时间",
   "core.interrupts.title": "中断的咏唱",
+  "core.invalid-event.title": "",
+  "core.invalid-event.trigger.invalid-timestamp": "",
   "core.lucid-dreaming.suggestion.content": "尽可能保持 <0/> 不空转以增加可用的MP。",
   "core.lucid-dreaming.suggestion.why": "因为CD空转了至少 {0}，你大约少用了 {usesMissed, plural, other {#}} {usesMissed, plural, other {次}}醒梦。",
   "core.overheal.abilities-direct.name": "直接治疗能力技",

--- a/src/event.ts
+++ b/src/event.ts
@@ -45,6 +45,20 @@ export type Events = MergeType<EventTypeRepository>
 /** Union of every event type declared throughout the application. */
 export type Event = Events[keyof EventTypeRepository]
 
+/**
+ * The time window before the pull in which events are considered valid.
+ *
+ * Some events may occur prior to the official start point of a pull
+ * (`pull.timestamp`), such as the `prepare` for an `action` cast on, or shortly
+ * after, the pull.
+ *
+ * Parser logic may need to make assumptions about a point in time that is prior
+ * to any events in a pull. As the parser ensures that no event prior to this
+ * window exists, it is safe to assume that any timestamps synthesised outside
+ * the window will be before all events.
+ */
+export const PREPULL_EVENT_WINDOW = 10_000
+
 // -----
 // #region Core xivanalysis parser event definitions.
 // -----

--- a/src/parser/core/modules/BrokenLog.tsx
+++ b/src/parser/core/modules/BrokenLog.tsx
@@ -7,8 +7,6 @@ import {getReportPatch} from 'data/PATCHES'
 import {ReactNode} from 'react'
 import {Table} from 'semantic-ui-react'
 import {Analyser, DisplayMode} from '../Analyser'
-import {dependency} from '../Injectable'
-import {Data} from './Data'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 
 interface Trigger {
@@ -21,8 +19,6 @@ export class BrokenLog extends Analyser {
 	static override title = t('core.broken-log.title')`Broken Log`
 	static override displayOrder = DISPLAY_ORDER.BROKEN_LOG
 	static override displayMode = DisplayMode.RAW
-
-	@dependency private data!: Data
 
 	private triggers = new Map<string, Trigger>()
 
@@ -69,24 +65,6 @@ export class BrokenLog extends Analyser {
 			source: constructor,
 			reason,
 		})
-	}
-
-	override initialise() {
-		const unknownAction = this.data.actions.UNKNOWN.id
-		this.addEventHook({cause: {type: 'action', action: unknownAction}}, this.triggerUnknownCause)
-		this.addEventHook({action: unknownAction}, this.triggerUnknownCause)
-
-		const unknownStatus = this.data.statuses.UNKNOWN.id
-		this.addEventHook({cause: {type: 'status', status: unknownStatus}}, this.triggerUnknownCause)
-		this.addEventHook({status: unknownStatus}, this.triggerUnknownCause)
-	}
-
-	private triggerUnknownCause() {
-		this.trigger(this, 'unknown action', (
-			<Trans id="core.broken-log.trigger.unknown-action">
-				One or more actions were recorded incorrectly, and could not be parsed.
-			</Trans>
-		))
 	}
 
 	override output() {

--- a/src/parser/core/modules/Gauge/CounterGauge.ts
+++ b/src/parser/core/modules/Gauge/CounterGauge.ts
@@ -1,3 +1,4 @@
+import {PREPULL_EVENT_WINDOW} from 'event'
 import _ from 'lodash'
 import {ReactNode} from 'react'
 import {AbstractGauge, AbstractGaugeOptions} from './AbstractGauge'
@@ -130,7 +131,7 @@ export class CounterGauge extends AbstractGauge {
 		// Ensure we have a gauge init event, can't do in constructor because the parser reference might not be there yet
 		if (this.history.length === 0) {
 			this.history.push({
-				timestamp: -1,
+				timestamp: this.parser.pull.timestamp - PREPULL_EVENT_WINDOW,
 				value: this.initialValue,
 				minimum: this.minimum,
 				maximum: this.maximum,

--- a/src/parser/core/modules/Gauge/EnumGauge.ts
+++ b/src/parser/core/modules/Gauge/EnumGauge.ts
@@ -1,4 +1,5 @@
 import Color from 'color'
+import {PREPULL_EVENT_WINDOW} from 'event'
 import _ from 'lodash'
 import {ReactNode} from 'react'
 import {AbstractGauge, AbstractGaugeOptions} from './AbstractGauge'
@@ -102,7 +103,7 @@ export class EnumGauge extends AbstractGauge {
 		// Ensure we have a gauge init event, can't do in constructor because the parser reference might not be there yet
 		if (this.history.length === 0) {
 			this.history.push({
-				timestamp: -1,
+				timestamp: this.parser.pull.timestamp - PREPULL_EVENT_WINDOW,
 				values: [],
 				reason: 'init',
 			})

--- a/src/parser/core/modules/Gauge/SetEnumGauge.ts
+++ b/src/parser/core/modules/Gauge/SetEnumGauge.ts
@@ -1,3 +1,4 @@
+import {PREPULL_EVENT_WINDOW} from 'event'
 import _ from 'lodash'
 import {AbstractGauge, AbstractGaugeOptions} from './AbstractGauge'
 import {GaugeEventReason} from './CounterGauge'
@@ -103,7 +104,7 @@ export class SetEnumGauge extends AbstractGauge {
 		// Ensure we have a gauge init event, can't do in constructor because the parser reference might not be there yet
 		if (this.history.length === 0) {
 			this.history.push({
-				timestamp: -1,
+				timestamp: this.parser.pull.timestamp - PREPULL_EVENT_WINDOW,
 				groups: [],
 				reason: 'init',
 			})

--- a/src/parser/core/modules/Gauge/SetGauge.ts
+++ b/src/parser/core/modules/Gauge/SetGauge.ts
@@ -1,4 +1,5 @@
 import Color from 'color'
+import {PREPULL_EVENT_WINDOW} from 'event'
 import _ from 'lodash'
 import {ReactNode} from 'react'
 import {AbstractGauge, AbstractGaugeOptions} from './AbstractGauge'
@@ -98,7 +99,7 @@ export class SetGauge extends AbstractGauge {
 		// Ensure we have a gauge init event, can't do in constructor because the parser reference might not be there yet
 		if (this.history.length === 0) {
 			this.history.push({
-				timestamp: -1,
+				timestamp: this.parser.pull.timestamp - PREPULL_EVENT_WINDOW,
 				values: [],
 				reason: 'init',
 			})

--- a/src/parser/core/modules/InvalidEvent.tsx
+++ b/src/parser/core/modules/InvalidEvent.tsx
@@ -1,0 +1,36 @@
+import {t} from "@lingui/macro"
+import {Trans} from "@lingui/react"
+import {Event, PREPULL_EVENT_WINDOW} from "event"
+import {Analyser} from "../Analyser"
+import {dependency} from "../Injectable"
+import {BrokenLog} from "./BrokenLog"
+
+export class InvalidEvent extends Analyser {
+	static override handle = 'invalidEvent'
+	static override title = t('core.invalid-event.title')`Invalid Event`
+
+	@dependency private brokenLog!: BrokenLog
+
+	override initialise(): void {
+		const firstEventHook = this.addEventHook(
+			(event): event is Event => true,
+			event => {
+				this.removeEventHook(firstEventHook)
+				this.onFirstEvent(event)
+			}
+		)
+	}
+
+	private onFirstEvent(event: Event) {
+		// If the timestamp is inside the window, we've got nothing to worry about.
+		if (event.timestamp >= this.parser.pull.timestamp - PREPULL_EVENT_WINDOW) {
+			return
+		}
+
+		this.brokenLog.trigger(this, 'invalid timestamp', (
+			<Trans id="core.invalid-event.trigger.invalid-timestamp">
+				An event occured outside the permissible time window for the pull.
+			</Trans>
+		))
+	}
+}

--- a/src/parser/core/modules/InvalidEvent.tsx
+++ b/src/parser/core/modules/InvalidEvent.tsx
@@ -4,14 +4,25 @@ import {Event, PREPULL_EVENT_WINDOW} from "event"
 import {Analyser} from "../Analyser"
 import {dependency} from "../Injectable"
 import {BrokenLog} from "./BrokenLog"
+import {Data} from "./Data"
 
 export class InvalidEvent extends Analyser {
 	static override handle = 'invalidEvent'
 	static override title = t('core.invalid-event.title')`Invalid Event`
 
 	@dependency private brokenLog!: BrokenLog
+	@dependency private data!: Data
 
 	override initialise(): void {
+		const unknownAction = this.data.actions.UNKNOWN.id
+		this.addEventHook({cause: {type: 'action', action: unknownAction}}, this.triggerUnknownCause)
+		this.addEventHook({action: unknownAction}, this.triggerUnknownCause)
+
+		const unknownStatus = this.data.statuses.UNKNOWN.id
+		this.addEventHook({cause: {type: 'status', status: unknownStatus}}, this.triggerUnknownCause)
+		this.addEventHook({status: unknownStatus}, this.triggerUnknownCause)
+
+		// Listen to all events, but unhook after the first fire.
 		const firstEventHook = this.addEventHook(
 			(event): event is Event => true,
 			event => {
@@ -19,6 +30,14 @@ export class InvalidEvent extends Analyser {
 				this.onFirstEvent(event)
 			}
 		)
+	}
+
+	private triggerUnknownCause() {
+		this.brokenLog.trigger(this, 'unknown action', (
+			<Trans id="core.broken-log.trigger.unknown-action">
+					One or more actions were recorded incorrectly, and could not be parsed.
+			</Trans>
+		))
 	}
 
 	private onFirstEvent(event: Event) {

--- a/src/parser/core/modules/index.ts
+++ b/src/parser/core/modules/index.ts
@@ -16,6 +16,7 @@ import {Dummy} from './Dummy'
 import {EventsView} from './EventsView'
 import {GlobalCooldown} from './GlobalCooldown'
 import {Hijinks} from './Hijinks'
+import {InvalidEvent} from './InvalidEvent'
 import {Invulnerability} from './Invulnerability'
 import {Medicated} from './Medicated'
 import {RaidBuffs} from './RaidBuffs'
@@ -48,6 +49,7 @@ export const modules = [
 	EventsView,
 	GlobalCooldown,
 	Hijinks,
+	InvalidEvent,
 	Invulnerability,
 	Medicated,
 	RaidBuffs,


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/441424599310270464/1338498291507269725
- [x] The goal of this PR is detailed below:

Firefox's SVG renderer doesn't like it when a clip path that's almost entirely within the 0..1 domain has a few random points out at negative four million units. don't understand it, myself. pah.

Unfortunately, a timestamp of `-1` as used by some gauges results in said negative four million, which causes a lot of gauge graphs to break in firefox:
![image](https://github.com/user-attachments/assets/0ce845fc-2544-4e7c-b085-255a668a18e7)
Timer gauges are immune as they don't use the `-1` history synth.

This PR introduces `PREPULL_EVENT_WINDOW`, currently set to 10 seconds. All events that occur prior to the pull _must_ happen in this window - an event that occurs outside the window will trigger a broken log entry immediately.

This is more than reasonably necessary in the current analysis environment, and gives us plenty of room to work with for adapter-space synthesis. Should something upstream trip this, sentry should notify us.

The window also gives us an explicit value to utilise in instances such as gauge where we need an arbitrary point in time before any event have occured.

After:
![image](https://github.com/user-attachments/assets/ab158a9d-f586-40b3-a708-835d420a2cf5)

## Testing / Validation

<!-- If this PR contains any new functionality or bugfixes, please include log links that reviewers can use to help verify your changes.  Reviewers may also find additional logs to check your PR with, but having initial logs is important to speed the review process, especially for corner cases or hard to trigger analysis flags.  If this PR is a patch bump with no changes or potency only changes, you can delete this section. -->
- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:

https://xivanalysis.com/fflogs/a:AWazdhxbq97M6JVc/4/11

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [x] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
