### PR TITLE
[SAM][VPR]{RPR] 7.3 Patch bumps 

### DIFF
--- a/src/data/ACTIONS/layers/index.ts
+++ b/src/data/ACTIONS/layers/index.ts
@@ -4,6 +4,7 @@ import {patch701} from './patch7.01'
 import {patch705} from './patch7.05'
 import {patch710} from './patch7.1'
 import {patch720} from './patch7.2'
+import {patch730} from './patch7.3'
 
 export const layers: Array<Layer<ActionRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -13,4 +14,5 @@ export const layers: Array<Layer<ActionRoot>> = [
 	patch705,
 	patch710,
 	patch720,
+	patch730,
 ]

--- a/src/data/ACTIONS/layers/patch7.3.ts
+++ b/src/data/ACTIONS/layers/patch7.3.ts
@@ -1,0 +1,12 @@
+import {Layer} from 'data/layer'
+import {ActionRoot} from '../root'
+
+export const patch730: Layer<ActionRoot> = {
+	patch: '7.3',
+	data: {
+		// RPR
+		ENSHROUD: {
+			cooldown: 5000,
+		},
+	},
+}

--- a/src/parser/jobs/rpr/changelog.tsx
+++ b/src/parser/jobs/rpr/changelog.tsx
@@ -3,6 +3,11 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2025-08-09'),
+		Changes: () => <>Updated for 7.3, <DataLink action="ENSHROUD"/> now has a 5s cooldown.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
+	{
 		date: new Date('2025-03-24'),
 		Changes: () => <>Reaper 7.2 Support added. <DataLink action = "EXECUTIONERS_GUILLOTINE" /> breakpoint increased from 3 to 4. <DataLink action = "SPINNING_SCYTHE"/> breakpoint increased from 3 to 4.</>,
 		contributors: [CONTRIBUTORS.RYAN],

--- a/src/parser/jobs/rpr/index.tsx
+++ b/src/parser/jobs/rpr/index.tsx
@@ -16,7 +16,7 @@ export const REAPER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.2',
+		to: '7.3',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sam/index.tsx
+++ b/src/parser/jobs/sam/index.tsx
@@ -13,7 +13,7 @@ export const SAMURAI = new Meta({
 
 	supportedPatches: {
 		from: '7.05',
-		to: '7.2',
+		to: '7.3',
 	},
 
 	contributors: [

--- a/src/parser/jobs/vpr/index.tsx
+++ b/src/parser/jobs/vpr/index.tsx
@@ -17,7 +17,7 @@ export const VIPER = new Meta({
 
 	supportedPatches: {
 		from: '7.05',
-		to: '7.2',
+		to: '7.3',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [ x] This is a patch bump

## Pull request details

7.3 had no changes for analysis for VPR or SAM
7.3 reduced RPR's enshroud to 5 second cooldown, no impact to analysis.

  - [x ] I have updated the data files for all potency changes for this patch

## Testing / Validation
- [ x] I used the log(s) listed below to develop and test this bugfix:

   https://www.fflogs.com/reports/3gjhakGyYLfZq8nz?fight=3&type=damage-done

## Job Maintenance
- [ x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR

