### PR TITLE
[DRK] Fix bug related to incorrectly logged dark arts for multiple dark knights in party

### DIFF
--- a/src/parser/jobs/drk/changelog.tsx
+++ b/src/parser/jobs/drk/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// },
 	//
 	{
+		date: new Date('2025-12-29'),
+		Changes: () => <>Fixed bug related to missed Dark Arts being incorrectly logged with multiple Dark Knights in the party.</>,
+		contributors: [CONTRIBUTORS.VIOLET],
+	},
+	{
 		date: new Date('2025-12-20'),
 		Changes: () => <>Patch 7.4 bump, minor bug fix related to Esteem evaluator, and severities adjusted.</>,
 		contributors: [CONTRIBUTORS.VIOLET],

--- a/src/parser/jobs/drk/modules/DarkArtsLost.tsx
+++ b/src/parser/jobs/drk/modules/DarkArtsLost.tsx
@@ -6,7 +6,6 @@ import {ActionKey} from 'data/ACTIONS'
 import {Event, Events} from 'event'
 import {filter} from 'parser/core/filter'
 import {Gauge} from 'parser/core/modules/Gauge'
-import {Team} from 'report'
 import {Table} from 'semantic-ui-react'
 
 const DARK_ARTS_SPENDERS: ActionKey[] = [
@@ -58,17 +57,13 @@ export class DarkArtsLost extends Gauge {
 			.type('action')
 			.action(this.data.matchActionId(DARK_ARTS_SPENDERS)), () => this.darkArts = false)
 
-		const friendlyTargets = this.parser.pull.actors
-			.filter(actor => actor.team === Team.FRIEND)
-			.map(actor => actor.id)
-
-		friendlyTargets.forEach((id) => {
-			this.addEventHook(
-				filter<Event>()
-					.source(id)
-					.type('statusRemove')
-					.status(this.data.statuses.BLACKEST_NIGHT.id), this.onRemoveBlackestNight)
-		})
+		const playerFilter = filter<Event>().source(this.parser.actor.id)
+		// Note: This approach misses the following chances to lose a Dark Arts:
+		// 1. You press TBN, and then a secondary Dark Knight uses TBN on the same target
+		// 2. You press TBN on another player, and that player's TBN does not pop (death/expiry/a second dark Knight using TBN on them/etc)
+		// For #1, it doesn't seem reasonable to mark it 'against' the player, and for #2, there are
+		// enough edge cases for minimal value that it seems fine to leave that for a future exercise.
+		this.addEventHook(playerFilter.type('statusRemove').status(this.data.statuses.BLACKEST_NIGHT.id), this.onRemoveBlackestNight)
 
 	}
 

--- a/src/parser/jobs/drk/modules/MPUsage.tsx
+++ b/src/parser/jobs/drk/modules/MPUsage.tsx
@@ -10,7 +10,6 @@ import {dependency} from 'parser/core/Injectable'
 import {Actors} from 'parser/core/modules/Actors'
 import {Data} from 'parser/core/modules/Data'
 import {Suggestions, SEVERITY, TieredSuggestion} from 'parser/core/modules/Suggestions'
-import {Team} from 'report'
 import {isSuccessfulHit} from 'utilities'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 
@@ -95,16 +94,12 @@ export class MPUsage extends Analyser {
 		this.addEventHook(playerFilter.type('statusApply').status(this.data.statuses.DELIRIUM.id), this.onApplyDelirium)
 		this.addEventHook(playerFilter.type('statusRemove').status(this.data.statuses.DELIRIUM.id), this.onRemoveDelirium)
 
-		const friendlyTargets = this.parser.pull.actors
-			.filter(actor => actor.team === Team.FRIEND)
-			.map(actor => actor.id)
-		friendlyTargets.forEach((id) => {
-			this.addEventHook(
-				filter<Event>()
-					.source(id)
-					.type('statusRemove')
-					.status(this.data.statuses.BLACKEST_NIGHT.id), this.onRemoveBlackestNight)
-		})
+		// Note: This approach misses the following chances to lose a Dark Arts:
+		// 1. You press TBN, and then a secondary Dark Knight uses TBN on the same target
+		// 2. You press TBN on another player, and that player's TBN does not pop (death/expiry/a second dark Knight using TBN on them/etc)
+		// For #1, it doesn't seem reasonable to mark it 'against' the player, and for #2, there are
+		// enough edge cases for minimal value that it seems fine to leave that for a future exercise.
+		this.addEventHook(playerFilter.type('statusRemove').status(this.data.statuses.BLACKEST_NIGHT.id), this.onRemoveBlackestNight)
 
 		this.addEventHook(playerFilter.type('action').action(this.data.matchActionId(DARK_ARTS_SPENDERS)), () => this.darkArts = false)
 


### PR DESCRIPTION
## Pull request type

- [X] This is a bugfix to existing functionality

## Pull request details

There appears to be a bug with the DRK module when multiple Dark Knights are in the party for the lost Dark Arts module.

There is validity to checking TBNs from multiple Dark Knights --- if I apply TBN to myself and then someone applies TBN to me before it popped, I lose my Dark Arts charge, but it appears the logic is flawed. [This log](https://xivanalysis.com/fflogs/a:pjy6xdNvazDkW1Cm/29/43) seems to show the linked Dark Knight having a suggestion due to a different Dark Knight using a TBN on a different party member at 5:57 for example.

It is probably possible to catch every edge case for lost dark arts, but also it seems incorrect to mark 'against' someone for a secondary DRK overwriting their TBN anyway. As a result, updated this to only care about TBNs from self to self (which it actually did before).

This is a regression I introduced in https://github.com/xivanalysis/xivanalysis/pull/2241 --- and the behaviour now matches what it was before that regression.

## Testing / Validation

Example log with incorrect Dark Arts missed logs (two DRKs in party):
https://xivanalysis.com/fflogs/a:pjy6xdNvazDkW1Cm/29/43

Example log with correct Dark Arts missed logs:
https://xivanalysis.com/fflogs/fxrmAT2nVHPZRa61/2/3

(After the change, both appear correctly)

## Job Maintenance
Not an official maintainer (I'd be happy to get more involved, though) but active in discord. Let me know if you have any concerns.