### PR TITLE
war: consider either single-target or aoe actions valid in pot windows

### DIFF
--- a/src/parser/jobs/war/modules/Tincture.tsx
+++ b/src/parser/jobs/war/modules/Tincture.tsx
@@ -1,6 +1,6 @@
 import {Trans} from '@lingui/react/macro'
 import {dependency} from 'parser/core/Injectable'
-import {ExpectedActionsEvaluator, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
+import {ExpectedActionGroupsEvaluator, ExpectedGcdCountEvaluator} from 'parser/core/modules/ActionWindow'
 import {GlobalCooldown} from 'parser/core/modules/GlobalCooldown'
 import {SEVERITY} from 'parser/core/modules/Suggestions'
 import {Tincture as CoreTincture} from 'parser/core/modules/Tincture'
@@ -31,15 +31,33 @@ export class Tincture extends CoreTincture {
 			},
 		}))
 
-		this.addEvaluator(new ExpectedActionsEvaluator({
-			expectedActions: [
-				{action: this.data.actions.PRIMAL_REND, expectedPerWindow: 1},
-				{action: this.data.actions.PRIMAL_RUINATION, expectedPerWindow: 1},
-				{action: this.data.actions.PRIMAL_WRATH, expectedPerWindow: 1},
-				{action: this.data.actions.INNER_CHAOS, expectedPerWindow: 2},
-				{action: this.data.actions.FELL_CLEAVE, expectedPerWindow: 3},
-				{action: this.data.actions.ONSLAUGHT, expectedPerWindow: 3},
-				{action: this.data.actions.UPHEAVAL, expectedPerWindow: 1},
+		this.addEvaluator(new ExpectedActionGroupsEvaluator({
+			expectedActionGroups: [
+				{
+					actions: [this.data.actions.PRIMAL_REND], expectedPerWindow: 1,
+				},
+				{
+					actions: [this.data.actions.PRIMAL_RUINATION],
+					expectedPerWindow: 1,
+				},
+				{
+					actions: [this.data.actions.PRIMAL_WRATH], expectedPerWindow: 1,
+				},
+				{
+					actions: [this.data.actions.ONSLAUGHT], expectedPerWindow: 3,
+				},
+				{
+					actions: [this.data.actions.UPHEAVAL, this.data.actions.OROGENY],
+					expectedPerWindow: 1,
+				},
+				{
+					actions: [this.data.actions.INNER_CHAOS, this.data.actions.CHAOTIC_CYCLONE],
+					expectedPerWindow: 2,
+				},
+				{
+					actions: [this.data.actions.FELL_CLEAVE, this.data.actions.DECIMATE],
+					expectedPerWindow: 3,
+				},
 			],
 			suggestionIcon,
 			suggestionContent: <Trans id="war.tincture.suggestions.trackedactions.content">
@@ -47,9 +65,9 @@ export class Tincture extends CoreTincture {
 			</Trans>,
 			suggestionWindowName,
 			severityTiers: {
-				2: SEVERITY.MINOR,
-				4: SEVERITY.MEDIUM,
-				6: SEVERITY.MAJOR,
+				1: SEVERITY.MINOR,
+				2: SEVERITY.MEDIUM,
+				3: SEVERITY.MAJOR,
 			},
 		}))
 	}


### PR DESCRIPTION
## Pull request type

- [x] This is new functionality or an addition to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: [*[Link to thread or start of discussion]*](https://discord.com/channels/441414116914233364/470049767477608459/1377102215617183754)

Since in m6s we are likely to pot on AoE, the feedback for recommended actions to use during potion windows ought to support AoE resource spenders and AoE versions of oGCDs.

This updates the warrior implementation of the tincture module to use action groups containing single-target and AoE versions of those actions.

What it doesn't do is update the logic around rushing - the number of expected GCDs in the tincture action usage panel gets displayed but the number of actions considered "missed" doesn't. Happy to add this but at a quick glance I couldn't see how to!

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:

Checked against this log Ryan provided on discord: https://xivanalysis.com/fflogs/49CgTRyvA3h2JYLZ/8/52

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
