### PR TITLE
restore Chinese language support with Cafemaker V2 API

### DIFF
--- a/src/components/ui/DbLink.tsx
+++ b/src/components/ui/DbLink.tsx
@@ -26,15 +26,18 @@ export interface ProviderProps {
 /** Tooltip data provider. Wrapping here to supply i18n language context. */
 export function Provider({children}: ProviderProps) {
 	const {i18nStore} = useContext(StoreContext)
+	const gameLang = i18nStore.safeGameLanguage
+	const apiLanguage = gameLang === Language.CHINESE
+        ? 'chs'  // Cafemaker using 'chs' instead of 'zh'
+        : gameLang  
 
-	// const baseUrl = i18nStore.gameLanguage === Language.CHINESE
-	// 	? 'https://cafemaker.wakingsands.com'
-	// 	: undefined
-	const baseUrl = 'https://v2.xivapi.com/api'
+	const baseUrl = i18nStore.gameLanguage === Language.CHINESE
+		? 'https://xivapi-v2.xivcdn.com/api' //cafemaker v2 API
+		: 'https://v2.xivapi.com/api'
 
 	return useObserver(() => (
 		<TooltipProvider
-			language={i18nStore.safeGameLanguage}
+			language={apiLanguage}
 			baseUrl={baseUrl}
 		>
 			{children}

--- a/src/store/i18n.ts
+++ b/src/store/i18n.ts
@@ -5,7 +5,7 @@ import {getUserLanguage} from 'utilities'
 
 export const gameLanguageEditions: GameEdition[] = [
 	GameEdition.GLOBAL,
-	// GameEdition.CHINESE, // Cafemaker
+	GameEdition.CHINESE, // Cafemaker
 ]
 
 function getGameLanguage(language: Language): Language {


### PR DESCRIPTION
- Enable Chinese game edition in language configuration
- Route Chinese requests to Cafemaker V2 API with 'chs' language code
- Keep other languages on XIVAPI v2
- Fix language code mapping between internal 'zh' and API-specific 'chs'