### PR TITLE
[MNK] Expected GCD count for Brotherhood

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -671,6 +671,7 @@
   "mnk.balls.suggestions.overcap.content": "",
   "mnk.balls.suggestions.overcap.why": "",
   "mnk.balls.title": "",
+  "mnk.bh.suggestions.gcd.content": "",
   "mnk.bookending.formless.checklist.description": "",
   "mnk.bookending.formless.checklist.name": "",
   "mnk.bookending.formless.checklist.requirement": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -671,6 +671,7 @@
   "mnk.balls.suggestions.overcap.content": "Try not to overcap your Fury gauge. Use <0/>, <1/>, and <2/> over their alternatives whenever a stack of their respective Fury gauge is available.",
   "mnk.balls.suggestions.overcap.why": "You lost {overCap, plural, one {# stack} other {# stacks}} of Fury due to overcapping.",
   "mnk.balls.title": "Fury Gauge",
+  "mnk.bh.suggestions.gcd.content": "Aim to hit {EXPECTED_GCDS} GCDs during each <0/> window.",
   "mnk.bookending.formless.checklist.description": "Opo-opo actions have the highest average potency of the three forms. Try to maximize uses of these actions by consuming <0/> with <1/>, <2/>, or <3/>.",
   "mnk.bookending.formless.checklist.name": "Consume <0/> with Opo-opo actions",
   "mnk.bookending.formless.checklist.requirement": "<0/> used on Opo-opo actions",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -671,6 +671,7 @@
   "mnk.balls.suggestions.overcap.content": "Essayez de ne pas écraser de ressource dans votre jauge de Fureur. Utilisez <0/>, <1/> et <2/> plutôt que leurs alternatives quand une charge de leur jauge de fureur respective est disponible.",
   "mnk.balls.suggestions.overcap.why": "Vous avez perdu {overCap, plural, one {# charge} other {# charges}} de Fureur dû à un écrasement de charge.",
   "mnk.balls.title": "Jauge de Fureur",
+  "mnk.bh.suggestions.gcd.content": "",
   "mnk.bookending.formless.checklist.description": "Les actions Opo-opo ont la plus grande puissance en moyenne sur les 3 postures. Essayez d'en maximiser l'utilisation en consommant <0/> avec <1/>, <2/> ou <3/>.",
   "mnk.bookending.formless.checklist.name": "Consommez <0/> avec vos actions Opo-opo",
   "mnk.bookending.formless.checklist.requirement": "<0/> utilisés sur des actions Opo-opo",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -671,6 +671,7 @@
   "mnk.balls.suggestions.overcap.content": "",
   "mnk.balls.suggestions.overcap.why": "",
   "mnk.balls.title": "",
+  "mnk.bh.suggestions.gcd.content": "",
   "mnk.bookending.formless.checklist.description": "",
   "mnk.bookending.formless.checklist.name": "",
   "mnk.bookending.formless.checklist.requirement": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -671,6 +671,7 @@
   "mnk.balls.suggestions.overcap.content": "",
   "mnk.balls.suggestions.overcap.why": "",
   "mnk.balls.title": "",
+  "mnk.bh.suggestions.gcd.content": "",
   "mnk.bookending.formless.checklist.description": "",
   "mnk.bookending.formless.checklist.name": "",
   "mnk.bookending.formless.checklist.requirement": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -671,6 +671,7 @@
   "mnk.balls.suggestions.overcap.content": "不要覆盖你的象形拳量谱。当<0/>、<1/>、 <2/>所指向的身形功力可用的时候，使用它们而非其他技能。",
   "mnk.balls.suggestions.overcap.why": "你由于覆盖导致损失了 {overCap, plural, other {# 次}}身形。",
   "mnk.balls.title": "怒气值",
+  "mnk.bh.suggestions.gcd.content": "",
   "mnk.bookending.formless.checklist.description": "魔猿身形的技能在3种身形中有着最高的平均威力。用<1/>、<2/>或<3/>来消耗<0/>以最大化使用这些技能。",
   "mnk.bookending.formless.checklist.name": "用魔猿技能消耗<0/>",
   "mnk.bookending.formless.checklist.requirement": "在魔猿技能中使用了<0/>",

