### PR TITLE
Update Chinese server patch info up to patch 7.2

### DIFF
--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -59,7 +59,7 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 	'7.0': {
 		date: {
 			[GameEdition.GLOBAL]: 1719565200, // 28/06/24 09:00:00 GMT
-			[GameEdition.CHINESE]: 1727402400, // 27/09/24 02:00:00 GMT (10:00:00 GMT+8)
+			// [GameEdition.CHINESE]: 1727402400, // 27/09/24 02:00:00 GMT (10:00:00 GMT+8) Chinese version of 7.0 is unnecessary.
 		},
 	},
 	'7.01': {
@@ -71,18 +71,21 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 		date: {
 			[GameEdition.GLOBAL]: 1722333600, // 30/07/24 10:00:00 GMT
 			[GameEdition.KOREAN]: 1733212800, // 03/12/24 08:00:00 GMT
+			[GameEdition.CHINESE]: 1727402400, // 27/09/24 02:00:00 GMT (10:00:00 GMT+8) Chinese version come with 7.05 job changes when launched.
 		},
 	},
 	'7.1': {
 		date: {
 			[GameEdition.GLOBAL]: 1731398400, // 12/11/24 8:00:00 GMT
 			[GameEdition.KOREAN]: 1742284800, // 18/03/25 08:00:00 GMT
+			[GameEdition.CHINESE]: 1739865600, // 18/02/25 08:00:00 GMT
 		},
 	},
 	'7.2': {
 		date: {
 			[GameEdition.GLOBAL]: 1742889600, // 25/03/25 8:00:00 GMT
 			[GameEdition.KOREAN]: 1752566400, // 15/07/25 08:00:00 GMT
+			[GameEdition.CHINESE]: 1750752000, // 24/06/25 08:00:00 GMT
 		},
 	},
 	'7.3': {


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

Reproduction: Select a fflog which region is CN, under patch 7.05 and later, containing SAM and VIP.
Expected: The SAM and VIP should be supported.
Actual: The outcome will indicate that the SAM and VIP is outdated and no supported.


## Testing / Validation

- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
- [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:

https://xivanalysis.com/fflogs/XZkQfpKc3wgjn4vP/1/9
https://cn.fflogs.com/reports/3tTNpPbWvnqh2aQd
https://cn.fflogs.com/reports/V9zBbGWRy3pJTqd7

## Job Maintenance
- [ ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [x] I prefer to receive any communications through GitHub only
