### PR TITLE
[AST] Bump 7.4 and remove unnecessary CO from overheal

### DIFF
--- a/src/data/STATUSES/layers/patch7.4.ts
+++ b/src/data/STATUSES/layers/patch7.4.ts
@@ -4,5 +4,8 @@ import {StatusRoot} from '../root'
 export const patch740: Layer<StatusRoot> = {
 	patch: '7.4',
 	data: {
+		COLLECTIVE_UNCONSCIOUS_MITIGATION: {
+			duration: 10000,
+		},
 	},
 }

--- a/src/data/STATUSES/root/AST.ts
+++ b/src/data/STATUSES/root/AST.ts
@@ -77,7 +77,7 @@ export const AST = ensureStatuses({
 		id: 849,
 		name: 'Collective Unconscious (Mitigation)',
 		icon: iconUrl(213226),
-		duration: 18000,
+		duration: 10000,
 	},
 
 	WHEEL_OF_FORTUNE: {

--- a/src/data/STATUSES/root/AST.ts
+++ b/src/data/STATUSES/root/AST.ts
@@ -77,7 +77,7 @@ export const AST = ensureStatuses({
 		id: 849,
 		name: 'Collective Unconscious (Mitigation)',
 		icon: iconUrl(213226),
-		duration: 10000,
+		duration: 5000,
 	},
 
 	WHEEL_OF_FORTUNE: {

--- a/src/parser/jobs/ast/changelog.tsx
+++ b/src/parser/jobs/ast/changelog.tsx
@@ -3,6 +3,11 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2025-12-18'),
+		Changes: () => <>Removed the non-mit, non-heal portion of <DataLink status="COLLECTIVE_UNCONSCIOUS" /> from overhealing.</>,
+		contributors: [CONTRIBUTORS.OTOCEPHALY],
+	},
+	{
 		date: new Date('2025-04-20'),
 		Changes: () => <>Move Lightspeed and Swiftcast usage/cooldown availability information from Defensives to Utilities, and add Lucid Dreaming.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/ast/index.tsx
+++ b/src/parser/jobs/ast/index.tsx
@@ -29,7 +29,7 @@ export const ASTROLOGIAN = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/ast/modules/Overheal.tsx
+++ b/src/parser/jobs/ast/modules/Overheal.tsx
@@ -1,7 +1,6 @@
 import {Trans} from '@lingui/react/macro'
 import {DataLink} from 'components/ui/DbLink'
 import {Action} from 'data/ACTIONS'
-import {Status} from 'data/STATUSES'
 import {Events} from 'event'
 import {Overheal as CoreOverheal, TrackedOverhealOpts} from 'parser/core/modules/Overheal'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
@@ -10,12 +9,6 @@ const NEUTRAL_SECT_APPLICATION_BUCKET_ID = 1
 
 export class Overheal extends CoreOverheal {
 	protected override checklistDisplayOrder = DISPLAY_ORDER.OVERHEAL_CHECKLIST
-
-	private ignoredStatuses: Array<Status['id']> = [
-		//collective unconscious applies wheel of fortune during ticks when party member is within bubble so this specific status can be ignored
-		//note: there is a mit portion that isn't included in overhealing, but is tracked in a separate ID
-		this.data.statuses.COLLECTIVE_UNCONSCIOUS.id,
-	]
 
 	private readonly shieldGCDIds: Array<Action['id']> = [
 		this.data.actions.ASPECTED_BENEFIC.id,
@@ -94,13 +87,18 @@ export class Overheal extends CoreOverheal {
 				this.data.statuses.OPPOSITION.id,
 			],
 		},
+		{
+			name: 'Collective Unconscious (non-heal non-mit)',
+			trackedHealIds: [
+				this.data.statuses.COLLECTIVE_UNCONSCIOUS.id,
+			],
+			//collective unconscious applies wheel of fortune during ticks when party member is within bubble so this specific status can be ignored
+			//note: there is a mit portion that isn't included in overhealing, but is tracked in a separate ID
+			ignore: true,
+		},
 	]
 
 	protected override considerHeal(event: Events['heal'], pet?: boolean): boolean {
-		//ignore if these specific statuses
-		if (event.cause.type ==='status' && this.ignoredStatuses.includes(event.cause.status)) {
-			return false
-		}
 
 		// Default consideration for heals from actions and pet effects (ie. Star)
 		if (event.cause.type === 'action' || pet) { return true }

--- a/src/parser/jobs/ast/modules/Overheal.tsx
+++ b/src/parser/jobs/ast/modules/Overheal.tsx
@@ -99,7 +99,6 @@ export class Overheal extends CoreOverheal {
 	]
 
 	protected override considerHeal(event: Events['heal'], pet?: boolean): boolean {
-
 		// Default consideration for heals from actions and pet effects (ie. Star)
 		if (event.cause.type === 'action' || pet) { return true }
 

--- a/src/parser/jobs/ast/modules/Overheal.tsx
+++ b/src/parser/jobs/ast/modules/Overheal.tsx
@@ -1,6 +1,7 @@
 import {Trans} from '@lingui/react/macro'
 import {DataLink} from 'components/ui/DbLink'
 import {Action} from 'data/ACTIONS'
+import {Status} from 'data/STATUSES'
 import {Events} from 'event'
 import {Overheal as CoreOverheal, TrackedOverhealOpts} from 'parser/core/modules/Overheal'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
@@ -9,6 +10,12 @@ const NEUTRAL_SECT_APPLICATION_BUCKET_ID = 1
 
 export class Overheal extends CoreOverheal {
 	protected override checklistDisplayOrder = DISPLAY_ORDER.OVERHEAL_CHECKLIST
+
+	private ignoredStatuses: Array<Status['id']> = [
+		//collective unconscious applies wheel of fortune during ticks when party member is within bubble so this specific status can be ignored
+		//note: there is a mit portion that isn't included in overhealing, but is tracked in a separate ID
+		this.data.statuses.COLLECTIVE_UNCONSCIOUS.id,
+	]
 
 	private readonly shieldGCDIds: Array<Action['id']> = [
 		this.data.actions.ASPECTED_BENEFIC.id,
@@ -90,6 +97,11 @@ export class Overheal extends CoreOverheal {
 	]
 
 	protected override considerHeal(event: Events['heal'], pet?: boolean): boolean {
+		//ignore if these specific statuses
+		if (event.cause.type ==='status' && this.ignoredStatuses.includes(event.cause.status)) {
+			return false
+		}
+
 		// Default consideration for heals from actions and pet effects (ie. Star)
 		if (event.cause.type === 'action' || pet) { return true }
 


### PR DESCRIPTION
bumped 7.4 and removed the unnecessary status from overhealing for collective unconsciousness

## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [x] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [x] The goal of this PR is detailed below:

		*[For new functionality / added functionality, describe what is being added]*
		*[For bugfixes, please provide reproduction steps and what the expected vs actual behavior is in production right now]*
    - not count the non-heal, non-mit portion of collective unconscious and bump
    

<!-- If this PR is for a patch bump, please complete the section below.  For functionality additions or bug fixes, delete this comment and the section below -->
- [x] The job(s) in this patch bump had no changes for this patch
    - the change to Collective Unconscious has no additional effect on analysis since it just changed one status from 5 to 10 seconds. The other change was just to remove the non-heal, non-mit portion from being counted unnecessarily in overheal.

## Testing / Validation

<!-- If this PR contains any new functionality or bugfixes, please include log links that reviewers can use to help verify your changes.  Reviewers may also find additional logs to check your PR with, but having initial logs is important to speed the review process, especially for corner cases or hard to trigger analysis flags.  If this PR is a patch bump with no changes or potency only changes, you can delete this section. -->
- [x] I used the log(s) listed below to develop and test this bugfix:
- Any log where an AST cast collective unconscious at least once will show this. I used this one as an example https://www.fflogs.com/reports/t9X8rHvczjymMTgq?fight=3&source=6

   *[Provide a list of log links - either direct to FFLogs or the xivanalysis log link for development or production]*

## Job Maintenance
- [x] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it

## Screenshots
Before
<img width="1038" height="1030" alt="image" src="https://github.com/user-attachments/assets/063d9b1d-a696-40f1-86f7-23e2fe95b7e3" />

After
<img width="1342" height="1109" alt="image" src="https://github.com/user-attachments/assets/01a4d345-6bb4-4572-8a7b-a517f428cf50" />

