### PR TITLE
Bucket event filter predicates by type

### DIFF
--- a/src/parser/core/Dispatcher.ts
+++ b/src/parser/core/Dispatcher.ts
@@ -53,6 +53,8 @@ export interface Dispatcher {
 	removeTimestampHook(hook: TimestampHook): boolean
 }
 
+const FILTER_TYPE_FALLBACK = '__CHECK_ALL'
+
 /**
  * Dispatcher is in charge of consuming events from the parser and fanning them
  * out to matching hooks where required.
@@ -63,12 +65,9 @@ export class DispatcherImpl implements Dispatcher {
 	get timestamp() { return this._timestamp }
 
 	private eventHooks = new Map<
-		Handle,
-		Map<
-			string | undefined,
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			Set<EventHook<any>>
-		>
+		`${Handle}::${string | typeof FILTER_TYPE_FALLBACK}`,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		Set<EventHook<any>>
 	>()
 
 	// Stored nearest-last so we can use the significantly-faster pop
@@ -123,21 +122,16 @@ export class DispatcherImpl implements Dispatcher {
 
 		const issues: DispatchIssue[] = []
 
-		const typeKeys = [event.type, undefined]
+		const typeKeys = [event.type, FILTER_TYPE_FALLBACK] as const
 
 		// Iterate over the handles provided, looking for registered hooks
 		for (const handle of handles) {
-			const handleHooks = this.eventHooks.get(handle)
-			if (handleHooks == null) { continue }
-
+			// Try to execute any matching hooks for the current handle
 			try {
-				// Try to execute any matching hooks for the current handle
 				for (const typeKey of typeKeys) {
-					const handleTypes = handleHooks.get(typeKey)
-					if (handleTypes == null) {
-						continue
-					}
-					for (const hook of handleTypes.values()) {
+					const hooks = this.eventHooks.get(`${handle}::${typeKey}`)
+					if (hooks == null) { continue }
+					for (const hook of hooks.values()) {
 						if (!hook.predicate(event)) { continue }
 						hook.callback(event)
 					}
@@ -163,20 +157,15 @@ export class DispatcherImpl implements Dispatcher {
 	 * @param hook The hook to register.
 	 */
 	addEventHook<T extends Event>(hook: EventHook<T>) {
-		let handleTypes = this.eventHooks.get(hook.handle)
-		if (handleTypes == null) {
-			handleTypes = new Map()
-			this.eventHooks.set(hook.handle, handleTypes)
+		const filterType = hook.predicate[FILTER_TYPE] ?? FILTER_TYPE_FALLBACK
+		const key = `${hook.handle}::${filterType}` as const
+		let hooks = this.eventHooks.get(key)
+		if (hooks == null) {
+			hooks = new Set()
+			this.eventHooks.set(key, hooks)
 		}
 
-		const filterType = hook.predicate[FILTER_TYPE]
-		let handleHooks = handleTypes.get(filterType)
-		if (handleHooks == null) {
-			handleHooks = new Set()
-			handleTypes.set(filterType, handleHooks)
-		}
-
-		handleHooks.add(hook)
+		hooks.add(hook)
 	}
 
 	/**
@@ -187,21 +176,12 @@ export class DispatcherImpl implements Dispatcher {
 	 * @return `true` if the hook was removed successfully.
 	 */
 	removeEventHook<T extends Event>(hook: EventHook<T>): boolean {
-		const handleTypes = this.eventHooks.get(hook.handle)
-		if (handleTypes == null) { return false }
+		const filterType = hook.predicate[FILTER_TYPE] ?? FILTER_TYPE_FALLBACK
+		const key = `${hook.handle}::${filterType}` as const
+		const hooks = this.eventHooks.get(key)
+		if (hooks == null) { return false }
 
-		const filterType = hook.predicate[FILTER_TYPE]
-		const handleHooks = handleTypes.get(filterType)
-		if (handleHooks == null) { return false }
-
-		const removed = handleHooks.delete(hook)
-		if (!removed) { return false }
-
-		if (handleHooks.size === 0) {
-			handleTypes.delete(filterType)
-		}
-
-		return true
+		return hooks.delete(hook)
 	}
 
 	/**

--- a/src/parser/core/Dispatcher.ts
+++ b/src/parser/core/Dispatcher.ts
@@ -53,8 +53,6 @@ export interface Dispatcher {
 	removeTimestampHook(hook: TimestampHook): boolean
 }
 
-const FILTER_TYPE_FALLBACK = '__CHECK_ALL'
-
 /**
  * Dispatcher is in charge of consuming events from the parser and fanning them
  * out to matching hooks where required.
@@ -65,9 +63,12 @@ export class DispatcherImpl implements Dispatcher {
 	get timestamp() { return this._timestamp }
 
 	private eventHooks = new Map<
-		`${Handle}::${string | typeof FILTER_TYPE_FALLBACK}`,
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		Set<EventHook<any>>
+		Handle,
+		Map<
+			string | undefined,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			Set<EventHook<any>>
+		>
 	>()
 
 	// Stored nearest-last so we can use the significantly-faster pop
@@ -122,16 +123,21 @@ export class DispatcherImpl implements Dispatcher {
 
 		const issues: DispatchIssue[] = []
 
-		const typeKeys = [event.type, FILTER_TYPE_FALLBACK] as const
+		const typeKeys = [event.type, undefined]
 
 		// Iterate over the handles provided, looking for registered hooks
 		for (const handle of handles) {
-			// Try to execute any matching hooks for the current handle
+			const handleHooks = this.eventHooks.get(handle)
+			if (handleHooks == null) { continue }
+
 			try {
+				// Try to execute any matching hooks for the current handle
 				for (const typeKey of typeKeys) {
-					const hooks = this.eventHooks.get(`${handle}::${typeKey}`)
-					if (hooks == null) { continue }
-					for (const hook of hooks.values()) {
+					const handleTypes = handleHooks.get(typeKey)
+					if (handleTypes == null) {
+						continue
+					}
+					for (const hook of handleTypes.values()) {
 						if (!hook.predicate(event)) { continue }
 						hook.callback(event)
 					}
@@ -157,15 +163,20 @@ export class DispatcherImpl implements Dispatcher {
 	 * @param hook The hook to register.
 	 */
 	addEventHook<T extends Event>(hook: EventHook<T>) {
-		const filterType = hook.predicate[FILTER_TYPE] ?? FILTER_TYPE_FALLBACK
-		const key = `${hook.handle}::${filterType}` as const
-		let hooks = this.eventHooks.get(key)
-		if (hooks == null) {
-			hooks = new Set()
-			this.eventHooks.set(key, hooks)
+		let handleTypes = this.eventHooks.get(hook.handle)
+		if (handleTypes == null) {
+			handleTypes = new Map()
+			this.eventHooks.set(hook.handle, handleTypes)
 		}
 
-		hooks.add(hook)
+		const filterType = hook.predicate[FILTER_TYPE]
+		let handleHooks = handleTypes.get(filterType)
+		if (handleHooks == null) {
+			handleHooks = new Set()
+			handleTypes.set(filterType, handleHooks)
+		}
+
+		handleHooks.add(hook)
 	}
 
 	/**
@@ -176,12 +187,21 @@ export class DispatcherImpl implements Dispatcher {
 	 * @return `true` if the hook was removed successfully.
 	 */
 	removeEventHook<T extends Event>(hook: EventHook<T>): boolean {
-		const filterType = hook.predicate[FILTER_TYPE] ?? FILTER_TYPE_FALLBACK
-		const key = `${hook.handle}::${filterType}` as const
-		const hooks = this.eventHooks.get(key)
-		if (hooks == null) { return false }
+		const handleTypes = this.eventHooks.get(hook.handle)
+		if (handleTypes == null) { return false }
 
-		return hooks.delete(hook)
+		const filterType = hook.predicate[FILTER_TYPE]
+		const handleHooks = handleTypes.get(filterType)
+		if (handleHooks == null) { return false }
+
+		const removed = handleHooks.delete(hook)
+		if (!removed) { return false }
+
+		if (handleHooks.size === 0) {
+			handleTypes.delete(filterType)
+		}
+
+		return true
 	}
 
 	/**


### PR DESCRIPTION
this'd really benefit from testing on like any log you can think of.

---

currently; event hooks are filtered by arbitrary predicate functions - `filter<T>()` is really just a predicate builder, and any `(event) => event is T` is a valid predicate.

this is great for composibility!
this is shit for optimisations!

for every event, _every_ hook predicate needs to be called to work out which hooks should actually be executed. given a vast majority of events will trigger a minority of hooks, this is pretty wasteful.

the most common property of events (perhaps other than their timestamp) is their type - and conveniently, it's also a very-commonly-filtered property. if we can bucket predicated by the type they filter for, and then bypass any predicates that don't have a matching type _before_ calling them, we can save on that execution time.

---

this pr implements the above through the introduction of a(n optional) special key on filter predicates, and a side channel within the filter implementation to provide that key in straight-forward consumption.

more concretely;

- `Dispatcher` will now check predicates for a `[FILTER_KEY]` (symbol) property.
	- If it exists, it will be used to bucket the predicate - it will only be called if the event's type matches the key (map lookup).
	- If it _does not_ exist, it will be called for every event.
- `filter<T>()` checks the value provided to any `.type(...)` calls, and exposes it in `[FILTER_KEY]`
	- this is currently only checking for literal strings, which catches the vast majority of filters that i've checked.
	- any non-literal type filters (i.e. `.type(oneOf(...))`), or filters with no type at all, will not expose a `[FILTER_KEY]`.

it'd be possible to support `oneOf` and similar as well, but I don't think the gains are worth the additional effort at this point in time.

before:
![image](https://github.com/user-attachments/assets/d01717a5-bd6a-448a-ba1b-efe70110fe62)

sick gains:
![firefox_zVWf24L7Ts](https://github.com/user-attachments/assets/6ca45964-07d4-4f3e-882b-011b1e511c00)
