### PR TITLE
Misc SGE Fixes

### DIFF
--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -1129,7 +1129,7 @@
   "sge.gauge.suggestions.lost-to-rhizomata.content": "You lost Addersgall due to capping the gauge with <0/>, which wastes the time already spent charging the third stack. Try to use <1/> when you are at one stack or less to keep from losing timer progress.",
   "sge.gauge.suggestions.lost-to-rhizomata.why": "{rhizomataLostStacks, plural, one {# Addersgall stack was} other {# Addersgall stacks were}} lost to capping the gauge with <0/>.",
   "sge.interrupts.suggestion.content": "Avoid interrupting casts by either prepositioning yourself or utilizing slidecasting where possible. Use windows created by normal <0/> refreshes to move in advance of mechanics. When that's not an option, try to plan and utilize <1/> or <2/> heals to keep your GCD rolling and cover movement. Overwriting <3/> early should be your last resort for movement.",
-  "sge.kardia.checklist.kardia.description": "Placing <0/> on a player will heal them over time when you deal damage with your GCDs, allowing you keep them healthier without spending other resources to do so. Try to keep it on someone, like a tank, at all times.",
+  "sge.kardia.checklist.kardia.description": "Placing <0/> on a player will heal them over time when you deal damage with your GCDs, allowing you to keep them healthier without spending other resources to do so. Try to keep it on someone, like a tank, at all times.",
   "sge.kardia.checklist.kardia.name": "Choose a <0/> target",
   "sge.kardia.checklist.kardia.uptime": "<0/> uptime (excluding downtime)",
   "sge.kardia.title": "Kardia",

--- a/src/parser/jobs/sge/changelog.tsx
+++ b/src/parser/jobs/sge/changelog.tsx
@@ -7,6 +7,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2026-02-23'),
+		Changes: () => <>Track Eukrasian Dyskrasia as a mutually-exclusive DoT with Eukrasian Dosis, and some other minor fixes.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2025-04-20'),
 		Changes: () => <>Add informational display of Swiftcast and Lucid Dreaming usage/cooldown availability adjacent to Defensives.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/sge/modules/AoEUsages.ts
+++ b/src/parser/jobs/sge/modules/AoEUsages.ts
@@ -1,0 +1,15 @@
+import {AoEUsages as CoreAoE} from 'parser/core/modules/AoEUsages'
+
+export class AoEUsages extends CoreAoE {
+	suggestionIcon = this.data.actions.DYSKRASIA_II.icon
+
+	trackedActions = [
+		// Regular Dyskrasia has niche use as a "keep some amount of damage going while handling movement" tool,
+		// so warning against its use here below a target threshold is not included.
+		{
+			aoeAction: this.data.actions.EUKRASIAN_DYSKRASIA,
+			stActions: [this.data.actions.EUKRASIAN_DOSIS_III],
+			minTargets: 3,
+		},
+	]
+}

--- a/src/parser/jobs/sge/modules/DoTs.tsx
+++ b/src/parser/jobs/sge/modules/DoTs.tsx
@@ -20,9 +20,11 @@ export class DoTs extends CoreDoTs {
 
 	protected override trackedStatuses = [
 		this.data.statuses.EUKRASIAN_DOSIS_III.id,
+		this.data.statuses.EUKRASIAN_DYSKRASIA.id,
 	]
 
 	protected override addChecklistRules() {
+		const dotUptimePct = this.getUptimePercent(this.data.statuses.EUKRASIAN_DOSIS_III.id) + this.getUptimePercent(this.data.statuses.EUKRASIAN_DYSKRASIA.id)
 		this.checklist.add(new Rule({
 			name: <Trans id="sge.dots.rule.name">Keep your DoT up</Trans>,
 			description: <Trans id="sge.dots.rule.description">
@@ -31,14 +33,14 @@ export class DoTs extends CoreDoTs {
 			requirements: [
 				new Requirement({
 					name: <Trans id="sge.dots.requirement.uptime.name"><DataLink status="EUKRASIAN_DOSIS_III" /> uptime</Trans>,
-					percent: this.getUptimePercent(this.data.statuses.EUKRASIAN_DOSIS_III.id),
+					percent: dotUptimePct,
 				}),
 			],
 		}))
 	}
 
 	protected addClippingSuggestions() {
-		const dosisClipPerMinute = this.getClippingAmount(this.data.statuses.EUKRASIAN_DOSIS_III.id)
+		const dosisClipPerMinute = this.getClippingAmount(this.data.statuses.EUKRASIAN_DOSIS_III.id) + this.getClippingAmount(this.data.statuses.EUKRASIAN_DYSKRASIA.id)
 		this.suggestions.add(new TieredSuggestion({
 			icon: this.data.actions.EUKRASIAN_DOSIS_III.icon,
 			content: <Trans id="sge.dots.suggestion.clip.content">

--- a/src/parser/jobs/sge/modules/Kardia.tsx
+++ b/src/parser/jobs/sge/modules/Kardia.tsx
@@ -36,7 +36,7 @@ export class Kardia extends Analyser {
 		this.checklist.add(new Rule({
 			name: <Trans id="sge.kardia.checklist.kardia.name">Choose a <DataLink status="KARDIA" /> target</Trans>,
 			description: <Trans id="sge.kardia.checklist.kardia.description">
-				Placing <DataLink status="KARDIA" /> on a player will heal them over time when you deal damage with your GCDs, allowing you keep them healthier without spending other resources to do so. Try to keep it on someone, like a tank, at all times.
+				Placing <DataLink status="KARDIA" /> on a player will heal them over time when you deal damage with your GCDs, allowing you to keep them healthier without spending other resources to do so. Try to keep it on someone, like a tank, at all times.
 			</Trans>,
 			target: 100,
 			requirements: [

--- a/src/parser/jobs/sge/modules/Tincture.tsx
+++ b/src/parser/jobs/sge/modules/Tincture.tsx
@@ -11,6 +11,8 @@ export class Tincture extends CoreTincture {
 	override initialise() {
 		super.initialise()
 
+		this.ignoreActions([this.data.actions.PNEUMA_HEAL.id])
+
 		this.addEvaluator(new ExpectedActionsEvaluator({
 			expectedActions: [
 				{

--- a/src/parser/jobs/sge/modules/index.ts
+++ b/src/parser/jobs/sge/modules/index.ts
@@ -1,4 +1,5 @@
 import {ActionTimeline} from './ActionTimeline'
+import {AoEUsages} from './AoEUsages'
 import {CooldownDowntime} from './CooldownDowntime'
 import {Defensives} from './Defensives'
 import {DoTs} from './DoTs'
@@ -13,6 +14,7 @@ import {Weaving} from './Weaving'
 import {Zoe} from './Zoe'
 
 export const modules = [
+	AoEUsages,
 	ActionTimeline,
 	CooldownDowntime,
 	Defensives,


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [x] This is in response to a GitHub issue: https://github.com/xivanalysis/xivanalysis/issues/2291
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1278266632346669076/1473922286259273851
- [x] The goal of this PR is detailed below:

- Track Eukrasian Dyskrasia as a mutually-exclusive DoT with Eukrasian Dosis III, the same way BLM tracks its ST and AoE High Thunders, to make sure overall DoT uptime calculations are correct
- Add an AoE Usages check for Eukrasian Dyskrasia warning against its use below 3 targets
- Filter Pneuma's heal component out of the TInctures rotation display, similar to how we've done for other buff window overrides
- Fix a typo in the "make sure someone has Kardia" suggestion text

## Testing / Validation

None in particular, pick your favorite logs. Changes weren't particularly complicated.

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
