### PR TITLE
fix: patch the SequenceID value for miss actions when cleaving invuln targets

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2025-02-12'),
+		Changes: () => <>Fixed an issue that caused AOE attacks to incorrectly report broken combos if they cleaved an invulnerable target.</>,
+		contributors: [CONTRIBUTORS.AZARIAH],
+	},
+	{
 		date: new Date('2025-01-28'),
 		Changes: () => <>Fix recently introduced checklist requirement bugs.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/adapter.ts
@@ -7,6 +7,7 @@ import {DeduplicateActorUpdateStep} from './deduplicateActorUpdates'
 import {DeduplicateAoEStep} from './deduplicateAoE'
 import {DeduplicateStatusApplicationStep} from './deduplicateStatus'
 import {ErroneousFriendDeathAdapterStep} from './erroneousFriendDeath'
+import {FixMissEventSequenceIDStep} from './fixMissEventSequenceID'
 import {InterruptsAdapterStep} from './interrupts'
 import {MergeActorInstancesStep} from './mergeActorInstance'
 import {OneHpLockAdapterStep} from './oneHpLock'
@@ -36,6 +37,7 @@ class EventAdapter {
 			new ReassignUnknownActorStep(opts),
 			new MergeActorInstancesStep(opts),
 			new TranslateAdapterStep(opts),
+			new FixMissEventSequenceIDStep(opts),
 			new ErroneousFriendDeathAdapterStep(opts),
 			new AssignOverhealStep(opts),
 			new InterruptsAdapterStep(opts),

--- a/src/reportSources/legacyFflogs/eventAdapter/fixMissEventSequenceID.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/fixMissEventSequenceID.ts
@@ -1,6 +1,7 @@
-import {Cause, Event} from 'event'
-import {filter} from 'parser/core/filter'
+import {Action} from 'data/ACTIONS'
+import {Event, Events} from 'event'
 import {AdapterStep} from './base'
+import {FflogsEvent} from '../eventTypes'
 
 /**
  * FFLogs models damage events that hit multiple targets as separate events with the same SequenceID and timestamp.
@@ -9,23 +10,65 @@ import {AdapterStep} from './base'
  * NOTE: this adapter step MUST run before DeduplicateAoEStep or it won't have any effect
  */
 export class FixMissEventSequenceIDStep extends AdapterStep {
-	override postprocess(adaptedEvents: Event[]) {
-		const actionEventFilter = filter<Event>().type('damage').cause(filter<Cause>().type('action'))
-		const actionEvents = adaptedEvents.filter(actionEventFilter)
+	private lastTimestamp = -1
+	private sequenceless = new Map<Action['id'], Array<Events['damage']>>()
+	private sequences = new Map<Action['id'], number>()
 
-		const missEvents = actionEvents.filter(e => e.sequence == null)
-		for (const missEvent of missEvents) {
-			const matchingAction = actionEvents.find(e => e.sequence != null &&
-														  e.timestamp === missEvent.timestamp &&
-														  e.cause.type === "action" && missEvent.cause.type === "action" &&
-														  e.cause.action === missEvent.cause.action)
-			if (matchingAction != null) {
-				missEvent.sequence = matchingAction.sequence
-			} else {
-				missEvent.sequence = missEvent.timestamp
-			}
+	override adapt(_baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
+		return adaptedEvents.map(event => this.adaptEvent(event))
+	}
+
+	private adaptEvent(event: Event): Event {
+		// We only care about damage events caused by an action
+		if (event.type !== 'damage') {
+			return event
 		}
 
-		return adaptedEvents
+		const cause = event.cause
+		if (cause.type !== 'action') {
+			return event
+		}
+
+		// If the timestamp has changed, any remaining sequenceless events can be
+		// backfilled with a faux sequence value, and state can be cleared.
+		if (event.timestamp !== this.lastTimestamp) {
+			for (const toBackfill of this.sequenceless.values()) {
+				for (const backfillEvent of toBackfill) {
+					backfillEvent.sequence = backfillEvent.timestamp
+				}
+			}
+
+			this.sequenceless.clear()
+			this.sequences.clear()
+		}
+
+		const lastSequence = this.sequences.get(cause.action)
+
+		if (event.sequence != null) {
+			// This event has a sequence, record it for the action, and backfill any
+			// matching sequenceless events.
+			this.sequences.set(cause.action, event.sequence)
+
+			const toBackfill = this.sequenceless.get(cause.action) ?? []
+			this.sequenceless.delete(cause.action)
+			for (const backfillEvent of toBackfill) {
+				backfillEvent.sequence = event.sequence
+			}
+		} else if (lastSequence != null) {
+			// Event doesn't have a sequence, use the one from the last matching cause.
+			event.sequence = lastSequence
+		} else {
+			// We've got nothing - record it as sequenceless and hopefully pick it up later.
+			let toBackfill = this.sequenceless.get(cause.action)
+			if (toBackfill == null) {
+				toBackfill = []
+				this.sequenceless.set(cause.action, toBackfill)
+			}
+			toBackfill.push(event)
+		}
+
+		this.lastTimestamp = event.timestamp
+
+		return event
 	}
 }

--- a/src/reportSources/legacyFflogs/eventAdapter/fixMissEventSequenceID.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/fixMissEventSequenceID.ts
@@ -1,4 +1,3 @@
-import {Action} from 'data/ACTIONS'
 import {Event, Events} from 'event'
 import {AdapterStep} from './base'
 import {FflogsEvent} from '../eventTypes'
@@ -7,12 +6,12 @@ import {FflogsEvent} from '../eventTypes'
  * FFLogs models damage events that hit multiple targets as separate events with the same SequenceID and timestamp.
  * However, if one event fails to hit (miss or an invuln target), then the sequence ID will be omitted from the failed hit.
  * We need to readd the omitted SequenceID so that AOE deduplication will work correctly
- * NOTE: this adapter step MUST run before DeduplicateAoEStep or it won't have any effect
+ * NOTE: this adapter step MUST run after TranslateStep or it will not have any effect.  Running after translation to simplify event interface that we need to look at and modify.
  */
 export class FixMissEventSequenceIDStep extends AdapterStep {
 	private lastTimestamp = -1
-	private sequenceless = new Map<Action['id'], Array<Events['damage']>>()
-	private sequences = new Map<Action['id'], number>()
+	private sequenceless = new Map<string, Array<Events['damage']>>()
+	private sequences = new Map<string, number>()
 
 	override adapt(_baseEvent: FflogsEvent, adaptedEvents: Event[]): Event[] {
 		return adaptedEvents.map(event => this.adaptEvent(event))
@@ -42,29 +41,35 @@ export class FixMissEventSequenceIDStep extends AdapterStep {
 			this.sequences.clear()
 		}
 
-		const lastSequence = this.sequences.get(cause.action)
+		// Key events on action ID and the source actor ID to make sure we don't match actions from different actors at the same timestamp
+		const eventKey = `${cause.action}|${event.source}`
 
 		if (event.sequence != null) {
 			// This event has a sequence, record it for the action, and backfill any
 			// matching sequenceless events.
-			this.sequences.set(cause.action, event.sequence)
+			this.sequences.set(eventKey, event.sequence)
 
-			const toBackfill = this.sequenceless.get(cause.action) ?? []
-			this.sequenceless.delete(cause.action)
+			const toBackfill = this.sequenceless.get(eventKey) ?? []
+			this.sequenceless.delete(eventKey)
 			for (const backfillEvent of toBackfill) {
 				backfillEvent.sequence = event.sequence
 			}
-		} else if (lastSequence != null) {
-			// Event doesn't have a sequence, use the one from the last matching cause.
-			event.sequence = lastSequence
 		} else {
-			// We've got nothing - record it as sequenceless and hopefully pick it up later.
-			let toBackfill = this.sequenceless.get(cause.action)
-			if (toBackfill == null) {
-				toBackfill = []
-				this.sequenceless.set(cause.action, toBackfill)
+			// Event doesn't have a sequence, check if there's a matching event to provide a sequence id
+			const matchingSequence = this.sequences.get(eventKey)
+
+			if (matchingSequence != null) {
+				// Set this event's sequence to the matched event
+				event.sequence = matchingSequence
+			} else {
+				// We've got nothing - record it as sequenceless and hopefully pick it up later.
+				let toBackfill = this.sequenceless.get(eventKey)
+				if (toBackfill == null) {
+					toBackfill = []
+					this.sequenceless.set(eventKey, toBackfill)
+				}
+				toBackfill.push(event)
 			}
-			toBackfill.push(event)
 		}
 
 		this.lastTimestamp = event.timestamp

--- a/src/reportSources/legacyFflogs/eventAdapter/fixMissEventSequenceID.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/fixMissEventSequenceID.ts
@@ -1,0 +1,31 @@
+import {Cause, Event} from 'event'
+import {filter} from 'parser/core/filter'
+import {AdapterStep} from './base'
+
+/**
+ * FFLogs models damage events that hit multiple targets as separate events with the same SequenceID and timestamp.
+ * However, if one event fails to hit (miss or an invuln target), then the sequence ID will be omitted from the failed hit.
+ * We need to readd the omitted SequenceID so that AOE deduplication will work correctly
+ * NOTE: this adapter step MUST run before DeduplicateAoEStep or it won't have any effect
+ */
+export class FixMissEventSequenceIDStep extends AdapterStep {
+	override postprocess(adaptedEvents: Event[]) {
+		const actionEventFilter = filter<Event>().type('damage').cause(filter<Cause>().type('action'))
+		const actionEvents = adaptedEvents.filter(actionEventFilter)
+
+		const missEvents = actionEvents.filter(e => e.sequence == null)
+		for (const missEvent of missEvents) {
+			const matchingAction = actionEvents.find(e => e.sequence != null &&
+														  e.timestamp === missEvent.timestamp &&
+														  e.cause.type === "action" && missEvent.cause.type === "action" &&
+														  e.cause.action === missEvent.cause.action)
+			if (matchingAction != null) {
+				missEvent.sequence = matchingAction.sequence
+			} else {
+				missEvent.sequence = missEvent.timestamp
+			}
+		}
+
+		return adaptedEvents
+	}
+}


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [X] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [X] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1328437196541132963
- [ ] The goal of this PR is detailed below:

## Testing / Validation

<!-- If this PR contains any new functionality or bugfixes, please include log links that reviewers can use to help verify your changes.  Reviewers may also find additional logs to check your PR with, but having initial logs is important to speed the review process, especially for corner cases or hard to trigger analysis flags.  If this PR is a patch bump with no changes or potency only changes, you can delete this section. -->
- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [X] I used the log(s) listed below to develop and test this bugfix:

https://xivanalysis.com/fflogs/zL8x9DjVBkXY7mpy/3/36
https://xivanalysis.com/fflogs/yK4dfcQRjZrF6bXz/20/407

## Job Maintenance
- [X] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [X] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