--- a/src/parser/jobs/mnk/changelog.tsx
+++ b/src/parser/jobs/mnk/changelog.tsx
@@ -4,7 +4,7 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 export const changelog = [
 	{
 		date: new Date('2025-04-11'),
-		Changes: () => <>Add a 10-GCD requirement to <StatusLink status="BROTHERHOOD" /> windows. It is technically possible to get 11 GCDs in Brotherhood, but this is extremely tight at the standard 1.94 GCD.</>,
+		Changes: () => <>Add a 10-GCD target for <StatusLink status="BROTHERHOOD" /> windows. It is technically possible to get 11 GCDs in Brotherhood, but this is extremely tight at the standard 1.94 GCD.</>,
 		contributors: [CONTRIBUTORS.HINT],
 	},
 	{

--- a/src/parser/jobs/mnk/changelog.tsx
+++ b/src/parser/jobs/mnk/changelog.tsx
@@ -3,6 +3,11 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2025-04-11'),
+		Changes: () => <>Add a 10-GCD requirement to <StatusLink status="BROTHERHOOD" /> windows. It is technically possible to get 11 GCDs in Brotherhood, but this is extremely tight at the standard 1.94 GCD.</>,
+		contributors: [CONTRIBUTORS.HINT],
+	},
+	{
 		date: new Date('2024-12-12'),
 		Changes: () => <>Add a chakra gauge to the timeline and suggestions for overcapping chakra. Gauge events are only visible to the logging player, so these won't show up unless the Monk was the player who uploaded this log.</>,
 		contributors: [CONTRIBUTORS.HINT],

--- a/src/parser/jobs/mnk/modules/Brotherhood.tsx
+++ b/src/parser/jobs/mnk/modules/Brotherhood.tsx
@@ -1,12 +1,12 @@
+import {Trans} from '@lingui/react'
+import {DataLink} from 'components/ui/DbLink'
 import {dependency} from 'parser/core/Injectable'
 import {EvaluatedAction, ExpectedGcdCountEvaluator, RaidBuffWindow} from 'parser/core/modules/ActionWindow'
 import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
 import {BrotherhoodDriftEvaluator, MissedBrotherhoodEvaluator} from './evaluators/BrotherhoodEvaluator'
 import {RiddleOfFire} from './RiddleOfFire'
-import {SEVERITY} from 'parser/core/modules/Suggestions'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
-import {DataLink} from 'components/ui/DbLink'
-import {Trans} from '@lingui/react'
+import {SEVERITY} from 'parser/core/modules/Suggestions'
 
 const EXPECTED_GCDS = 10
 

--- a/src/parser/jobs/mnk/modules/Brotherhood.tsx
+++ b/src/parser/jobs/mnk/modules/Brotherhood.tsx
@@ -1,8 +1,22 @@
 import {dependency} from 'parser/core/Injectable'
-import {EvaluatedAction, RaidBuffWindow} from 'parser/core/modules/ActionWindow'
+import {EvaluatedAction, ExpectedGcdCountEvaluator, RaidBuffWindow} from 'parser/core/modules/ActionWindow'
 import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
 import {BrotherhoodDriftEvaluator, MissedBrotherhoodEvaluator} from './evaluators/BrotherhoodEvaluator'
 import {RiddleOfFire} from './RiddleOfFire'
+import {SEVERITY} from 'parser/core/modules/Suggestions'
+import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
+import {DataLink} from 'components/ui/DbLink'
+import {Trans} from '@lingui/react'
+
+const EXPECTED_GCDS = 10
+
+const SEVERITIES = {
+	TOTAL_GCDS: {
+		9: SEVERITY.MINOR,
+		8: SEVERITY.MEDIUM,
+		5: SEVERITY.MAJOR,
+	},
+}
 
 export interface BrotherhoodWindow {
 	start: number
@@ -34,12 +48,28 @@ export class Brotherhood extends RaidBuffWindow {
 
 	override buffStatus = this.data.statuses.BROTHERHOOD
 
+	@dependency private globalCooldown!: GlobalCooldown
 	@dependency private riddleOfFire!: RiddleOfFire
 
 	private windowOverlaps: Map<number, OverlapStatus> = new Map<number, OverlapStatus>()
 
 	override initialise() {
 		super.initialise()
+
+		this.addEvaluator(new ExpectedGcdCountEvaluator({
+			expectedGcds: EXPECTED_GCDS,
+			globalCooldown: this.globalCooldown,
+			hasStacks: false,
+			suggestionIcon: this.data.actions.BROTHERHOOD.icon,
+			severityTiers: SEVERITIES.TOTAL_GCDS,
+			suggestionWindowName: <DataLink action="BROTHERHOOD" />,
+			suggestionContent: <Trans id="mnk.bh.suggestions.gcd.content">
+				Aim to hit {EXPECTED_GCDS} GCDs during each <DataLink action="BROTHERHOOD" /> window.
+			</Trans>,
+			// 6SS counts as 2 GCDs
+			adjustCount: (window) =>
+				-window.data.filter(value => value.action.id === this.data.actions.SIX_SIDED_STAR.id).length,
+		}))
 
 		this.addEvaluator(new BrotherhoodDriftEvaluator({
 			suggestionIcon: this.data.actions.BROTHERHOOD.icon,

--- a/src/parser/jobs/mnk/modules/Brotherhood.tsx
+++ b/src/parser/jobs/mnk/modules/Brotherhood.tsx
@@ -3,10 +3,10 @@ import {DataLink} from 'components/ui/DbLink'
 import {dependency} from 'parser/core/Injectable'
 import {EvaluatedAction, ExpectedGcdCountEvaluator, RaidBuffWindow} from 'parser/core/modules/ActionWindow'
 import {HistoryEntry} from 'parser/core/modules/ActionWindow/History'
-import {BrotherhoodDriftEvaluator, MissedBrotherhoodEvaluator} from './evaluators/BrotherhoodEvaluator'
-import {RiddleOfFire} from './RiddleOfFire'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
+import {BrotherhoodDriftEvaluator, MissedBrotherhoodEvaluator} from './evaluators/BrotherhoodEvaluator'
+import {RiddleOfFire} from './RiddleOfFire'
 
 const EXPECTED_GCDS = 10
 


### PR DESCRIPTION
## Pull request type

- [X] This is new functionality or an addition to existing functionality

## Pull request details

- [X] The goal of this PR is detailed below:

Add a new column in the Brotherhood raid buff table to show how many GCDs were landed under this buff, as requested by monk players in the Balance.

## Testing / Validation

- [X] I used the log(s) listed below to develop and test this bugfix:

https://xivanalysis.com/fflogs/dG8vW9ncmzQfNZHT/11/47
https://xivanalysis.com/fflogs/PWawdDvbxYGch1V3/14/61

## Job Maintenance
- [X] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
