### PR TITLE
Fix "Conciation" typo

### DIFF
--- a/src/data/ACTIONS/root/SCH.ts
+++ b/src/data/ACTIONS/root/SCH.ts
@@ -119,7 +119,7 @@ export const SCH = ensureActions({
 
 	CONCITATION: {
 		id: 37013,
-		name: 'Conciation',
+		name: 'Concitation',
 		icon: iconUrl(2880),
 		onGcd: true,
 		speedAttribute: Attribute.SPELL_SPEED,


### PR DESCRIPTION
## Pull request type

- [X] This is a bugfix to existing functionality

## Pull request details

- [X] The goal of this PR is detailed below:

The SCH actions contain a typo: Concitation is mistakenly called "Conciation", this can be seen in the UI when hovering over the spell in the timeline.

## Testing / Validation

Created local build, used a private log to verify the tooltip now shows "Concitation".

## Job Maintenance

- [X] I prefer to receive any communications through GitHub only
