### PR TITLE
[VPR][SAM][RPR][GNB] 7.2 bumps

### DIFF
--- a/src/parser/jobs/gnb/changelog.tsx
+++ b/src/parser/jobs/gnb/changelog.tsx
@@ -6,7 +6,7 @@ export const changelog = [
 		date: new Date('2025-03-24'),
 		Changes: () => <>GNB 7.2 Support added.</>,
 		contributors: [CONTRIBUTORS.RYAN],
-	}
+	},
 	{
 		date: new Date('2024-11-14'),
 		Changes: () => <>GNB 7.1 Support added.</>,

--- a/src/parser/jobs/gnb/changelog.tsx
+++ b/src/parser/jobs/gnb/changelog.tsx
@@ -3,6 +3,11 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2025-03-24'),
+		Changes: () => <>GNB 7.2 Support added.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	}
+	{
 		date: new Date('2024-11-14'),
 		Changes: () => <>GNB 7.1 Support added.</>,
 		contributors: [CONTRIBUTORS.RYAN],

--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -19,7 +19,7 @@ export const GUNBREAKER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.1',
+		to: '7.2',
 	},
 
 	contributors: [

--- a/src/parser/jobs/rpr/changelog.tsx
+++ b/src/parser/jobs/rpr/changelog.tsx
@@ -1,6 +1,12 @@
+import { DataLink } from 'components/ui/DbLink'
 import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
+	{
+		date: new Date('2025-03-24'),
+		Changes: () => <>Reaper 7.2 Support added. <DataLink action = "EXECUTIONERS_GUILLOTINE" /> breakpoint increased from 3 to 4. <DataLink action = "SPINNING_SCYTHE"/> breakpoint increased from 3 to 4.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
 	{
 		date: new Date('2024-11-14'),
 		Changes: () => <> Reaper 7.1 Support added</>,

--- a/src/parser/jobs/rpr/changelog.tsx
+++ b/src/parser/jobs/rpr/changelog.tsx
@@ -1,4 +1,4 @@
-import { DataLink } from 'components/ui/DbLink'
+import {DataLink} from 'components/ui/DbLink'
 import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [

--- a/src/parser/jobs/rpr/index.tsx
+++ b/src/parser/jobs/rpr/index.tsx
@@ -16,7 +16,7 @@ export const REAPER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.1',
+		to: '7.2',
 	},
 
 	contributors: [

--- a/src/parser/jobs/rpr/modules/AoE.ts
+++ b/src/parser/jobs/rpr/modules/AoE.ts
@@ -10,7 +10,7 @@ export class AoE extends AoEUsages {
 		{
 			aoeAction: this.data.actions.SPINNING_SCYTHE,
 			stActions: [this.data.actions.SLICE],
-			minTargets: 3,
+			minTargets: 4,
 		}, {
 			aoeAction: this.data.actions.SOUL_SCYTHE,
 			stActions: [this.data.actions.SOUL_SLICE],
@@ -33,7 +33,7 @@ export class AoE extends AoEUsages {
 		{
 			aoeAction: this.data.actions.EXECUTIONERS_GUILLOTINE,
 			stActions: [this.data.actions.EXECUTIONERS_GALLOWS, this.data.actions.EXECUTIONERS_GIBBET],
-			minTargets: 3,
+			minTargets: 4,
 		},
 		{
 			aoeAction: this.data.actions.LEMURES_SCYTHE,

--- a/src/parser/jobs/sam/changelog.tsx
+++ b/src/parser/jobs/sam/changelog.tsx
@@ -1,7 +1,13 @@
+import { date } from '@lingui/macro'
 import {DataLink} from 'components/ui/DbLink'
 import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
+	{
+		date: new Date('2025-03-24'),
+		Changes: () => <>SAM 7.2 Support added. <DataLink action="HISSATSU_GUREN"/> breakpoint increased to 3 from 2.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
 	{
 		date: new Date('2025-01-19'),
 		Changes: () => <>Fixed the spelling of <DataLink action="TENGENTSU"/>.</>,

--- a/src/parser/jobs/sam/changelog.tsx
+++ b/src/parser/jobs/sam/changelog.tsx
@@ -1,4 +1,3 @@
-import {date} from '@lingui/macro'
 import {DataLink} from 'components/ui/DbLink'
 import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 

--- a/src/parser/jobs/sam/changelog.tsx
+++ b/src/parser/jobs/sam/changelog.tsx
@@ -1,4 +1,4 @@
-import { date } from '@lingui/macro'
+import {date} from '@lingui/macro'
 import {DataLink} from 'components/ui/DbLink'
 import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 

--- a/src/parser/jobs/sam/index.tsx
+++ b/src/parser/jobs/sam/index.tsx
@@ -14,7 +14,7 @@ export const SAMURAI = new Meta({
 
 	supportedPatches: {
 		from: '7.05',
-		to: '7.1',
+		to: '7.2',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sam/modules/AoeChecker.ts
+++ b/src/parser/jobs/sam/modules/AoeChecker.ts
@@ -21,7 +21,7 @@ export class AoeChecker extends AoEUsages {
 		{
 			aoeAction: ACTIONS.HISSATSU_GUREN,
 			stActions: [ACTIONS.HISSATSU_SENEI],
-			minTargets: 2,
+			minTargets: 3,
 		},
 
 		{

--- a/src/parser/jobs/vpr/changelog.tsx
+++ b/src/parser/jobs/vpr/changelog.tsx
@@ -1,7 +1,13 @@
+import { date } from '@lingui/macro'
 import {DataLink} from 'components/ui/DbLink'
 import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
+	{
+		date: new Date('2025-03-24'),
+		Changes: () => <>Viper 7.2 Support added.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
 	{
 		date: new Date('2025-01-29'),
 		Changes: () => <>Fix a data error that was causing phantom prepull uses of <DataLink action="VICEWINDER"/> and <DataLink action="VICEPIT"/> follow-up GCDs to be recorded.</>,

--- a/src/parser/jobs/vpr/changelog.tsx
+++ b/src/parser/jobs/vpr/changelog.tsx
@@ -1,4 +1,3 @@
-import {date} from '@lingui/macro'
 import {DataLink} from 'components/ui/DbLink'
 import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 

--- a/src/parser/jobs/vpr/changelog.tsx
+++ b/src/parser/jobs/vpr/changelog.tsx
@@ -1,4 +1,4 @@
-import { date } from '@lingui/macro'
+import {date} from '@lingui/macro'
 import {DataLink} from 'components/ui/DbLink'
 import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 

--- a/src/parser/jobs/vpr/index.tsx
+++ b/src/parser/jobs/vpr/index.tsx
@@ -17,7 +17,7 @@ export const VIPER = new Meta({
 
 	supportedPatches: {
 		from: '7.05',
-		to: '7.1',
+		to: '7.2',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type


- [ x] This is a patch bump

## Pull request details

- [x ] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch

GNB: No analysis changes, big number bigger
VPR: No Analysis changes, small number bigger
SAM: AoE Breakpoint changes, Guren now gain on 3, not 2.
RPR: AoE Breakpoint changes, Executioner's Guillotine now a gain on 4. Regular AoE Combo now a gain on 4.


## Testing / Validation

2 + 1 = 3.
3 + 1 = 4.


## Job Maintenance
- [x ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
