### PR TITLE
Patch 7.4 definition

### DIFF
--- a/src/data/ACTIONS/layers/index.ts
+++ b/src/data/ACTIONS/layers/index.ts
@@ -5,6 +5,7 @@ import {patch705} from './patch7.05'
 import {patch710} from './patch7.1'
 import {patch720} from './patch7.2'
 import {patch730} from './patch7.3'
+import {patch740} from './patch7.4'
 
 export const layers: Array<Layer<ActionRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -15,4 +16,5 @@ export const layers: Array<Layer<ActionRoot>> = [
 	patch710,
 	patch720,
 	patch730,
+	patch740,
 ]

--- a/src/data/ACTIONS/layers/patch7.4.ts
+++ b/src/data/ACTIONS/layers/patch7.4.ts
@@ -1,0 +1,8 @@
+import {Layer} from 'data/layer'
+import {ActionRoot} from '../root'
+
+export const patch740: Layer<ActionRoot> = {
+	patch: '7.4',
+	data: {
+	},
+}

--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -95,6 +95,12 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 			[GameEdition.CHINESE]: 1757982344, // 16/09/25 08:00:00 GMT
 		},
 	},
+	'7.4': {
+		date: {
+			[GameEdition.GLOBAL]: 1765872000, // 25/12/16 8:00:00 GMT
+			[GameEdition.CHINESE]: 1765872000, // CN is synced with global as of 7.4
+		},
+	},
 })
 
 export type PatchNumber = keyof typeof PATCHES

--- a/src/data/STATUSES/layers/index.ts
+++ b/src/data/STATUSES/layers/index.ts
@@ -4,6 +4,7 @@ import {patch701} from './patch7.01'
 import {patch705} from './patch7.05'
 import {patch710} from './patch7.1'
 import {patch720} from './patch7.2'
+import {patch740} from './patch7.4'
 
 export const layers: Array<Layer<StatusRoot>> = [
 	// Layers should be in their own files, and imported for use here.
@@ -13,4 +14,5 @@ export const layers: Array<Layer<StatusRoot>> = [
 	patch705,
 	patch710,
 	patch720,
+	patch740,
 ]

--- a/src/data/STATUSES/layers/patch7.4.ts
+++ b/src/data/STATUSES/layers/patch7.4.ts
@@ -1,0 +1,8 @@
+import {Layer} from 'data/layer'
+import {StatusRoot} from '../root'
+
+export const patch740: Layer<StatusRoot> = {
+	patch: '7.4',
+	data: {
+	},
+}

--- a/src/parser/jobs/blm/index.tsx
+++ b/src/parser/jobs/blm/index.tsx
@@ -13,7 +13,7 @@ export const BLACK_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/blu/index.tsx
+++ b/src/parser/jobs/blu/index.tsx
@@ -19,7 +19,7 @@ export const BLUE_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -15,7 +15,7 @@ export const DRAGOON = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/mnk/index.tsx
+++ b/src/parser/jobs/mnk/index.tsx
@@ -19,7 +19,7 @@ export const MONK = new Meta({
 
 	supportedPatches: {
 		from: '7.01',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/pct/index.tsx
+++ b/src/parser/jobs/pct/index.tsx
@@ -19,7 +19,7 @@ export const PICTOMANCER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -19,7 +19,7 @@ export const PALADIN = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/rpr/index.tsx
+++ b/src/parser/jobs/rpr/index.tsx
@@ -16,7 +16,7 @@ export const REAPER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sam/index.tsx
+++ b/src/parser/jobs/sam/index.tsx
@@ -13,7 +13,7 @@ export const SAMURAI = new Meta({
 
 	supportedPatches: {
 		from: '7.05',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -21,7 +21,7 @@ export const SUMMONER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/war/index.tsx
+++ b/src/parser/jobs/war/index.tsx
@@ -16,7 +16,7 @@ export const WARRIOR = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [x] This is a patch preparation change

## Pull request details

Creates the patch 7.4 data defintions, and adds action/status data layer files in the likely chance that we'll need both for 7.4.

Does not seek to bump anything for support, we'll do that after the patch goes up and logs of new fights get uploaded to test with.

12/16 edit: Now also includes patch bumps for the jobs that didn't receive updates (they'll still show as outdated for now since core is not yet bumped)

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
