### PR TITLE
Add a warning for not-level-cap content

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -287,6 +287,8 @@
   "brd.ragingstrikes.title": "Wütende Attacke",
   "code.suggestions.severity.memes": "",
   "core.abc.title": "",
+  "core.about.content-unsupported.description": "",
+  "core.about.content-unsupported.title": "",
   "core.about.contributors": "Mitwirkende:",
   "core.about.patch-unsupported.description": "Dieser Log wurde während Patch {0} aufgezeichnet, welcher nicht vom Analysator unterstützt wird. Berechnungen und Vorschläge könnten durch eventuelle Spieländerungen nicht korrekt sein.",
   "core.about.patch-unsupported.title": "Nicht unterstützten Patch melden",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -287,6 +287,8 @@
   "brd.ragingstrikes.title": "Raging Strikes",
   "code.suggestions.severity.memes": "Memes",
   "core.abc.title": "Always Be Casting",
+  "core.about.content-unsupported.description": "This report is for level {loggedLevel} content, which is not supported by the analyser. Calculations and suggestions will be inaccurate due to missing abilities and incomplete rotations.",
+  "core.about.content-unsupported.title": "Report content unsupported",
   "core.about.contributors": "Contributors:",
   "core.about.patch-unsupported.description": "This report was logged during patch {0}, which is not supported by the analyser. Calculations and suggestions may be impacted by changes in the interim.",
   "core.about.patch-unsupported.title": "Report patch unsupported",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -287,6 +287,8 @@
   "brd.ragingstrikes.title": "Tir furieux",
   "code.suggestions.severity.memes": "Memes",
   "core.abc.title": "",
+  "core.about.content-unsupported.description": "",
+  "core.about.content-unsupported.title": "",
   "core.about.contributors": "Contributeurs:",
   "core.about.patch-unsupported.description": "Ce rapport a été généré durant la patch {0}, qui n'est pas supportée par l'analyseur. Les calculs et suggestions peuvent être impactés par les changements depuis ce temps.",
   "core.about.patch-unsupported.title": "Patch de ce rapport non-supportée",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -287,6 +287,8 @@
   "brd.ragingstrikes.title": "猛者の撃",
   "code.suggestions.severity.memes": "",
   "core.abc.title": "",
+  "core.about.content-unsupported.description": "",
+  "core.about.content-unsupported.title": "",
   "core.about.contributors": "貢献者:",
   "core.about.patch-unsupported.description": "このログはパッチ {0} のものですが、まだこのアナライザーではサポートされていません。計算や提案は暫定的なもので、今後変更されるかもしれません。",
   "core.about.patch-unsupported.title": "報告された未対応パッチ",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -287,6 +287,8 @@
   "brd.ragingstrikes.title": "용맹한 사격",
   "code.suggestions.severity.memes": "",
   "core.abc.title": "",
+  "core.about.content-unsupported.description": "",
+  "core.about.content-unsupported.title": "",
   "core.about.contributors": "기여자:",
   "core.about.patch-unsupported.description": "이 리포트는 분석기의 지원을 받을 수 없는 {0} 버전에서 작성되었습니다. 계산 결과와 조언들은 이후 패치의 영향을 받을 수 있습니다.",
   "core.about.patch-unsupported.title": "지원되지 않는 패치",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -287,6 +287,8 @@
   "brd.ragingstrikes.title": "猛者强击",
   "code.suggestions.severity.memes": "Memes",
   "core.abc.title": "保持使用技能",
+  "core.about.content-unsupported.description": "",
+  "core.about.content-unsupported.title": "",
   "core.about.contributors": "贡献者：",
   "core.about.patch-unsupported.description": "这个报告是在{0} 版本记录的，分析器不支持此报告。计算和建议可能会因版本间更改而受到影响。",
   "core.about.patch-unsupported.title": "不支持该报告的版本。",

