### PR TITLE
Temporarily pause DNC gaugeUpdate event use for 7.4+

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2026-01-10'),
+		Changes: () => <>Temporarily revert to gauge event simulation for Patch 7.4 logs, even for the log uploader, due to a data format change.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2025-01-11'),
 		Changes: () => <>Adjust Technical Finish window tracking to be less prescriptive about Last Dance and Saber Dance since they're equivalent potency.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/dnc/modules/Gauge.tsx
+++ b/src/parser/jobs/dnc/modules/Gauge.tsx
@@ -151,8 +151,11 @@ export class Gauge extends CoreGauge {
 
 		this.addEventHook('complete', this.onComplete)
 
+		// Temporarily disable gauge event logging for 7.4 and forwards due to an event format update from ACT/fflogs, until I have time to figure out how to deal with it...
+		if (this.parser.patch.before('7.4')) {
 		// right now only the logging player has gauge update events, but in case that changes, narrow this to only the parsing actor
-		this.addEventHook(filter<Event>().actor(this.parser.actor.id).type('gaugeUpdate'), this.handleLoggedGauge)
+			this.addEventHook(filter<Event>().actor(this.parser.actor.id).type('gaugeUpdate'), this.handleLoggedGauge)
+		}
 	}
 
 	private handleLoggedGauge(event: Events['gaugeUpdate']) {


### PR DESCRIPTION
## Pull request type

- [x] This is a temporary workaround to a game data/ACT/fflogs change I don't have time to fix for real...

## Pull request details

Something changed about the data format of DNC's gaugeUpdate events, such that we're not getting the real data coming in the format we'd expect, which is producing gauge graphs that look like they have nothing in them.

<img width="985" height="288" alt="image" src="https://github.com/user-attachments/assets/089487cf-a9d5-4f3d-9bdb-ff38795a0eef" />

I don't have time right now to figure out what the new format looks like, or how the hell to do patch-specific stuff in adapter space, so I'm just turning it off for 7.4+ logs until I do have time...

## Testing / Validation

Make sure the gauge graphs look like they actually have stuff in them...

- [x] I used the log(s) listed below to develop and test this bugfix:
- Log with Gauge events no longer being used: https://xivanalysis.com/fflogs/HMVvtqTbN68cQnB1/36/6
- Log without DNC gauge events: http://localhost:3000/fflogs/vZPTnq8XgFjC3tkh/17/63

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
