### PR TITLE
[DRK] Add indicator about which Esteems were incorrect

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -566,6 +566,7 @@
   "drk.delirium.suggestions.gcdactions.content": "",
   "drk.delirium.title": "Blutdelirium-Nutzung",
   "drk.esteem.nonstandard.rotation": "",
+  "drk.esteem.nonstandard.rotation.header": "",
   "drk.esteem.nonstandard.rotation.why": "",
   "drk.esteem.rotation.window.description": "",
   "drk.esteem.rotation.window.title": "",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -566,7 +566,7 @@
   "drk.delirium.suggestions.gcdactions.content": "Each <0/> window should contain <1/>, <2/>, and <3/>, or three <4/>s. Using non-Delirium combo actions resets your Delirium combo progress and causes you to lose the increased potency of the comboed skills.",
   "drk.delirium.title": "Delirium Usage",
   "drk.esteem.nonstandard.rotation": "<0/> lost potency due to either not executing its full rotation or being interrupted, such as by being out of range part way through. <1/> accounts for a lot of your damage, make sure to use it when it will be able to execute its full rotation, and in a position where it will not become out of range.",
-  "drk.esteem.nonstandard.rotation.header": "Full damage?",
+  "drk.esteem.nonstandard.rotation.header": "Full Damage?",
   "drk.esteem.nonstandard.rotation.why": "{badLivingShadows, plural, one {# Living Shadow} other {# Living Shadows}} lost potency due to Esteem having its rotation interrupted by downtime or range.",
   "drk.esteem.rotation.window.description": "This shows the actions used by Esteem following each use of <0/>. If uninterrupted, at level 100, Esteem will use the following six abilities in order: <1/>, <2/>, <3/>, <4/>, <5/>, <6/>. Less than six abilities indicates Esteem did not get all of its attacks off on an enemy, such as due to the boss phasing. Duplicate abilities indicate that Esteem was out of range at one or more points during its attacks. Both can be significant potency losses.",
   "drk.esteem.rotation.window.title": "Actions Used By Esteem (Living Shadow)",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -566,6 +566,7 @@
   "drk.delirium.suggestions.gcdactions.content": "Each <0/> window should contain <1/>, <2/>, and <3/>, or three <4/>s. Using non-Delirium combo actions resets your Delirium combo progress and causes you to lose the increased potency of the comboed skills.",
   "drk.delirium.title": "Delirium Usage",
   "drk.esteem.nonstandard.rotation": "<0/> lost potency due to either not executing its full rotation or being interrupted, such as by being out of range part way through. <1/> accounts for a lot of your damage, make sure to use it when it will be able to execute its full rotation, and in a position where it will not become out of range.",
+  "drk.esteem.nonstandard.rotation.header": "Full damage?",
   "drk.esteem.nonstandard.rotation.why": "{badLivingShadows, plural, one {# Living Shadow} other {# Living Shadows}} lost potency due to Esteem having its rotation interrupted by downtime or range.",
   "drk.esteem.rotation.window.description": "This shows the actions used by Esteem following each use of <0/>. If uninterrupted, at level 100, Esteem will use the following six abilities in order: <1/>, <2/>, <3/>, <4/>, <5/>, <6/>. Less than six abilities indicates Esteem did not get all of its attacks off on an enemy, such as due to the boss phasing. Duplicate abilities indicate that Esteem was out of range at one or more points during its attacks. Both can be significant potency losses.",
   "drk.esteem.rotation.window.title": "Actions Used By Esteem (Living Shadow)",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -566,6 +566,7 @@
   "drk.delirium.suggestions.gcdactions.content": "Chaque fenêtre de <0/> devrait contenir <1/>, <2/> et <3/>, ou trois <4/>s. Utiliser des techniques d'armes de votre combo de base annule l'avancée de votre combo Delirium et occasionne donc une perte de dégâts.",
   "drk.delirium.title": "Utilisation de Delirium de sang",
   "drk.esteem.nonstandard.rotation": "",