--- a/src/data/JOBS.ts
+++ b/src/data/JOBS.ts
@@ -70,6 +70,7 @@ export interface Job {
 	colour: string
 	role: RoleKey
 	usesMP?: boolean // Used by Actors to determine if an MP graph should be shown for jobs outside the healer and caster roles
+	isLimited?: boolean // Used by utilities.ts to determine whether to show the "this content is below level cap" warning
 }
 
 // Yeah I know there's lots of repetition but they're all different apis and endpoints and shit and I don't wanna pull it apart later to fix a desync
@@ -246,6 +247,7 @@ export const JOBS = ensureRecord<Job>()({
 		icon: 'blu',
 		colour: '#3366ff',
 		role: 'MAGICAL_RANGED',
+		isLimited: true,
 	},
 })
 

--- a/src/data/PATCHES/index.ts
+++ b/src/data/PATCHES/index.ts
@@ -1,4 +1,4 @@
 export {Patch} from './Patch'
 export {PATCHES} from './patches'
 export type {PatchInfo, PatchNumber} from './patches'
-export {getPatch, getPatchDate, getReportPatch, patchSupported} from './utilities'
+export {contentSupported, getPatch, getPatchDate, getReportPatch, patchSupported} from './utilities'

--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -15,6 +15,7 @@ export interface PatchInfo {
 	branch?: PatchBranch
 }
 
