### PR TITLE
Update UTA statuses with some missed ones

### DIFF
--- a/src/generated/unableToActStatusIds.ts
+++ b/src/generated/unableToActStatusIds.ts
@@ -272,6 +272,8 @@ export const UNABLE_TO_ACT_STATUS_IDS = [
 	4578, // Fetters (lockActions, lockControl)
 	4618, // Standing Firm (lockActions, lockControl)
 	4619, //  (lockActions, lockControl)
+	5043, // Stun (lockActions)
 	5058, // Stone Curse (lockActions)
+	5110, //  (lockActions, lockControl)
 	5174, // Forced March (lockActions)
 ]


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

Last time I ran the uta status generation for the current patch, it either didn't pick up a few statuses, or savage launch added a few more. Not sure exactly what they are (it's not for the Flatliner knockups though), but just getting them in the file nonetheless.

## Testing / Validation

No specifics, I just ran `pnpm run generate` again.

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