+  "drk.esteem.nonstandard.rotation.header": "",
   "drk.esteem.nonstandard.rotation.why": "",
   "drk.esteem.rotation.window.description": "",
   "drk.esteem.rotation.window.title": "",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -566,6 +566,7 @@
   "drk.delirium.suggestions.gcdactions.content": "",
   "drk.delirium.title": "ブラッドデリリアムの使用状況",
   "drk.esteem.nonstandard.rotation": "",
+  "drk.esteem.nonstandard.rotation.header": "",
   "drk.esteem.nonstandard.rotation.why": "",
   "drk.esteem.rotation.window.description": "",
   "drk.esteem.rotation.window.title": "",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -566,6 +566,7 @@
   "drk.delirium.suggestions.gcdactions.content": "",
   "drk.delirium.title": "피의 열광 사용",
   "drk.esteem.nonstandard.rotation": "",
+  "drk.esteem.nonstandard.rotation.header": "",
   "drk.esteem.nonstandard.rotation.why": "",
   "drk.esteem.rotation.window.description": "",
   "drk.esteem.rotation.window.title": "",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -566,6 +566,7 @@
   "drk.delirium.suggestions.gcdactions.content": "每个<0/>窗口应包含<1/>、<2/>和<3/>，或者三个<4/>，使用非血乱连击技能会中断血乱连击，导致血乱连击后续技能的高威力丧失。",
   "drk.delirium.title": "血乱的使用",
   "drk.esteem.nonstandard.rotation": "",
+  "drk.esteem.nonstandard.rotation.header": "",
   "drk.esteem.nonstandard.rotation.why": "",
   "drk.esteem.rotation.window.description": "",
   "drk.esteem.rotation.window.title": "",

--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// },
 	//
 	{
+		date: new Date('2025-12-11'),
+		Changes: () => <>Made Living Shadow evaluator clearer as to which uses were full damage and which weren't.</>,
+		contributors: [CONTRIBUTORS.VIOLET],
+	},
+	{
 		date: new Date('2025-12-05'),
 		Changes: () => <>Fixed minor issue where Living Shadow usages would be marked as having lost potency when only equivalent actions were replaced by Abyssal Drain.</>,
 		contributors: [CONTRIBUTORS.VIOLET],

--- a/src/parser/jobs/drk/modules/EsteemUsageEvaluator.tsx
+++ b/src/parser/jobs/drk/modules/EsteemUsageEvaluator.tsx
@@ -23,7 +23,7 @@ export class EsteemUsageEvaluator extends RulePassedEvaluator  {
 	private actorLevelFunc: () => number | undefined
 
 	override header = {
-		header: <Trans id="drk.esteem.nonstandard.rotation.header">Full damage?</Trans>,
+		header: <Trans id="drk.esteem.nonstandard.rotation.header">Full Damage?</Trans>,
 		accessor: 'fulldamage',
 	}
 

--- a/src/parser/jobs/drk/modules/EsteemUsageEvaluator.tsx
+++ b/src/parser/jobs/drk/modules/EsteemUsageEvaluator.tsx
@@ -22,7 +22,10 @@ export class EsteemUsageEvaluator extends RulePassedEvaluator  {
 	private equivalentActionIds: number[]
 	private actorLevelFunc: () => number | undefined
 
-	override header = undefined
+	override header = {
+		header: <Trans id="drk.esteem.nonstandard.rotation.header">Full damage?</Trans>,
+		accessor: 'fulldamage',
+	}
 
 	constructor(opts: EsteemUsageEvaluatorOpts) {
 		super()


### PR DESCRIPTION
## Pull request type

- [X] This is new functionality or an addition to existing functionality

## Pull request details
Adds "Full damage?" header to Esteem evaluator
<img width="987" height="643" alt="image" src="https://github.com/user-attachments/assets/b9b79956-5d0a-4987-a0f1-0d8b2f8fa388" />

<img width="955" height="567" alt="image" src="https://github.com/user-attachments/assets/32cf45d5-04f1-4a53-bf6f-21395113e5ac" />


## Testing / Validation
https://xivanalysis.com//fflogs/a:XxAFJpLgP7ZYQ62m/5/134

## Job Maintenance
Active in discord but not official job maintainer.