+export const LEVEL_CAP = 100
 // This is all right from /PatchList - should be easy to sync Eventually™
 export const FALLBACK_KEY = '✖'
 export const PATCHES = ensureRecord<PatchInfo>()({

--- a/src/data/PATCHES/utilities.ts
+++ b/src/data/PATCHES/utilities.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import {Report} from 'report'
 import {GameEdition} from '../EDITIONS'
-import {FALLBACK_KEY, PATCHES, PatchInfo, PatchNumber} from './patches'
+import {FALLBACK_KEY, LEVEL_CAP, PATCHES, PatchInfo, PatchNumber} from './patches'
 
 interface PatchData {[key: string]: PatchInfo}
 const patchData: PatchData = PATCHES
@@ -46,4 +46,13 @@ export function patchSupported(
 		: Infinity
 
 	return _.inRange(at, fromDate, toDate)
+}
+
+export function contentSupported(loggedLevel: number | undefined) {
+	if (!loggedLevel) {
+		// If the log doesn't include a level, assume it's supported to preserve the status quo.
+		return true
+	}
+
+	return loggedLevel < LEVEL_CAP
 }

--- a/src/data/PATCHES/utilities.ts
+++ b/src/data/PATCHES/utilities.ts
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import {Report} from 'report'
 import {GameEdition} from '../EDITIONS'
 import {FALLBACK_KEY, LEVEL_CAP, PATCHES, PatchInfo, PatchNumber} from './patches'
-import {JobKey} from "../JOBS"
+import {JobKey, JOBS} from "../JOBS"
 
 interface PatchData {[key: string]: PatchInfo}
 const patchData: PatchData = PATCHES
@@ -55,8 +55,8 @@ export function contentSupported(loggedLevel: number | undefined, job: JobKey) {
 		return true
 	}
 
-	if (job === "BLUE_MAGE") {
-		// The level cap is only relevant for non-limited jobs like BLU. If and when they eventually add more (looking at you, BST), we'll need to update this.
+	if (JOBS[job].isLimited) {
+		// The level cap is only relevant for non-limited jobs, so all content should be considered supported for limited ones.
 		return true
 	}
 

--- a/src/data/PATCHES/utilities.ts
+++ b/src/data/PATCHES/utilities.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import {Report} from 'report'
 import {GameEdition} from '../EDITIONS'
 import {FALLBACK_KEY, LEVEL_CAP, PATCHES, PatchInfo, PatchNumber} from './patches'
+import {JobKey} from "../JOBS"
 
 interface PatchData {[key: string]: PatchInfo}
 const patchData: PatchData = PATCHES
@@ -48,11 +49,16 @@ export function patchSupported(
 	return _.inRange(at, fromDate, toDate)
 }
 
-export function contentSupported(loggedLevel: number | undefined) {
+export function contentSupported(loggedLevel: number | undefined, job: JobKey) {
 	if (!loggedLevel) {
 		// If the log doesn't include a level, assume it's supported to preserve the status quo.
 		return true
 	}
 
-	return loggedLevel < LEVEL_CAP
+	if (job === "BLUE_MAGE") {
+		// The level cap is only relevant for non-limited jobs like BLU. If and when they eventually add more (looking at you, BST), we'll need to update this.
+		return true
+	}
+
+	return loggedLevel === LEVEL_CAP
 }

--- a/src/parser/core/modules/About.tsx
+++ b/src/parser/core/modules/About.tsx
@@ -84,7 +84,7 @@ export class About extends Analyser {
 						</Message>
 					)}
 
-					{contentSupported(loggedLevel) && (
+					{!contentSupported(loggedLevel, this.parser.actor.job) && (
 						<Message error icon="times circle outline">
 							<Message.Header>
 								<Trans id="core.about.content-unsupported.title">Report content unsupported</Trans>

--- a/src/parser/core/modules/About.tsx
+++ b/src/parser/core/modules/About.tsx
@@ -3,7 +3,7 @@ import {Trans} from '@lingui/react/macro'
 import {Message, Segment} from 'akkd'
 import {ContributorLabel} from 'components/ui/ContributorLabel'
 import {NormalisedMessage} from 'components/ui/NormalisedMessage'
-import {patchSupported} from 'data/PATCHES'
+import {contentSupported, patchSupported} from 'data/PATCHES'
 import {AVAILABLE_MODULES} from 'parser/AVAILABLE_MODULES'
 import {Analyser, DisplayMode} from 'parser/core/Analyser'
 import {ComponentType} from 'react'
@@ -80,6 +80,17 @@ export class About extends Analyser {
 							</Message.Header>
 							<Trans id="core.about.patch-unsupported.description">
 								This report was logged during patch {this.parser.patch.key}, which is not supported by the analyser. Calculations and suggestions may be impacted by changes in the interim.
+							</Trans>
+						</Message>
+					)}
+
+					{contentSupported(loggedLevel) && (
+						<Message error icon="times circle outline">
+							<Message.Header>
+								<Trans id="core.about.content-unsupported.title">Report content unsupported</Trans>
+							</Message.Header>
+							<Trans id="core.about.content-unsupported.description">
+								This report is for level {loggedLevel} content, which is not supported by the analyser. Calculations and suggestions will be inaccurate due to missing abilities and incomplete rotations.
 							</Trans>
 						</Message>
 					)}


### PR DESCRIPTION
## Pull request type

- [x] This is new functionality or an addition to existing functionality
- [ ] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

- [ ] This is in response to a GitHub issue: *[Link to issue]*
- [x] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1488926686912319649
- [ ] The goal of this PR is detailed below:

The PR adds a warning into the About box at the top of the page when the user tries to analyze content below the current level cap, warning that analysis **will** (not may) be inaccurate, with the goal of reducing the number of confused new users wondering why the page is yelling at them about missing skills that they don't have yet (among other things).

## Testing / Validation

- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
  - [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [x] I used the log(s) listed below to develop and test this bugfix:

* Log provided by the user who made the request (level 80 content, shows warning): https://www.fflogs.com/reports/TN7rFJ3xzWkdqtYD?fight=1&source=2
* Log of my own (level 100 content, doesn't show warning): https://www.fflogs.com/reports/QXk6CDqj2tWT9bnA?fight=6&type=summary&source=8
* Log provided by otocephaly on Discord (level 60 BLU content, doesn't show warning): https://www.fflogs.com/reports/a:7JPTyHrg4KVMBhfp?fight=3&type=summary&source=4

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
