### PR TITLE
WHM Patch 7.4 update

### DIFF
--- a/src/parser/jobs/whm/index.tsx
+++ b/src/parser/jobs/whm/index.tsx
@@ -20,7 +20,7 @@ export const WHITE_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.3',
+		to: '7.4',
 	},
 
 	contributors: [

--- a/src/parser/jobs/whm/modules/Lilies.tsx
+++ b/src/parser/jobs/whm/modules/Lilies.tsx
@@ -64,11 +64,12 @@ export class Lilies extends CoreGauge {
 
 	private lilyGauge = this.add(new CounterGauge({
 		maximum: LILY_MAX_STACKS,
-		initialValue: 0,
+		initialValue: this.parser.patch.before('7.4') ? 0 : LILY_MAX_STACKS,
 		graph: {
 			label: <Trans id="whm.gauge.lily.stacks.label">Lily</Trans>,
 			color: GAUGE_COLOURS.LILY_GAUGE,
 		},
+		correctHistory: true,
 	}))
 
 	private lilyTimer = this.add(new TimerGauge({
@@ -78,16 +79,16 @@ export class Lilies extends CoreGauge {
 			label: <Trans id="whm.gauge.lily.timer.label">Lily Timer</Trans>,
 			color: GAUGE_COLOURS.LILY_TIMER,
 		},
-
 	}))
 
 	private bloodLilyGauge = this.add(new CounterGauge({
 		maximum: LILY_MAX_STACKS,
-		initialValue: 0,
+		initialValue: this.parser.patch.before('7.4') ? 0 : LILY_MAX_STACKS,
 		graph: {
 			label: <Trans id="whm.gauge.bloodlily.stacks.label">Blood Lily</Trans>,
 			color: GAUGE_COLOURS.BLOODLILY,
 		},
+		correctHistory: true,
 	}))
 
 	override initialise() {
@@ -100,7 +101,9 @@ export class Lilies extends CoreGauge {
 
 		this.addEventHook('complete', this.onComplete)
 
-		this.lilyTimer.start()
+		if (this.parser.patch.before('7.4')) {
+			this.lilyTimer.start()
+		}
 	}
 
 	private onGain() {


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

- [x] This is the last PR after all analysis changes for this job have been merged, and now the job is ready to be marked supported for this patch

WHM's main change was to the Lily gauge, where it now starts full, akin to Sage's Addersting and Addersgall gauges. Added some patch conditionals to the lily and blood lilky gauge's initial value assignment, as well as turning history correction on for those gauges, and also conditioned the initial start of the lily gauge's timer on the path level.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
 - Pre 7.4: http://localhost:3000/fflogs/tr2y86zk7YvGWJDc/15/58
 - Post 7.4: http://localhost:3000/fflogs/r6k32NTKZXPRWHfn/11/12

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR