### PR TITLE
add Plenary to tracked defensives for WHM

### DIFF
--- a/src/parser/jobs/whm/modules/Defensives.ts
+++ b/src/parser/jobs/whm/modules/Defensives.ts
@@ -6,6 +6,7 @@ export class Defensives extends CoreDefensives {
 		this.data.actions.ASYLUM,
 		this.data.actions.AQUAVEIL,
 		this.data.actions.DIVINE_BENISON,
+		this.data.actions.PLENARY_INDULGENCE,
 		this.data.actions.TEMPERANCE,
 	]
 }


### PR DESCRIPTION
## Pull request type

- [x] This is new functionality or an addition to existing functionality

## Pull request details

- [x] This is in response to a GitHub issue: https://github.com/xivanalysis/xivanalysis/issues/2292

Having gained 10% mitigation since patch 7.4, Plenary Indulgence should be used frequently for that purpose, even when additional healing is not necessary.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:

https://www.fflogs.com/reports/8JFh71ga2TQzB3wm?fight=40&type=damage-done

## Job Maintenance
I am in the Discord, not a maintainer.
