### PR TITLE
Modify Overwritten Procs to nearly always be Minor

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -973,7 +973,7 @@
   "rdm.procs.suggestions.overwritten-fire.why": "{overWrittenFire, plural, one {# Verfire proc was} other {# Verfire procs were}} lost due to being overwritten.",
   "rdm.procs.suggestions.overwritten-stone.content": "Don't cast <0/> when you have <1/>.",
   "rdm.procs.suggestions.overwritten-stone.why": "{overWrittenStone, plural, one {# Verstone proc was} other {# Verstone procs were}} lost due to being overwritten.",
-  "rdm.procs.suggestions.overwritten.content": "When not using <0/> with both procs available, trye to avoid casting <1/> when you have <2/> or <3/> when you have <4/>.",
+  "rdm.procs.suggestions.overwritten.content": "When not using <0/> with both procs available, try to avoid casting <1/> when you have <2/> or <3/> when you have <4/>.",
   "rdm.procs.suggestions.overwritten.why": "{overWrittenFire, plural, one {# Verfire proc} other {# Verfire procs}} and {overWrittenStone, plural, one {# Verstone proc} other {# Verstone procs}} were lost due to being overwritten.",
   "rdm.swiftcast.suggestion.content": "Spells used while <0/> is up should be limited to <1/>, <2/>, <3/>, and <4/>.",
   "rdm.swiftcast.table.note.bad": "Swiftcast used on a suboptimal spell",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -973,7 +973,7 @@
   "rdm.procs.suggestions.overwritten-fire.why": "{overWrittenFire, plural, one {# Verfire proc was} other {# Verfire procs were}} lost due to being overwritten.",
   "rdm.procs.suggestions.overwritten-stone.content": "Don't cast <0/> when you have <1/>.",
   "rdm.procs.suggestions.overwritten-stone.why": "{overWrittenStone, plural, one {# Verstone proc was} other {# Verstone procs were}} lost due to being overwritten.",
-  "rdm.procs.suggestions.overwritten.content": "Don't cast <0/> when you have <1/> or <2/> when you have <3/>.",
+  "rdm.procs.suggestions.overwritten.content": "When not using <0/> with both procs available, trye to avoid casting <1/> when you have <2/> or <3/> when you have <4/>.",
   "rdm.procs.suggestions.overwritten.why": "{overWrittenFire, plural, one {# Verfire proc} other {# Verfire procs}} and {overWrittenStone, plural, one {# Verstone proc} other {# Verstone procs}} were lost due to being overwritten.",
   "rdm.swiftcast.suggestion.content": "Spells used while <0/> is up should be limited to <1/>, <2/>, <3/>, and <4/>.",
   "rdm.swiftcast.table.note.bad": "Swiftcast used on a suboptimal spell",

--- a/src/parser/jobs/rdm/changelog.tsx
+++ b/src/parser/jobs/rdm/changelog.tsx
@@ -2,6 +2,11 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2026-02-15'),
+		Changes: () => <>Modified Overwritten procs suggestion when both procs are available, adjusted tiers so that for now all overwrite proc suggestions will be Minor.</>,
+		contributors: [CONTRIBUTORS.LEYLIA],
+	},
+	{
 		date: new Date('2025-12-31'),
 		Changes: () => <>Removed Manafication GCD Window; fixed the oversight on Mana gauge calcualtions with the new manafication ranged melee combo.</>,
 		contributors: [CONTRIBUTORS.LEYLIA],

--- a/src/parser/jobs/rdm/modules/Procs.tsx
+++ b/src/parser/jobs/rdm/modules/Procs.tsx
@@ -5,7 +5,10 @@ import {TieredSuggestion, SEVERITY} from 'parser/core/modules/Suggestions'
 
 const SEVERITY_OVERWRITTEN_PROCS = {
 	1: SEVERITY.MINOR,
-	15: SEVERITY.MEDIUM,
+	//It's been reported that this particular suggestion isn't as helpful as they thought but since they are uncertain as to what they want to do about it
+	//for now it's been asked that we make this always a minor suggestion; it's easily possible they'll change their minds later so for now just leaving
+	//this as a tiered suggestion but making it nigh impossible in a single fight to reach medium.
+	100: SEVERITY.MEDIUM,
 }
 
 const SEVERITY_INVULN_PROCS = {
@@ -96,7 +99,7 @@ export class Procs extends CoreProcs {
 	private getOverwrittenProcContent(overWrittenFire: number, overWrittenStone: number) {
 		if (overWrittenFire > 0 && overWrittenStone > 0) {
 			return <Trans id="rdm.procs.suggestions.overwritten.content">
-				Don't cast <DataLink action="VERTHUNDER_III"/> when you have <DataLink status="VERFIRE_READY"/> or <DataLink action="VERAERO_III"/> when you have <DataLink status="VERSTONE_READY"/>.
+				When not using <DataLink action="ACCELERATION"/> with both procs available, trye to avoid casting <DataLink action="VERTHUNDER_III"/> when you have <DataLink status="VERFIRE_READY"/> or <DataLink action="VERAERO_III"/> when you have <DataLink status="VERSTONE_READY"/>.
 			</Trans>
 		}
 		if (overWrittenFire > 0) {

--- a/src/parser/jobs/rdm/modules/Procs.tsx
+++ b/src/parser/jobs/rdm/modules/Procs.tsx
@@ -99,7 +99,7 @@ export class Procs extends CoreProcs {
 	private getOverwrittenProcContent(overWrittenFire: number, overWrittenStone: number) {
 		if (overWrittenFire > 0 && overWrittenStone > 0) {
 			return <Trans id="rdm.procs.suggestions.overwritten.content">
-				When not using <DataLink action="ACCELERATION"/> with both procs available, trye to avoid casting <DataLink action="VERTHUNDER_III"/> when you have <DataLink status="VERFIRE_READY"/> or <DataLink action="VERAERO_III"/> when you have <DataLink status="VERSTONE_READY"/>.
+				When not using <DataLink action="ACCELERATION"/> with both procs available, try to avoid casting <DataLink action="VERTHUNDER_III"/> when you have <DataLink status="VERFIRE_READY"/> or <DataLink action="VERAERO_III"/> when you have <DataLink status="VERSTONE_READY"/>.
 			</Trans>
 		}
 		if (overWrittenFire > 0) {


### PR DESCRIPTION
## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [x] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [x] This is in response to a discussion or thread on Discord: RDM-TC in The Balance
- [x] The goal of this PR is detailed below:

It's been noticed that the current suggestion for overwritten procs seems to be leading people in the wrong direction.  As such it was asked that the suggestion for overwritten procs be made Minor and have its wording adjusted to help make things a bit more clear about the impact of proc overwrites.

## Testing / Validation

- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:

Random Log with a RDM in it to verify the suggestion - https://www.fflogs.com/reports/3vNVwGhmL2Z4bFQp?fight=2&type=damage-done

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
