### PR TITLE
Show edge and flood of darkness for level synced ultimates

### DIFF
--- a/src/data/ACTIONS/root/DRK.ts
+++ b/src/data/ACTIONS/root/DRK.ts
@@ -210,6 +210,12 @@ export const DRK = ensureActions({
 		cooldown: 15000,
 		statusesApplied: ['BLACKEST_NIGHT'],
 	},
+	FLOOD_OF_DARKNESS: {
+		id: 16466,
+		name: 'Flood of Darkness',
+		icon: iconUrl(3082),
+		cooldown: 1000,
+	},
 	FLOOD_OF_SHADOW: {
 		id: 16469,
 		name: 'Flood of Shadow',
@@ -219,6 +225,12 @@ export const DRK = ensureActions({
 			value: 100,
 			bonusModifiers: [],
 		}],
+	},
+	EDGE_OF_DARKNESS: {
+		id: 16467,
+		name: 'Edge of Darkness',
+		icon: iconUrl(3083),
+		cooldown: 1000,
 	},
 	EDGE_OF_SHADOW: {
 		id: 16470,

--- a/src/data/ACTIONS/root/DRK.ts
+++ b/src/data/ACTIONS/root/DRK.ts
@@ -379,4 +379,14 @@ export const DRK = ensureActions({
 		name: 'Disesteem',
 		icon: iconUrl(3099),
 	},
+	ESTEEM_CARVE_AND_SPIT: {
+		id: 17915,
+		name: 'Carve and Spit',
+		icon: iconUrl(3058),
+	},
+	ESTEEM_FLOOD_OF_SHADOW: {
+		id: 17907,
+		name: 'Flood of Shadow',
+		icon: iconUrl(3085),
+	},
 })

--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -7,6 +7,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2025-08-30'),
+		Changes: () => <>Display Edge and Flood of Darkness on the timeline for level synced content.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2025-06-03'),
 		Changes: () => <>Corrected Shadowstride icon.</>,
 		contributors: [CONTRIBUTORS.VIOLET],

--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -8,7 +8,7 @@ export const changelog = [
 	// },
 	{
 		date: new Date('2025-08-30'),
-		Changes: () => <>Display Edge and Flood of Darkness on the timeline for level synced content.</>,
+		Changes: () => <>Display Edge and Flood of Darkness, as well as lower level Esteem actions, on the timeline for level synced content.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],
 	},
 	{

--- a/src/parser/jobs/drk/modules/ActionTimeline.tsx
+++ b/src/parser/jobs/drk/modules/ActionTimeline.tsx
@@ -12,6 +12,8 @@ export class ActionTimeline extends CoreActionTimeline {
 		'SHADOWBRINGER',
 		'EDGE_OF_SHADOW',
 		'FLOOD_OF_SHADOW',
+		'EDGE_OF_DARKNESS',
+		'FLOOD_OF_DARKNESS',
 		'CARVE_AND_SPIT',
 		'ABYSSAL_DRAIN',
 		['SALTED_EARTH', 'SALT_AND_DARKNESS'],


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1408032099419816088
- [x] The goal of this PR is detailed below:

We typically try to have the timeline be complete for lower level content, even if analysis doesn't account for level synced versions of current-level actions. DRK was missing the data definitions for Edge and Flood of Darkness (which later upgrade to Edge and Flood of Shadow), so those were not showing up on the timeline. Adding those, and updating the ActionTimeline override to make sure they keep displaying in the same order as their higher-level equivalents.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
  - http://localhost:3000/fflogs/pPHtyDJxmMZKnQVC/48/372

## Job Maintenance
- [x] I am active on the xivanalysis Discord ~~and part of the job maintainers group for the job(s) in this PR~~
