### PR TITLE
[BugFixes] GCD Delay & Proc Priority

### DIFF
--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2026-03-15'),
+		Changes: () => <>Update Always be Casting GCD Delay calculation to better handle longer than normal GCD recasts, such as PCT's Motif spells.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2026-01-11'),
 		Changes: () => <>Improve DoT uptime calculations for multi-target fights.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/core/modules/AlwaysBeCasting/AlwaysBeCasting.tsx
+++ b/src/parser/core/modules/AlwaysBeCasting/AlwaysBeCasting.tsx
@@ -289,7 +289,7 @@ export class AlwaysBeCasting extends AlwaysBeCastingAnalyser {
 	}
 
 	override getDelayPerIssue(downtime: GcdDowntimeWindow) {
-		return (downtime.stop ?? downtime.start) - downtime.start - this.gcdLength
+		return (downtime.stop ?? downtime.start) - downtime.start - (this.castTime.recastForEvent(downtime.leadingEvent) ?? this.gcdLength)
 	}
 
 	override getTotalDelay() {

--- a/src/parser/core/modules/Procs.tsx
+++ b/src/parser/core/modules/Procs.tsx
@@ -39,6 +39,9 @@ export interface ProcGroup {
 	procStatus: Status,
 	consumeActions: Action[],
 	mayOverwrite?: boolean,
+	// If an action can consume multiple procs, but only one of them per usage (see DNC's Silken/Flourishing Symmetry/Flow procs), set this to indicate the
+	// relative priority of those proc statuses. Higher numbers indicate those are consumed first when the action is used.
+	priority?: number
 }
 
 type ProcIssueType =
@@ -423,7 +426,8 @@ export abstract class Procs extends Analyser {
 	}
 
 	private onCast(event: Events['action']): void {
-		for (const activeProc of this.currentWindows.keys()) {
+		// Sort the procs by their relative consumption priorities before figuring out which may have been used by this event
+		for (const activeProc of this.currentWindows.keys().toArray().sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))) {
 			// If this action consumed a proc, log it
 			if (this.checkConsumeProc(activeProc, event)) {
 				if (this.invulnerability.isActive({

--- a/src/parser/jobs/dnc/changelog.tsx
+++ b/src/parser/jobs/dnc/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2026-03-15'),
+		Changes: () => <>Update Proc consumption checking to better handle both Silken and Flourishing procs being active at the same time.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2026-01-12'),
 		Changes: () => <>Fix Dancer gauge event translation, and return to using gauge events instead of gauge simulation for the log uploader.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/dnc/modules/Procs.tsx
+++ b/src/parser/jobs/dnc/modules/Procs.tsx
@@ -15,18 +15,22 @@ export class Procs extends CoreProcs {
 		{
 			procStatus: this.data.statuses.SILKEN_SYMMETRY,
 			consumeActions: [this.data.actions.REVERSE_CASCADE, this.data.actions.RISING_WINDMILL],
+			priority: 2,
 		},
 		{
 			procStatus: this.data.statuses.SILKEN_FLOW,
 			consumeActions: [this.data.actions.FOUNTAINFALL, this.data.actions.BLOODSHOWER],
+			priority: 2,
 		},
 		{
 			procStatus: this.data.statuses.FLOURISHING_SYMMETRY,
 			consumeActions: [this.data.actions.REVERSE_CASCADE, this.data.actions.RISING_WINDMILL],
+			priority: 1,
 		},
 		{
 			procStatus: this.data.statuses.FLOURISHING_FLOW,
 			consumeActions: [this.data.actions.FOUNTAINFALL, this.data.actions.BLOODSHOWER],
+			priority: 1,
 		},
 		{
 			procStatus: this.data.statuses.FLOURISHING_STARFALL,


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

Bundling into a single PR because they're both tiny fixes and easy to check

## Pull request details

- [x] This is in response to a GitHub issue:
  - Proc Priority: https://github.com/xivanalysis/xivanalysis/issues/2294
  - GCD Delay: https://github.com/xivanalysis/xivanalysis/issues/2299
- [x] This is in response to a discussion or thread on Discord:
  - Proc Priority: https://discord.com/channels/441414116914233364/1482100497589473321
- [x] The goal of this PR is detailed below:

- Proc Priority: 
  - DNC has two sets of procs, each with two actions that can potentially consume them. In-game they are always consumed in the order of Silken (thing) > Flourishing (thing).
  - Previously: We would treat them as consumed in the order they were applied, which did not always follow game behavior in determining which were consumed when
  - Now: Jobs can specify the relative priority order by which a proc will be consumed, and the core Procs processing will respect that order.

- GCD Delay:
  - PCT's Motifs spells have a much longer than normal GCD recast tied to them
  - Previously: We calculated the amount of GCD time lost per downtime event based on the base GCD recast
  - Now: We use the leading event's actual GCD recast (when available, falling back to the normal GCD recast if not) when determining how much GCD time was lost.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
  - Proc Priority:
    - https://xivanalysis.com/fflogs/fvq9KxWh4AV16npd/4/94
    - https://xivanalysis.com/fflogs/4vd3LxkpH8mJDRnz/3/2
  - GCD Delay:
    - https://xivanalysis.com/fflogs/A2mdH3y6pYT7LqRF/15/12

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
