### PR TITLE
[MCH] 7.2 support

### DIFF
--- a/src/parser/jobs/mch/changelog.tsx
+++ b/src/parser/jobs/mch/changelog.tsx
@@ -2,6 +2,11 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2025-04-11'),
+		Changes: () => <>Update AoE breakpoints for patch 7.2.</>,
+		contributors: [CONTRIBUTORS.HINT],
+	},
+	{
 		date: new Date('2024-06-30'),
 		Changes: () => <>Update Machinist data and modules for Dawntrail.</>,
 		contributors: [CONTRIBUTORS.HINT],

--- a/src/parser/jobs/mch/index.tsx
+++ b/src/parser/jobs/mch/index.tsx
@@ -24,7 +24,7 @@ export const MACHINIST = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.1',
+		to: '7.2',
 	},
 
 	contributors: [

--- a/src/parser/jobs/mch/modules/MultiHitSkills.ts
+++ b/src/parser/jobs/mch/modules/MultiHitSkills.ts
@@ -11,12 +11,12 @@ export class MultiHitSkills extends AoEUsages {
 			minTargets: 2,
 		}, {
 			aoeAction: ACTIONS.AUTO_CROSSBOW,
-			stActions: [ACTIONS.HEAT_BLAST],
-			minTargets: 3,
+			stActions: [ACTIONS.BLAZING_SHOT],
+			minTargets: 4,
 		}, {
 			aoeAction: ACTIONS.SCATTERGUN,
 			stActions: [ACTIONS.HEATED_SPLIT_SHOT],
-			minTargets: 3,
+			minTargets: 4,
 		},
 	]
 }


### PR DESCRIPTION
## Pull request type

- [X] This is a patch bump

## Pull request details

AoE breakpoints changed due to potency changes. There was also a reference to a pre-100 skill that got missed in the initial DT pass, this has been updated as well.

There were no other changes.

## Job Maintenance
- [X] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

