### PR TITLE
Fix DNC Gauge event translation

### DIFF
--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2026-01-12'),
+		Changes: () => <>Fix Dancer gauge event translation, and return to using gauge events instead of gauge simulation for the log uploader.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2026-01-10'),
 		Changes: () => <>Temporarily revert to gauge event simulation for Patch 7.4 logs, even for the log uploader, due to a data format change.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/dnc/modules/Gauge.tsx
+++ b/src/parser/jobs/dnc/modules/Gauge.tsx
@@ -151,11 +151,7 @@ export class Gauge extends CoreGauge {
 
 		this.addEventHook('complete', this.onComplete)
 
-		// Temporarily disable gauge event logging for 7.4 and forwards due to an event format update from ACT/fflogs, until I have time to figure out how to deal with it...
-		if (this.parser.patch.before('7.4')) {
-		// right now only the logging player has gauge update events, but in case that changes, narrow this to only the parsing actor
-			this.addEventHook(filter<Event>().actor(this.parser.actor.id).type('gaugeUpdate'), this.handleLoggedGauge)
-		}
+		this.addEventHook(filter<Event>().actor(this.parser.actor.id).type('gaugeUpdate'), this.handleLoggedGauge)
 	}
 
 	private handleLoggedGauge(event: Events['gaugeUpdate']) {

--- a/src/parser/jobs/dnc/modules/Gauge.tsx
+++ b/src/parser/jobs/dnc/modules/Gauge.tsx
@@ -276,7 +276,7 @@ export class Gauge extends CoreGauge {
 
 	private onCastGenerator() {
 		// Make sure we keep track of overcap even with gauge update events
-		if (!this.parser.actor.loggedGauge || this.espritGauge.capped) {
+		if (!this.parser.actor.loggedGauge || this.featherGauge.capped) {
 			this.featherGauge.generate(FEATHER_GENERATION_CHANCE)
 		}
 	}

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/browser'
+import {Patch} from 'data/PATCHES'
 import {STATUS_ID_OFFSET} from 'data/STATUSES'
 import {Event, Events, Cause, SourceModifier, TargetModifier, AttributeValue, Attribute, EventGaugeUpdate} from 'event'
 import {Actor} from 'report'
@@ -478,12 +479,19 @@ export class TranslateAdapterStep extends AdapterStep {
 	}
 
 	private adaptDancerGaugeEvent(event: GaugeUpdateEvent): Event[] {
+		// Patch 7.4 shifted both Esprit and Feather's byte field offsets over by one
+		// Figure out which offsets we should load the data from based on the game edition and log timestamp (in seconds precision to match our patch date definitions)
+		const beforePatch74 = new Patch(this.report.edition, this.report.timestamp / 1000).before('7.4')
+
+		const espritByteFieldOffset = beforePatch74 ? BYTE_FIELD_OFFSETS.SECOND : BYTE_FIELD_OFFSETS.FIRST
+		const feathersByteFieldOffset = beforePatch74 ? BYTE_FIELD_OFFSETS.THIRD : BYTE_FIELD_OFFSETS.SECOND
+
 		const adaptedEvent: Events['gaugeUpdate'] = {
 			...this.adaptBaseFields(event),
 			actor: this.loggingActorId, // Relies on there being a combatant info event first...
 			type: 'gaugeUpdate',
-			esprit: numberFromHexBytes(event.data1, BYTE_FIELD_OFFSETS.SECOND),
-			feathers: numberFromHexBytes(event.data1, BYTE_FIELD_OFFSETS.THIRD),
+			esprit: numberFromHexBytes(event.data1, espritByteFieldOffset),
+			feathers: numberFromHexBytes(event.data1, feathersByteFieldOffset),
 		}
 		// Only return an adapted event if something we care about actually changed
 		if (this.lastGaugeUpdate == null ||

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -486,6 +486,22 @@ export class TranslateAdapterStep extends AdapterStep {
 		const espritByteFieldOffset = beforePatch74 ? BYTE_FIELD_OFFSETS.SECOND : BYTE_FIELD_OFFSETS.FIRST
 		const feathersByteFieldOffset = beforePatch74 ? BYTE_FIELD_OFFSETS.THIRD : BYTE_FIELD_OFFSETS.SECOND
 
+		/**
+		 * I ever want to do something with it:
+		 *
+		 * event.data2 is the order of steps required to successfully complete the current dance (standard or technical)
+		 * It looks something like "2040301" for Technical and "302" for Standard. I don't know if the order the player
+		 * is expected to execute them in is in descending or ascending byte order yet, will need to eyeball some logs
+		 * to figure out which.
+		 *
+		 * event.data3 is the number of correctly executed steps in the current dance (and will therefor correspond to which)
+		 * standard or technical finish gets executed if the finish button is pressed next.
+		 *
+		 * All of the above is pretty low priority because the finishes have different action Ids, so we can know whether they did it right
+		 * by the existing "did you get the right finish, and did you not press too many steps" checks, but if the dances get more
+		 * complicated in the future (intentional repeats?), this might be helpful.
+		 */
+
 		const adaptedEvent: Events['gaugeUpdate'] = {
 			...this.adaptBaseFields(event),
 			actor: this.loggingActorId, // Relies on there being a combatant info event first...

--- a/src/reportSources/legacyFflogs/eventAdapter/translate.ts
+++ b/src/reportSources/legacyFflogs/eventAdapter/translate.ts
@@ -71,6 +71,10 @@ export class TranslateAdapterStep extends AdapterStep {
 	private loggingActorId: Actor['id'] = ''
 	private lastGaugeUpdate: EventGaugeUpdate | undefined = undefined
 
+	// Patch 7.4 made some breaking changes to gauge event data
+	// Determine whether this log was affected based on the game edition and log timestamp (in seconds precision to match our patch date definitions)
+	private beforePatch74 = new Patch(this.report.edition, this.report.timestamp / 1000).before('7.4')
+
 	override adapt(baseEvent: FflogsEvent, _adaptedEvents: Event[]): Event[] {
 		switch (baseEvent.type) {
 		case 'begincast':
@@ -480,14 +484,12 @@ export class TranslateAdapterStep extends AdapterStep {
 
 	private adaptDancerGaugeEvent(event: GaugeUpdateEvent): Event[] {
 		// Patch 7.4 shifted both Esprit and Feather's byte field offsets over by one
-		// Figure out which offsets we should load the data from based on the game edition and log timestamp (in seconds precision to match our patch date definitions)
-		const beforePatch74 = new Patch(this.report.edition, this.report.timestamp / 1000).before('7.4')
-
-		const espritByteFieldOffset = beforePatch74 ? BYTE_FIELD_OFFSETS.SECOND : BYTE_FIELD_OFFSETS.FIRST
-		const feathersByteFieldOffset = beforePatch74 ? BYTE_FIELD_OFFSETS.THIRD : BYTE_FIELD_OFFSETS.SECOND
+		// Figure out which offsets we should load the data from based on whether we're before or after that point
+		const espritByteFieldOffset = this.beforePatch74 ? BYTE_FIELD_OFFSETS.SECOND : BYTE_FIELD_OFFSETS.FIRST
+		const feathersByteFieldOffset = this.beforePatch74 ? BYTE_FIELD_OFFSETS.THIRD : BYTE_FIELD_OFFSETS.SECOND
 
 		/**
-		 * I ever want to do something with it:
+		 * If I ever want to do something with it:
 		 *
 		 * event.data2 is the order of steps required to successfully complete the current dance (standard or technical)
 		 * It looks something like "2040301" for Technical and "302" for Standard. I don't know if the order the player


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/441414116914233366/1459623093050937549
- [x] The goal of this PR is detailed below:

As of patch 7.4, somewhere in the chain of game data -> ACT -> FFlogs, the data that represents DNC's Esprit and Feather gauge state both shifted over one hexadecimal byte offset, resulting in gauge graphs that looked really weird for the log uploader. At the time I wasn't able to figure out that this was what had happened, but after checking back at the screenshots originally sent to us, I can now recognize that we were recording the Feather gauge state into the Esprit gauge, and that Feathers were empty because the byte offset was no longer being used.

Now, the DNC gauge event translation step in adapter space will dynamically determine which patch the log is for, and retrieve the data from the appropriate hexadecimal byte field.

While reviewing the provided 7.4 log, I also noticed a spurious "half a feather" that shouldn't have been there, and thought there was a bug in the graph correction, but as it turns out, it was in the logged gauge overcap stuff, because the code meant to handle Feather overcap was checking to see if the _Esprit_ gauge was overcapped. Oops.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
  - Pre 7.4 log for regression testing: http://localhost:3000/fflogs/8VfRmWbGyKdDYZjJ/20/2
  - 7.4 log for testing the fixes: http://localhost:3000/fflogs/HMVvtqTbN68cQnB1/36/6
    - The graph should look reasonably normal
    - Feathers should not have a "half feather" while Esprit is capped at the ~1:35 mark

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
