### PR TITLE
[DRK] Fix potion windows to allow Quietus

### DIFF
--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -7,7 +7,7 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
-		date: new Date('2025-06-03'),
+		date: new Date('2025-06-30'),
 		Changes: () => <>Potion windows will now expect a combination of two between Bloodspillers or Quietus, not just two Bloodspillers.</>,
 		contributors: [CONTRIBUTORS.VIOLET],
 	},

--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// },
 	{
 		date: new Date('2025-06-03'),
+		Changes: () => <>Potion windows will now expect a combination of two between Bloodspillers or Quietus, not just two Bloodspillers.</>,
+		contributors: [CONTRIBUTORS.VIOLET],
+	},
+	{
+		date: new Date('2025-06-03'),
 		Changes: () => <>Corrected Shadowstride icon.</>,
 		contributors: [CONTRIBUTORS.VIOLET],
 	},

--- a/src/parser/jobs/drk/modules/Tincture.tsx
+++ b/src/parser/jobs/drk/modules/Tincture.tsx
@@ -28,7 +28,7 @@ export class Tincture extends CoreTincture {
 					overrideHeader: <DataLink showName={false} action="DELIRIUM" />,
 				},
 				{
-					actions: [this.data.actions.BLOODSPILLER],
+					actions: [this.data.actions.BLOODSPILLER, this.data.actions.QUIETUS],
 					expectedPerWindow: 2,
 				},
 				{


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [X] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

This fixes the pot window expecting two Bloodspillers, allowing Quietus instead.

This can be seen here:
https://xivanalysis.com/fflogs/ZXqdgkFy421wMmbr/14/128

![image](https://github.com/user-attachments/assets/7a764f70-7074-44f4-aa09-2409dcc99ec8)

After:
![image](https://github.com/user-attachments/assets/a76c171c-6274-4a92-9512-bf35c62ac68a)


## Testing / Validation

- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [X] I used the log(s) listed below to develop and test this bugfix:

https://xivanalysis.com/fflogs/ZXqdgkFy421wMmbr/14/128

## Job Maintenance
- [ ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [X] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
