### PR TITLE
[DRK] Fixed Impalements adjusting single target action count in the wrong order

### DIFF
--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// },
 	{
 		date: new Date('2025-05-23'),
+		Changes: () => <>Fixed incorrect Delirium single target action count adjustments when using Impalement.</>,
+		contributors: [CONTRIBUTORS.VIOLET],
+	},
+	{
+		date: new Date('2025-05-23'),
 		Changes: () => <>Corrected reporting of Delirium windows that involve Impalement.</>,
 		contributors: [CONTRIBUTORS.VIOLET],
 	},

--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -8,7 +8,7 @@ export const changelog = [
 	// },
 	{
 		date: new Date('2025-05-23'),
-		Changes: () => <>Fixed incorrect Delirium single target action count adjustments when using Impalement.</>,
+		Changes: () => <>Fixed Delirium single target count adjustments being in the wrong order when using Impalement, and double-counting missed Delirium actions.</>,
 		contributors: [CONTRIBUTORS.VIOLET],
 	},
 	{

--- a/src/parser/jobs/drk/modules/Delirium.tsx
+++ b/src/parser/jobs/drk/modules/Delirium.tsx
@@ -57,14 +57,22 @@ export class Delirium extends BuffWindow {
 		const scarletUsed = window.data.filter(event => (event.action.id === this.data.actions.SCARLET_DELIRIUM.id)).length
 		const comeuppanceUsed = window.data.filter(event => (event.action.id === this.data.actions.COMEUPPANCE.id)).length
 		const torcleaverUsed = window.data.filter(event => (event.action.id === this.data.actions.TORCLEAVER.id)).length
+		const impalementUsed = window.data.filter(event => (event.action.id === this.data.actions.IMPALEMENT.id)).length
+		const totalNumberOfDeliriumStacks = 3
 
-		// Reduce required impalements by number of single target actions used
+		// Reduce required Impalements by number of single target actions used
 		if (action.action.id === this.data.actions.IMPALEMENT.id) {
+			const totalActionsUsed = scarletUsed + comeuppanceUsed + torcleaverUsed + impalementUsed
+			// We want to avoid double counting for missed actions, e.g. a fully missed Delirium being shown as 6 errors, like:
+			// 0/1 + 0/1 + 0/1 + 0/3
+			// So, if any are missed, lower required Impalements (since single target combo is much more common)
+			if (totalActionsUsed < totalNumberOfDeliriumStacks) {
+				return -(totalNumberOfDeliriumStacks - impalementUsed)
+			}
+
 			return -(scarletUsed + comeuppanceUsed + torcleaverUsed)
 		}
 
-		const totalNumberOfDeliriumStacks = 3
-		const impalementUsed = window.data.filter(event => (event.action.id === this.data.actions.IMPALEMENT.id)).length
 		// This will allow the following mixtures of AoE/single target:
 		// - 2x Impalement, 1x Scarlet Delirium
 		// - 1x Scarlet Delirium, 1x Comeuppance, 1x Impalement

--- a/src/parser/jobs/drk/modules/Delirium.tsx
+++ b/src/parser/jobs/drk/modules/Delirium.tsx
@@ -69,20 +69,23 @@ export class Delirium extends BuffWindow {
 		// - 2x Impalement, 1x Scarlet Delirium
 		// - 1x Scarlet Delirium, 1x Comeuppance, 1x Impalement
 		// Anything else (e.g. 2x Scarlet Delirium, 1x Impalement) is disallowed
-		if (impalementUsed === totalNumberOfDeliriumStacks) {
-			if (action.action.id === this.data.actions.TORCLEAVER.id) {
+		// Three Impalements means we miss a Scarlet Delirium
+		if (impalementUsed >= totalNumberOfDeliriumStacks) {
+			if (action.action.id === this.data.actions.SCARLET_DELIRIUM.id) {
 				return -1
 			}
 		}
 
+		// Two Impalements means we miss Comeuppance
 		if (impalementUsed >= 2) {
 			if (action.action.id === this.data.actions.COMEUPPANCE.id) {
 				return -1
 			}
 		}
 
+		// Any Impalement means means we miss Torcleaver
 		if (impalementUsed >= 1) {
-			if (action.action.id === this.data.actions.SCARLET_DELIRIUM.id) {
+			if (action.action.id === this.data.actions.TORCLEAVER.id) {
 				return -1
 			}
 		}


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [X] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

This corrects a bug wherein Impalements were reducing the count of single target Delirium actions in the wrong order, e.g.
Before:
![image](https://github.com/user-attachments/assets/d655dd23-3e6b-48af-95c1-a536b0b9e739)
After:
![image-1](https://github.com/user-attachments/assets/ef3a559f-c6e8-40f7-bd4b-fd197c935b8a)

It also fixes 'double counting' of missed actions, e.g.:
Before:
![image](https://github.com/user-attachments/assets/531b6d44-260a-4043-9da4-34547dea315a)
After:
![image](https://github.com/user-attachments/assets/e4cd610b-5a46-492b-a3d0-8614d75bfd36)



## Testing / Validation
- [X] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [X] I used the log(s) listed below to develop and test this bugfix:

https://www.fflogs.com/reports/LKrkAyaPvTbCmwYD?type=damage-done&fight=last

https://xivanalysis.com/fflogs/NnF94rPyWmKAwpdD/9/226

## Job Maintenance
- [ ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [X] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
