### PR TITLE
[DRK] Include pre-pull Living Shadows for 'Use your cooldowns' and Esteem evaluator

### DIFF
--- a/src/data/ACTIONS/layers/patch7.1.ts
+++ b/src/data/ACTIONS/layers/patch7.1.ts
@@ -109,5 +109,30 @@ export const patch710: Layer<ActionRoot> = {
 		VERHOLY: {
 			potency: 650,
 		},
+
+		SCARLET_DELIRIUM: {
+			potencies: [
+				{
+					value: 620,
+					bonusModifiers: [],
+				},
+			],
+		},
+		COMEUPPANCE: {
+			potencies: [
+				{
+					value: 720,
+					bonusModifiers: [],
+				},
+			],
+		},
+		TORCLEAVER: {
+			potencies: [
+				{
+					value: 820,
+					bonusModifiers: [],
+				},
+			],
+		},
 	},
 }

--- a/src/data/ACTIONS/layers/patch7.1.ts
+++ b/src/data/ACTIONS/layers/patch7.1.ts
@@ -110,6 +110,14 @@ export const patch710: Layer<ActionRoot> = {
 			potency: 650,
 		},
 
+		BLOODSPILLER: {
+			potencies: [
+				{
+					value: 600,
+					bonusModifiers: [],
+				},
+			],
+		},
 		SCARLET_DELIRIUM: {
 			potencies: [
 				{

--- a/src/data/ACTIONS/root/DRK.ts
+++ b/src/data/ACTIONS/root/DRK.ts
@@ -296,7 +296,7 @@ export const DRK = ensureActions({
 		speedAttribute: Attribute.SKILL_SPEED,
 		breaksCombo: false,
 		potencies: [{
-			value: 620,
+			value: 600,
 			bonusModifiers: [],
 		}],
 	},
@@ -308,7 +308,7 @@ export const DRK = ensureActions({
 		speedAttribute: Attribute.SKILL_SPEED,
 		breaksCombo: false,
 		potencies: [{
-			value: 720,
+			value: 700,
 			bonusModifiers: [],
 		}],
 	},
@@ -320,7 +320,7 @@ export const DRK = ensureActions({
 		speedAttribute: Attribute.SKILL_SPEED,
 		breaksCombo: false,
 		potencies: [{
-			value: 820,
+			value: 800,
 			bonusModifiers: [],
 		}],
 	},
@@ -344,7 +344,7 @@ export const DRK = ensureActions({
 		speedAttribute: Attribute.SKILL_SPEED,
 		breaksCombo: false,
 		potencies: [{
-			value: 1000,
+			value: 800,
 			bonusModifiers: [],
 		}],
 	},

--- a/src/data/ACTIONS/root/DRK.ts
+++ b/src/data/ACTIONS/root/DRK.ts
@@ -180,7 +180,7 @@ export const DRK = ensureActions({
 		speedAttribute: Attribute.SKILL_SPEED,
 		breaksCombo: false,
 		potencies: [{
-			value: 600,
+			value: 580,
 			bonusModifiers: [],
 		}],
 	},

--- a/src/data/ACTIONS/root/DRK.ts
+++ b/src/data/ACTIONS/root/DRK.ts
@@ -344,7 +344,7 @@ export const DRK = ensureActions({
 		speedAttribute: Attribute.SKILL_SPEED,
 		breaksCombo: false,
 		potencies: [{
-			value: 800,
+			value: 1000,
 			bonusModifiers: [],
 		}],
 	},

--- a/src/data/STATUSES/root/DRK.ts
+++ b/src/data/STATUSES/root/DRK.ts
@@ -87,4 +87,10 @@ export const DRK = ensureStatuses({
 		icon: iconUrl(213127),
 		duration: 20000,
 	},
+	SCORN: {
+		id: 3837,
+		name: 'Scorn',
+		icon: iconUrl(213126),
+		duration: 30000,
+	},
 })

--- a/src/parser/core/modules/CooldownDowntime.tsx
+++ b/src/parser/core/modules/CooldownDowntime.tsx
@@ -89,7 +89,7 @@ export abstract class CooldownDowntime extends Analyser {
 		return this.trackedCds.concat(this.suggestionOnlyCooldowns)
 	}
 
-	private usages = new Map<CooldownGroup, Array<Events['action']>>()
+	protected usages = new Map<CooldownGroup, Array<Events['action']>>()
 	private resets = new Map<CooldownGroup, Array<Events['action']>>()
 
 	protected checklistName = <Trans id="core.cooldownDowntime.use-ogcd-cds">Use your cooldowns</Trans>

--- a/src/parser/core/modules/CooldownDowntime.tsx
+++ b/src/parser/core/modules/CooldownDowntime.tsx
@@ -89,7 +89,7 @@ export abstract class CooldownDowntime extends Analyser {
 		return this.trackedCds.concat(this.suggestionOnlyCooldowns)
 	}
 
-	protected usages = new Map<CooldownGroup, Array<Events['action']>>()
+	private usages = new Map<CooldownGroup, Array<Events['action']>>()
 	private resets = new Map<CooldownGroup, Array<Events['action']>>()
 
 	protected checklistName = <Trans id="core.cooldownDowntime.use-ogcd-cds">Use your cooldowns</Trans>

--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog = [
 	//
 	{
 		date: new Date('2025-12-11'),
+		Changes: () => <>Living Shadow used prepull now counts towards usage for cooldown evaluation, and is shown in the Esteem evaluator.</>,
+		contributors: [CONTRIBUTORS.VIOLET],
+	},
+	{
+		date: new Date('2025-12-11'),
 		Changes: () => <>Made Living Shadow evaluator clearer as to which uses were full damage and which weren't.</>,
 		contributors: [CONTRIBUTORS.VIOLET],
 	},

--- a/src/parser/jobs/drk/modules/EsteemWindow.tsx
+++ b/src/parser/jobs/drk/modules/EsteemWindow.tsx
@@ -65,6 +65,10 @@ export class EsteemWindow extends ActionWindow {
 
 	@dependency private actors!: Actors
 
+	// If Scorn is being applied in the log (it is a level 100 log) then we should
+	// index Esteem starting off Scorn instead of Living Shadow usage.
+	private shouldUseScorn = false
+
 	override initialise() {
 		super.initialise()
 
@@ -76,13 +80,19 @@ export class EsteemWindow extends ActionWindow {
 			return esteemActionFilter(event)
 		})
 
+		// Note: we _want_ to index off Scorn being applied instead of Living Shadow being used
+		// since this captures pre-pull Living Shadows too.
+		// We can only do this if Scorn is being applied (we don't know the level right now).
+		// We add both event hooks, and the event hooks will figure out if they should be starting
+		// the window or not based on whether Scorn gets used.
 		const statusApplyFilter = filter<Event>()
 			.source(this.parser.actor.id)
 			.type("statusApply")
-
-		// Note: we index off Scorn being applied instead of Living Shadow being used
-		// since this captures pre-pull Living Shadows too.
-		this.addEventHook(statusApplyFilter.status(this.data.statuses.SCORN.id), this.beginEsteem)
+		this.addEventHook(statusApplyFilter.status(this.data.statuses.SCORN.id), this.beginEsteemWithScorn)
+		const playerActionFilter = filter<Event>()
+			.source(this.parser.actor.id)
+			.type('action')
+		this.addEventHook(playerActionFilter.action(this.data.matchActionId([EsteemWindow.LIVING_SHADOW_ACTION_KEY])), this.beginEsteemLivingShadow)
 
 		this.addEvaluator(new EsteemUsageEvaluator({
 			suggestionIcon: this.data.actions.LIVING_SHADOW.icon,
@@ -124,7 +134,23 @@ export class EsteemWindow extends ActionWindow {
 		return {action: action.action.id}
 	}
 
-	private beginEsteem(event: Events['statusApply']) {
+	private beginEsteemWithScorn(event: Events['statusApply']) {
+		// Scorn is being applied, so we should use Scorn to index Living Shadow usage:
+		this.shouldUseScorn = true
+
+		// Forcibly close any open windows, i.e. each Esteem Window is until the next Living Shadow is used
+		this.onWindowEnd(event.timestamp)
+		// Then start the new window
+		this.onWindowStart(event.timestamp)
+	}
+
+	private beginEsteemLivingShadow(event: Events['action']) {
+		// The log has Scorn usages, so we should ignore Living Shadow usages for the purposes
+		// of starting the window.
+		if (this.shouldUseScorn) {
+			return
+		}
+
 		// Forcibly close any open windows, i.e. each Esteem Window is until the next Living Shadow is used
 		this.onWindowEnd(event.timestamp)
 		// Then start the new window

--- a/src/parser/jobs/drk/modules/EsteemWindow.tsx
+++ b/src/parser/jobs/drk/modules/EsteemWindow.tsx
@@ -68,23 +68,21 @@ export class EsteemWindow extends ActionWindow {
 	override initialise() {
 		super.initialise()
 
-		const playerFilter = filter<Event>().source(this.parser.actor.id)
 		const pets = this.parser.pull.actors.filter(actor => actor.owner === this.parser.actor).map(actor => actor.id)
-
-		const playerActionFilter = filter<Event>()
-			.source(this.parser.actor.id)
-			.type('action')
 		const esteemActionFilter = filter<Event>()
 			.source(oneOf(pets))
 			.type('action')
 		this.setEventFilter((event): event is Events['action'] => {
-			if (playerActionFilter(event)) {
-				return event.action === this.data.actions[EsteemWindow.LIVING_SHADOW_ACTION_KEY].id
-			}
 			return esteemActionFilter(event)
 		})
 
-		this.addEventHook(playerFilter.type('action').action(this.data.matchActionId([EsteemWindow.LIVING_SHADOW_ACTION_KEY])), this.beginEsteem)
+		const statusApplyFilter = filter<Event>()
+			.source(this.parser.actor.id)
+			.type("statusApply")
+
+		// Note: we index off Scorn being applied instead of Living Shadow being used
+		// since this captures pre-pull Living Shadows too.
+		this.addEventHook(statusApplyFilter.status(this.data.statuses.SCORN.id), this.beginEsteem)
 
 		this.addEvaluator(new EsteemUsageEvaluator({
 			suggestionIcon: this.data.actions.LIVING_SHADOW.icon,
@@ -126,11 +124,10 @@ export class EsteemWindow extends ActionWindow {
 		return {action: action.action.id}
 	}
 
-	private beginEsteem(event: Events['action']) {
+	private beginEsteem(event: Events['statusApply']) {
 		// Forcibly close any open windows, i.e. each Esteem Window is until the next Living Shadow is used
 		this.onWindowEnd(event.timestamp)
 		// Then start the new window
 		this.onWindowStart(event.timestamp)
 	}
-
 }

--- a/src/parser/jobs/drk/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drk/modules/OGCDDowntime.ts
@@ -45,7 +45,7 @@ export class OGCDDowntime extends CooldownDowntime {
 		if (group.cooldowns.includes(this.data.actions.LIVING_SHADOW)) {
 			return this.numberOfScorns
 		}
-		return (this.usages.get(group) ?? []).length
+		return super.calculateUsageCount(group)
 
 	}
 

--- a/src/parser/jobs/drk/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drk/modules/OGCDDowntime.ts
@@ -39,13 +39,18 @@ export class OGCDDowntime extends CooldownDowntime {
 	}
 
 	override calculateUsageCount(group: CooldownGroup): number {
+		const usageCount = super.calculateUsageCount(group)
 		// Note: we index off Scorn being applied instead of Living Shadow being used
 		// since this captures pre-pull Living Shadows too. fflogs does not include
 		// Living Shadows used pre-pull, but it does include Scorn.
+		// We still want to check if Scorn >= usageCount since Scorn does not exist
+		// at lower levels.
 		if (group.cooldowns.includes(this.data.actions.LIVING_SHADOW)) {
-			return this.numberOfScorns
+			if (this.numberOfScorns >= usageCount) {
+				return this.numberOfScorns
+			}
 		}
-		return super.calculateUsageCount(group)
+		return usageCount
 
 	}
 

--- a/src/parser/jobs/drk/modules/OGCDDowntime.ts
+++ b/src/parser/jobs/drk/modules/OGCDDowntime.ts
@@ -1,6 +1,11 @@
-import {CooldownDowntime} from 'parser/core/modules/CooldownDowntime'
+import {Event} from 'event'
+import {filter} from 'parser/core/filter'
+import {CooldownDowntime, CooldownGroup} from 'parser/core/modules/CooldownDowntime'
 
 export class OGCDDowntime extends CooldownDowntime {
+
+	private numberOfScorns = 0
+
 	override trackedCds = [
 		{
 			cooldowns: [this.data.actions.DELIRIUM],
@@ -23,4 +28,28 @@ export class OGCDDowntime extends CooldownDowntime {
 			firstUseOffset: 5000,
 		},
 	]
+
+	override initialise() {
+		super.initialise()
+		const statusApplyFilter = filter<Event>()
+			.source(this.parser.actor.id)
+			.type("statusApply")
+
+		this.addEventHook(statusApplyFilter.status(this.data.statuses.SCORN.id), this.scornUsed)
+	}
+
+	override calculateUsageCount(group: CooldownGroup): number {
+		// Note: we index off Scorn being applied instead of Living Shadow being used
+		// since this captures pre-pull Living Shadows too. fflogs does not include
+		// Living Shadows used pre-pull, but it does include Scorn.
+		if (group.cooldowns.includes(this.data.actions.LIVING_SHADOW)) {
+			return this.numberOfScorns
+		}
+		return (this.usages.get(group) ?? []).length
+
+	}
+
+	private scornUsed() {
+		this.numberOfScorns++
+	}
 }


### PR DESCRIPTION
## Pull request type

- [X] This is a bugfix to existing functionality

## Pull request details

Indexes Living Shadow usage over Scorn being applied to the player instead of Living Shadow being used if the player is level 100. fflogs does not include Living Shadows used pre-pull, but it does always include Scorn.

- Fixes prepull Living Shadows not being counted for 'Use your cooldowns'
- Fixes actions used by Esteem not including prepull Esteems

Also visually changes the actions used by living shadow to remove Living Shadow

<img width="980" height="432" alt="image" src="https://github.com/user-attachments/assets/265c6049-93f8-407d-9373-c1c0832a8e03" />

Prepull Living Shadows are still absent for sub-100 logs, but everything displays as it did before.

## Testing / Validation
This log (rank 1 Necron) has a -6s Living Shadow
https://xivanalysis.com/fflogs/D31Mm8xw4yWBZfVt/2/12

Before:
<img width="419" height="216" alt="image" src="https://github.com/user-attachments/assets/becfbd52-9280-48de-8e31-284a204631da" />

<img width="989" height="365" alt="image" src="https://github.com/user-attachments/assets/047e81d7-dd0e-4ff2-96cd-788969b3d94b" />

After:
<img width="394" height="214" alt="image" src="https://github.com/user-attachments/assets/b9b94698-005f-4990-aa37-59a286036a20" />


<img width="986" height="416" alt="image" src="https://github.com/user-attachments/assets/600c81d3-cbdb-4565-aa01-e085e28570c8" />


## Job Maintenance
Not a maintainer but I am active on discord.