### PR TITLE
Remaining patch 7.3 bumps

### DIFF
--- a/src/parser/jobs/mch/index.tsx
+++ b/src/parser/jobs/mch/index.tsx
@@ -24,7 +24,7 @@ export const MACHINIST = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.2',
+		to: '7.3',
 	},
 
 	contributors: [

--- a/src/parser/jobs/mch/modules/MultiHitSkills.ts
+++ b/src/parser/jobs/mch/modules/MultiHitSkills.ts
@@ -1,6 +1,10 @@
 import {ACTIONS} from 'data/ACTIONS'
 import {AoEUsages} from 'parser/core/modules/AoEUsages'
 
+// Drill's potency was boosted from 600p to 620p in 7.3, so it now takes three targets for Bioblaster to pull ahead
+const BIO_BEFORE_73 = 2
+const BIO_AFTER_73 = 3
+
 export class MultiHitSkills extends AoEUsages {
 	suggestionIcon = ACTIONS.SPREAD_SHOT.icon
 
@@ -8,7 +12,7 @@ export class MultiHitSkills extends AoEUsages {
 		{
 			aoeAction: ACTIONS.BIOBLASTER,
 			stActions: [ACTIONS.DRILL],
-			minTargets: 2,
+			minTargets: this.parser.patch.before('7.3') ? BIO_BEFORE_73 : BIO_AFTER_73,
 		}, {
 			aoeAction: ACTIONS.AUTO_CROSSBOW,
 			stActions: [ACTIONS.BLAZING_SHOT],

--- a/src/parser/jobs/mnk/index.tsx
+++ b/src/parser/jobs/mnk/index.tsx
@@ -19,7 +19,7 @@ export const MONK = new Meta({
 
 	supportedPatches: {
 		from: '7.01',
-		to: '7.2',
+		to: '7.3',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sch/index.tsx
+++ b/src/parser/jobs/sch/index.tsx
@@ -17,7 +17,7 @@ export const SCHOLAR = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.2',
+		to: '7.3',
 	},
 
 	contributors: [

--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -21,7 +21,7 @@ export const SUMMONER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.2',
+		to: '7.3',
 	},
 
 	contributors: [

--- a/src/parser/jobs/smn/modules/MultiHitSkills.ts
+++ b/src/parser/jobs/smn/modules/MultiHitSkills.ts
@@ -3,6 +3,10 @@ import {AoEUsages} from 'parser/core/modules/AoEUsages'
 const PF_BP_71 = 3
 const PF_BP_72 = 4
 
+// Ruin 3 was boosted from 360p to 400p in 7.3, so it now takes 4 targets before Tri Disaster wins out
+const TD_BEFORE_73 = 3
+const TD_AFTER_73 = 4
+
 export class AoeChecker extends AoEUsages {
 	suggestionIcon = this.data.actions.TRI_DISASTER.icon
 
@@ -10,7 +14,7 @@ export class AoeChecker extends AoEUsages {
 		{
 			aoeAction: this.data.actions.TRI_DISASTER,
 			stActions: [this.data.actions.RUIN_III],
-			minTargets: 3,
+			minTargets: this.parser.patch.before('7.3') ? TD_BEFORE_73 : TD_AFTER_73,
 		},
 		{
 			aoeAction: this.data.actions.ENERGY_SIPHON,


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

- [x] The job(s) in this patch bump had no changes for this patch
- [x] The job(s) in this patch bump had only potency changes for this patch, which do not effect analysis
  - [ ] I have updated the data files for all potency changes for this patch
  - [x] The skills and jobs affected by these potency changes do not track potency for xivanaylsis purposes
- [x] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch

- MNK and SCH had no changes in patch 7.3 that altered their analysis
- MCH and SMN each had one potency change that affected AoE thresholds
  - MCH: Drill got a potency bump which meant Bioblaster needed an extra target
  - SMN: Ruin III got a potency bump which meant Tri-Disaster needed an extra target

## Job Maintenance
- [x] I am active on the xivanalysis Discord ~~and part of the job maintainers group for the job(s) in this PR~~
