### PR TITLE
Automatically retry on first module load failure

### DIFF
--- a/src/components/GlobalSidebar/Version.tsx
+++ b/src/components/GlobalSidebar/Version.tsx
@@ -1,22 +1,18 @@
+import {XIVA_VERSION, XIVA_GIT_COMMIT, XIVA_GIT_BRANCH} from 'env'
 import {Popup} from 'semantic-ui-react'
 import styles from './Version.module.css'
 
-// Version info
-const version = process.env.REACT_APP_VERSION || 'DEV'
-const gitCommit = process.env.REACT_APP_GIT_COMMIT || 'DEV'
-const gitBranch = process.env.REACT_APP_GIT_BRANCH || 'DEV'
-
 export const VersionInfo = () => (
 	<Popup
-		trigger={<span className={styles.version}>#{version}</span>}
+		trigger={<span className={styles.version}>#{XIVA_VERSION}</span>}
 		position="bottom center"
 	>
 		<Popup.Content>
 			<dl className={styles.versionInfo}>
 				<dt>Commit</dt>
-				<dd>{gitCommit}</dd>
+				<dd>{XIVA_GIT_COMMIT}</dd>
 				<dt>Branch</dt>
-				<dd>{gitBranch}</dd>
+				<dd>{XIVA_GIT_BRANCH}</dd>
 			</dl>
 		</Popup.Content>
 	</Popup>

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,3 @@
+export const XIVA_VERSION: string = process.env.REACT_APP_VERSION || 'DEV'
+export const XIVA_GIT_COMMIT: string = process.env.REACT_APP_GIT_COMMIT || 'DEV'
+export const XIVA_GIT_BRANCH: string = process.env.REACT_APP_GIT_BRANCH || 'DEV'

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser'
 import {ResultSegment} from 'components/ReportFlow/Analyse/ResultSegment'
 import {ErrorMessage} from 'components/ui/ErrorMessage'
 import {getReportPatch, Patch} from 'data/PATCHES'
+import {XIVA_VERSION} from 'env'
 import {DependencyCascadeError, ModulesNotFoundError} from 'errors'
 import {Event} from 'event'
 import {ReactNode} from 'react'
@@ -13,6 +14,8 @@ import {Analyser, DisplayMode} from './Analyser'
 import {Dispatcher, DispatcherImpl} from './Dispatcher'
 import {Injectable} from './Injectable'
 import {Meta} from './Meta'
+
+const LS_KEY_LAST_FAILING_VERSION = 'xiva.lastFailingVersion'
 
 export interface Result {
 	i18n_id?: string
@@ -145,7 +148,6 @@ export class Parser {
 	}
 
 	private async loadModuleConstructors() {
-		// If this throws, then there was probably a deploy between page load and this call. Tell them to refresh.
 		let allCtors: ReadonlyArray<typeof Injectable>
 		try {
 			allCtors = await this.meta.getModules()
@@ -153,6 +155,18 @@ export class Parser {
 			if (process.env.NODE_ENV === 'development') {
 				throw error
 			}
+
+			// If this is the first time we've failed on this version, try to refresh
+			// - there may have been a deploy between page load and this call.
+			const lastVersion = localStorage.getItem(LS_KEY_LAST_FAILING_VERSION)
+			localStorage.setItem(LS_KEY_LAST_FAILING_VERSION, XIVA_VERSION)
+			if (lastVersion !== XIVA_VERSION) {
+				window.location.reload()
+			}
+
+			// We're at the same version as the last failure, fail out with an error.
+			// We're still asking for a refresh in the error; as the programmatic one
+			// above _may_ not be enough.
 			throw new ModulesNotFoundError()
 		}
 

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -147,7 +147,7 @@ export class Parser {
 		})
 	}
 
-	private async loadModuleConstructors() {
+	private async loadModuleConstructors(): Promise<Record<string, typeof Injectable>> {
 		let allCtors: ReadonlyArray<typeof Injectable>
 		try {
 			allCtors = await this.meta.getModules()
@@ -162,6 +162,7 @@ export class Parser {
 			localStorage.setItem(LS_KEY_LAST_FAILING_VERSION, XIVA_VERSION)
 			if (lastVersion !== XIVA_VERSION) {
 				window.location.reload()
+				return {}
 			}
 
 			// We're at the same version as the last failure, fail out with an error.


### PR DESCRIPTION
Title. Like, 99% of errors in the sentry channel are just variations of the `Modules not found.` error that occurs en masse when a new version is deployed. There's a bunch of wizardry we could do to work around this - but, as `public/service-worker.js` so _eloquently_ puts it;

```
// to all ye who may see this file
// let it be known
// fuck service workers
// amen
```

so yeah nah this just trips a refresh of the page if it's the first time the deploy version has failed out. ez. what could go wrong.