### PR TITLE
Patch 7.4 bumps - Core, DNC, SGE

### DIFF
--- a/src/data/ENCOUNTERS.ts
+++ b/src/data/ENCOUNTERS.ts
@@ -11,6 +11,7 @@ export interface Encounter {
 export const ENCOUNTERS = ensureRecord<Encounter>()({
 	TRASH: {ids: {legacyFflogs: '0'}},
 	DSR: {ids: {legacyFflogs: '1076'}},
+	EX_TRAIN: {ids: {legacyFflogs: '1083'}},
 	FRU: {ids: {legacyFflogs: '1079'}},
 })
 

--- a/src/generated/unableToActStatusIds.ts
+++ b/src/generated/unableToActStatusIds.ts
@@ -268,7 +268,10 @@ export const UNABLE_TO_ACT_STATUS_IDS = [
 	4513, // Now Boarding (lockControl)
 	4515, //  (lockActions)
 	4537, // Stone Curse (lockActions)
+	4568, // Sum of All Sins (lockActions, lockControl)
 	4578, // Fetters (lockActions, lockControl)
 	4618, // Standing Firm (lockActions, lockControl)
 	4619, //  (lockActions, lockControl)
+	5058, // Stone Curse (lockActions)
+	5174, // Forced March (lockActions)
 ]

--- a/src/parser/AVAILABLE_MODULES.ts
+++ b/src/parser/AVAILABLE_MODULES.ts
@@ -1,6 +1,7 @@
 import {EncounterKey} from 'data/ENCOUNTERS'
 import {JobKey} from 'data/JOBS'
 import {DSR} from './bosses/dsr'
+import {EX_TRAIN} from './bosses/extrain'
 import {FRU} from './bosses/fru'
 import {CORE} from './core'
 import {Meta} from './core/Meta'
@@ -67,6 +68,7 @@ export const AVAILABLE_MODULES: AvailableModules = {
 
 	BOSSES: {
 		DSR,
+		EX_TRAIN,
 		FRU,
 	},
 }

--- a/src/parser/bosses/extrain/index.tsx
+++ b/src/parser/bosses/extrain/index.tsx
@@ -1,0 +1,5 @@
+import {Meta} from 'parser/core/Meta'
+
+export const EX_TRAIN = new Meta({
+	modules: () => import('./modules' /* webpackChunkName: "bosses-ex-train" */),
+})

--- a/src/parser/bosses/extrain/modules/Invulnerability.ts
+++ b/src/parser/bosses/extrain/modules/Invulnerability.ts
@@ -1,10 +1,14 @@
 import {Event, Events} from 'event'
 import {EventHook} from 'parser/core/Dispatcher'
+import {dependency} from 'parser/core/Injectable'
+import {Data} from 'parser/core/modules/Data'
 import {Invulnerability as CoreInvulnerability} from 'parser/core/modules/Invulnerability'
 import {Actor} from 'report'
 import {filter, noneOf, oneOf} from '../../../core/filter'
 
 const DOOMTRAIN_ACTOR_KIND = '18999'
+const AETHER_ACTOR_KIND = '19002'
+
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 const DERAIL_ACTION_IDS: number[] = [
 	45709, // the first one after intermission
@@ -12,9 +16,13 @@ const DERAIL_ACTION_IDS: number[] = [
 	46490, // the last one
 ]
 /* eslint-enable @typescript-eslint/no-magic-numbers */
+const RUNAWAY_TRAIN_ACTION_ID = 45645
 
 export class Invulnerability extends CoreInvulnerability {
+	@dependency private data!: Data
+
 	private doomtrainActor: Actor | undefined
+	private aetherActorIds: Array<Actor['id']> = []
 
 	private derailEndByActionHook: EventHook<Events['action']> | null = null
 	private derailEndByPrepareHook: EventHook<Events['prepare']> | null = null
@@ -23,6 +31,14 @@ export class Invulnerability extends CoreInvulnerability {
 		super.initialise()
 
 		this.doomtrainActor = this.parser.pull.actors.find(actor => actor.kind === DOOMTRAIN_ACTOR_KIND)
+		this.aetherActorIds = this.parser.pull.actors.filter(actor => actor.kind === AETHER_ACTOR_KIND).map(actor => actor.id)
+
+		this.addEventHook(
+			filter<Event>()
+				.type('damage')
+				.cause(this.data.matchCauseActionId([RUNAWAY_TRAIN_ACTION_ID])),
+			this.onRunawayTrain
+		)
 
 		// Shouldn't happen but I can't be arsed to figure out the null coalesce
 		if (this.doomtrainActor == null) { return }
@@ -34,6 +50,21 @@ export class Invulnerability extends CoreInvulnerability {
 				.action(oneOf(DERAIL_ACTION_IDS)),
 			this.startDerailUntargetable
 		)
+	}
+
+	// The death event for the aether add in the intermission phase can apparently sometimes ghost, how fun
+	// If we see the runaway train damage event from the intermission end, and haven't seen it die,
+	// just go ahead and "kill" the add...
+	private onRunawayTrain(event: Events['damage']) {
+		this.aetherActorIds.forEach(aetherActorId => {
+			// If we got an actual death event, we don't have to fake one
+			if (!this.isActive({
+				timestamp: event.timestamp,
+				actorFilter: filter<Actor>().id(aetherActorId),
+			})) {
+				this.addStartEdge(aetherActorId, event.timestamp)
+			}
+		})
 	}
 
 	// When Derail hits, Doomtrain is no longer targetable, but DoTs are still ticking

--- a/src/parser/bosses/extrain/modules/Invulnerability.ts
+++ b/src/parser/bosses/extrain/modules/Invulnerability.ts
@@ -1,0 +1,79 @@
+import {Event, Events} from 'event'
+import {EventHook} from 'parser/core/Dispatcher'
+import {Invulnerability as CoreInvulnerability} from 'parser/core/modules/Invulnerability'
+import {Actor} from 'report'
+import {filter, noneOf, oneOf} from '../../../core/filter'
+
+const DOOMTRAIN_ACTOR_KIND = '18999'
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+const DERAIL_ACTION_IDS: number[] = [
+	45709, // the first one after intermission
+	46489, // the second one
+	46490, // the last one
+]
+/* eslint-enable @typescript-eslint/no-magic-numbers */
+
+export class Invulnerability extends CoreInvulnerability {
+	private doomtrainActor: Actor | undefined
+
+	private derailEndByActionHook: EventHook<Events['action']> | null = null
+	private derailEndByPrepareHook: EventHook<Events['prepare']> | null = null
+
+	override initialise(): void {
+		super.initialise()
+
+		this.doomtrainActor = this.parser.pull.actors.find(actor => actor.kind === DOOMTRAIN_ACTOR_KIND)
+
+		// Shouldn't happen but I can't be arsed to figure out the null coalesce
+		if (this.doomtrainActor == null) { return }
+
+		this.addEventHook(
+			filter<Event>()
+				.type('action')
+				.source(oneOf([this.doomtrainActor.id]))
+				.action(oneOf(DERAIL_ACTION_IDS)),
+			this.startDerailUntargetable
+		)
+	}
+
+	// When Derail hits, Doomtrain is no longer targetable, but DoTs are still ticking
+	private startDerailUntargetable(event: Events['action']) {
+		if (this.doomtrainActor == null) { return }
+		this.addTypeStartEdge('untargetable', this.doomtrainActor.id, event.timestamp)
+		this.setDerailEndEdgeHooks()
+	}
+
+	// We need to simulate the "first time targeted" behavior after each derail edge start
+	// We'll hook action and prepare events targeting Doomtrain, as long as they're not sourced from Doomtrain itself
+	private setDerailEndEdgeHooks() {
+		if (this.doomtrainActor == null) { return }
+		const doomtrainTargetFilter = filter<Event>().target(this.doomtrainActor.id).source(noneOf([this.doomtrainActor.id]))
+		this.derailEndByActionHook = this.addEventHook(
+			doomtrainTargetFilter.type('action'),
+			this.endDerailUntargetable
+		)
+		this.derailEndByPrepareHook = this.addEventHook(
+			doomtrainTargetFilter.type('prepare'),
+			this.endDerailUntargetable
+		)
+	}
+
+	// When we see an event targeting Doomtrain, we can close the untargetable window
+	private endDerailUntargetable(event: Events['action'] | Events['prepare']) {
+		this.unsetDerailEndEdgeHooks()
+		if (this.doomtrainActor == null) { return }
+		this.addTypeEndEdge('untargetable', this.doomtrainActor.id, event.timestamp)
+	}
+
+	// Unset the hooks when we're done to save processing time until the next window begins
+	private unsetDerailEndEdgeHooks() {
+		if (this.derailEndByActionHook) {
+			this.removeEventHook(this.derailEndByActionHook)
+			this.derailEndByActionHook = null
+		}
+		if (this.derailEndByPrepareHook) {
+			this.removeEventHook(this.derailEndByPrepareHook)
+			this.derailEndByPrepareHook = null
+		}
+	}
+}

--- a/src/parser/bosses/extrain/modules/index.ts
+++ b/src/parser/bosses/extrain/modules/index.ts
@@ -1,0 +1,5 @@
+import {Invulnerability} from "./Invulnerability"
+
+export const modules = [
+	Invulnerability,
+]

--- a/src/parser/core/index.tsx
+++ b/src/parser/core/index.tsx
@@ -15,7 +15,7 @@ export const CORE = new Meta({
 	// Read `docs/patch-checklist.md` before editing the following values.
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 })
 

--- a/src/parser/core/modules/Invulnerability.tsx
+++ b/src/parser/core/modules/Invulnerability.tsx
@@ -491,7 +491,7 @@ export class Invulnerability extends Analyser {
 		}
 	}
 
-	private addTypeStartEdge = (type: Type, actorId: Actor['id'], timestamp: number) => {
+	protected addTypeStartEdge = (type: Type, actorId: Actor['id'], timestamp: number) => {
 		const edges = this.getActorEdges(actorId)
 
 		const typeEdges = edges[type]
@@ -509,7 +509,7 @@ export class Invulnerability extends Analyser {
 		})
 	}
 
-	private addTypeEndEdge = (type: Type, actorId: Actor['id'], timestamp: number) => {
+	protected addTypeEndEdge = (type: Type, actorId: Actor['id'], timestamp: number) => {
 		const edges = this.getActorEdges(actorId)
 
 		const typeEdges = edges[type]

--- a/src/parser/core/modules/Invulnerability.tsx
+++ b/src/parser/core/modules/Invulnerability.tsx
@@ -109,7 +109,7 @@ const DEFAULT_ACTOR_FILTER = filter<Actor>().team(Team.FOE)
 
 export class Invulnerability extends Analyser {
 	static override handle = 'invulnerability'
-	static override debug = false
+	static override debug = true
 
 	@dependency private timeline!: Timeline
 
@@ -467,7 +467,7 @@ export class Invulnerability extends Analyser {
 		this.addEndEdge(targetId, timestamp - 1)
 	}
 
-	private addStartEdge = (actorId: Actor['id'], timestamp: number) =>
+	protected addStartEdge = (actorId: Actor['id'], timestamp: number) =>
 		this.mirrorTypeEdge(this.addTypeStartEdge, actorId, timestamp)
 
 	private addEndEdge(actorId: Actor['id'], timestamp: number) {

--- a/src/parser/core/modules/Invulnerability.tsx
+++ b/src/parser/core/modules/Invulnerability.tsx
@@ -109,7 +109,7 @@ const DEFAULT_ACTOR_FILTER = filter<Actor>().team(Team.FOE)
 
 export class Invulnerability extends Analyser {
 	static override handle = 'invulnerability'
-	static override debug = true
+	static override debug = false
 
 	@dependency private timeline!: Timeline
 

--- a/src/parser/jobs/dnc/index.tsx
+++ b/src/parser/jobs/dnc/index.tsx
@@ -25,7 +25,7 @@ export const DANCER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sge/index.tsx
+++ b/src/parser/jobs/sge/index.tsx
@@ -17,7 +17,7 @@ export const SAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

- [x] The job(s) in this patch bump had only potency changes for this patch, which do not effect analysis
  - [x] The skills and jobs affected by these potency changes do not track potency for xivanaylsis purposes
- [x] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch


Edit: 12/26/2025 - PR now includes handling the untargetable windows caused by Derail in the back half of Doomtrain Extreme. DoTs still tick in the back half so we don't get normal actorUpdate events for its targetability, and we have to synthesize the edges off the Derail action (of which there are three different IDs...) and the next subsequent action/prepare event targeting Doomtrain.

## Testing / Validation

Pick your favorite train EX or normal raid logs if you want to double-check the invuln stuff.

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
