### PR TITLE
[DRK] Fix esteem evaluator for double shadowstride with no damage loss

### DIFF
--- a/src/parser/jobs/drk/modules/EsteemWindow.tsx
+++ b/src/parser/jobs/drk/modules/EsteemWindow.tsx
@@ -12,9 +12,15 @@ import {Message} from 'semantic-ui-react'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 import {EsteemUsageEvaluator} from './EsteemUsageEvaluator'
 
+// We don't include Shadowstride since we only want to
+// validate that the damaging actions went off. Multiple
+// Shadowstrides isn't inherently an issue unless it
+// costs a damage action.
+// Shadowstride is left commented out to illustrate the
+// standard set of Esteem actions regardless.
 const ESTEEM_LEVEL_80: ActionKey[] = [
 	'ESTEEM_ABYSSAL_DRAIN',
-	'ESTEEM_SHADOWSTRIDE',
+	//'ESTEEM_SHADOWSTRIDE',
 	'ESTEEM_FLOOD_OF_SHADOW',
 	'ESTEEM_EDGE_OF_SHADOW',
 	'ESTEEM_BLOODSPILLER',
@@ -23,7 +29,7 @@ const ESTEEM_LEVEL_80: ActionKey[] = [
 
 const ESTEEM_LEVEL_90: ActionKey[] = [
 	'ESTEEM_ABYSSAL_DRAIN',
-	'ESTEEM_SHADOWSTRIDE',
+	//'ESTEEM_SHADOWSTRIDE',
 	'ESTEEM_SHADOWBRINGER',
 	'ESTEEM_EDGE_OF_SHADOW',
 	'ESTEEM_BLOODSPILLER',
@@ -32,7 +38,7 @@ const ESTEEM_LEVEL_90: ActionKey[] = [
 
 const ESTEEM_LEVEL_100: ActionKey[] = [
 	'ESTEEM_ABYSSAL_DRAIN',
-	'ESTEEM_SHADOWSTRIDE',
+	//'ESTEEM_SHADOWSTRIDE',
 	'ESTEEM_SHADOWBRINGER',
 	'ESTEEM_EDGE_OF_SHADOW',
 	'ESTEEM_BLOODSPILLER',


### PR DESCRIPTION
## Pull request type

An assumption made in the Esteem Evaluator is what we (the DRK mentor team) believed to be true: that Living Shadow could only ever execute six actions. It seems that's not true as of 7.4 and it can have a double Shadowstride without losing damage. Crazy!

I've got some resources to update, but I wanted to fix this bug first.

## Pull request details

Before:
<img width="975" height="429" alt="image" src="https://github.com/user-attachments/assets/173ddf3d-94fb-440c-86a0-ebe14ff947c6" />

After:
<img width="1007" height="440" alt="image" src="https://github.com/user-attachments/assets/7d7d44e3-9562-42d1-afd4-1650717408a6" />

Works on bad esteems too still:
<img width="979" height="493" alt="image" src="https://github.com/user-attachments/assets/12dedc7d-0261-452a-b6d7-5360d597f0fe" />

https://xivanalysis.com/fflogs/ycZd41Vwanmk2RJW/10/10
https://xivanalysis.com/fflogs/a:XxAFJpLgP7ZYQ62m/5/134

## Job Maintenance
Not on the official job maintenance team (I'd be happy to be) but active on discord or wherever.