### PR TITLE
[BugFix] Correct Doomtrain invulnerability windows

### DIFF
--- a/src/parser/bosses/extrain/modules/Invulnerability.ts
+++ b/src/parser/bosses/extrain/modules/Invulnerability.ts
@@ -2,12 +2,14 @@ import {Event, Events} from 'event'
 import {EventHook} from 'parser/core/Dispatcher'
 import {dependency} from 'parser/core/Injectable'
 import {Data} from 'parser/core/modules/Data'
-import {Invulnerability as CoreInvulnerability} from 'parser/core/modules/Invulnerability'
+import {ActorsConfig, Invulnerability as CoreInvulnerability} from 'parser/core/modules/Invulnerability'
 import {Actor} from 'report'
 import {filter, noneOf, oneOf} from '../../../core/filter'
 
 const DOOMTRAIN_ACTOR_KIND = '18999'
 const AETHER_ACTOR_KIND = '19002'
+
+const DOOMTRAIN_INTERMISSION_EVENT_COUNT = 3
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 const DERAIL_ACTION_IDS: number[] = [
@@ -21,16 +23,23 @@ const RUNAWAY_TRAIN_ACTION_ID = 45645
 export class Invulnerability extends CoreInvulnerability {
 	@dependency private data!: Data
 
-	private doomtrainActor: Actor | undefined
+	private doomtrainActorId: Actor['id'] = ""
 	private aetherActorIds: Array<Actor['id']> = []
 
 	private derailEndByActionHook: EventHook<Events['action']> | null = null
 	private derailEndByPrepareHook: EventHook<Events['prepare']> | null = null
 
+	// Doomtrain takes DoT damage when it's untargetable in both halves of the fight, it's only invulnerable during the intermission
+	protected override actorConfig: ActorsConfig = [
+		{kind: {legacyFflogs: DOOMTRAIN_ACTOR_KIND}, exclude: false, mirrorToInvuln: false},
+	]
+
+	private trainEvents: number = 0
+
 	override initialise(): void {
 		super.initialise()
 
-		this.doomtrainActor = this.parser.pull.actors.find(actor => actor.kind === DOOMTRAIN_ACTOR_KIND)
+		this.doomtrainActorId = this.parser.pull.actors.find(actor => actor.kind === DOOMTRAIN_ACTOR_KIND)?.id ?? ""
 		this.aetherActorIds = this.parser.pull.actors.filter(actor => actor.kind === AETHER_ACTOR_KIND).map(actor => actor.id)
 
 		this.addEventHook(
@@ -40,16 +49,29 @@ export class Invulnerability extends CoreInvulnerability {
 			this.onRunawayTrain
 		)
 
-		// Shouldn't happen but I can't be arsed to figure out the null coalesce
-		if (this.doomtrainActor == null) { return }
-
 		this.addEventHook(
 			filter<Event>()
 				.type('action')
-				.source(oneOf([this.doomtrainActor.id]))
+				.source(oneOf([this.doomtrainActorId]))
 				.action(oneOf(DERAIL_ACTION_IDS)),
 			this.startDerailUntargetable
 		)
+	}
+
+	// Doomtrain is actually invulnerable during the intermission, which is the third untargetable event window reached during the fight.
+	// Since we're not mirroring events, manually start/end an invulnerable window as well as the untargetable one for that event.
+	protected override addStartEdge(actorId: Actor['id'], timestamp: number): void {
+		if (actorId === this.doomtrainActorId) { this.trainEvents++ }
+		super.addStartEdge(actorId, timestamp)
+		if (actorId === this.doomtrainActorId && this.trainEvents === DOOMTRAIN_INTERMISSION_EVENT_COUNT) {
+			this.addTypeStartEdge('invulnerable', this.doomtrainActorId, timestamp)
+		}
+	}
+	protected override addEndEdge(actorId: Actor['id'], timestamp: number): void {
+		super.addEndEdge(actorId, timestamp)
+		if (actorId === this.doomtrainActorId && this.trainEvents === DOOMTRAIN_INTERMISSION_EVENT_COUNT) {
+			this.addTypeEndEdge('invulnerable', this.doomtrainActorId, timestamp)
+		}
 	}
 
 	// The death event for the aether add in the intermission phase can apparently sometimes ghost, how fun
@@ -69,16 +91,14 @@ export class Invulnerability extends CoreInvulnerability {
 
 	// When Derail hits, Doomtrain is no longer targetable, but DoTs are still ticking
 	private startDerailUntargetable(event: Events['action']) {
-		if (this.doomtrainActor == null) { return }
-		this.addTypeStartEdge('untargetable', this.doomtrainActor.id, event.timestamp)
+		this.addStartEdge(this.doomtrainActorId, event.timestamp)
 		this.setDerailEndEdgeHooks()
 	}
 
 	// We need to simulate the "first time targeted" behavior after each derail edge start
 	// We'll hook action and prepare events targeting Doomtrain, as long as they're not sourced from Doomtrain itself
 	private setDerailEndEdgeHooks() {
-		if (this.doomtrainActor == null) { return }
-		const doomtrainTargetFilter = filter<Event>().target(this.doomtrainActor.id).source(noneOf([this.doomtrainActor.id]))
+		const doomtrainTargetFilter = filter<Event>().target(this.doomtrainActorId).source(noneOf([this.doomtrainActorId]))
 		this.derailEndByActionHook = this.addEventHook(
 			doomtrainTargetFilter.type('action'),
 			this.endDerailUntargetable
@@ -92,8 +112,7 @@ export class Invulnerability extends CoreInvulnerability {
 	// When we see an event targeting Doomtrain, we can close the untargetable window
 	private endDerailUntargetable(event: Events['action'] | Events['prepare']) {
 		this.unsetDerailEndEdgeHooks()
-		if (this.doomtrainActor == null) { return }
-		this.addTypeEndEdge('untargetable', this.doomtrainActor.id, event.timestamp)
+		this.addEndEdge(this.doomtrainActorId, event.timestamp)
 	}
 
 	// Unset the hooks when we're done to save processing time until the next window begins

--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2025-12-30'),
+		Changes: () => <>Fixed invulnerability checks for Doomtrain Extreme to ensure correct DoT uptime calculations.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2025-02-12'),
 		Changes: () => <>Fixed an issue that caused AOE attacks to incorrectly report broken combos if they cleaved an invulnerable target.</>,
 		contributors: [CONTRIBUTORS.AZARIAH],

--- a/src/parser/core/modules/Invulnerability.tsx
+++ b/src/parser/core/modules/Invulnerability.tsx
@@ -467,10 +467,10 @@ export class Invulnerability extends Analyser {
 		this.addEndEdge(targetId, timestamp - 1)
 	}
 
-	protected addStartEdge = (actorId: Actor['id'], timestamp: number) =>
+	protected addStartEdge(actorId: Actor['id'], timestamp: number) {
 		this.mirrorTypeEdge(this.addTypeStartEdge, actorId, timestamp)
-
-	private addEndEdge(actorId: Actor['id'], timestamp: number) {
+	}
+	protected addEndEdge(actorId: Actor['id'], timestamp: number) {
 		this.mirrorTypeEdge(this.addTypeEndEdge, actorId, timestamp)
 
 		// It's not uncommon for some checks such as TARGETABLE to close a window before


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

Doomtrain is apparently vulnerable to DoTs during the cart flips at the beginning of the fight as well, not just after the intermission. Go figure.

Disabled mirroring untargetable events to invulnerability for Doomtrain entirely, and manually set invulnerable events for the intermission by overriding the add[Start/End]Edge methods to specifically set an invulnerable window when the third untargetable window (ie. the intermission) is reached.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
 - http://localhost:3000/fflogs/j4p3LwQdRmfbrXqW/3/5

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
