### PR TITLE
Patch 7.5 definition

### DIFF
--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -103,6 +103,13 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 			[GameEdition.CHINESE]: 1765872000, // CN is synced with global as of 7.4
 		},
 	},
+	'7.5': {
+		date: {
+			[GameEdition.GLOBAL]: 1777363200, // 28/04/26 8:00:00 GMT
+			[GameEdition.KOREAN]: 1777363200, // KR is synced with global as of 7.5
+			[GameEdition.CHINESE]: 1777363200,
+		},
+	},
 })
 
 export type PatchNumber = keyof typeof PATCHES

--- a/src/data/PATCHES/patches.ts
+++ b/src/data/PATCHES/patches.ts
@@ -91,15 +91,15 @@ export const PATCHES = ensureRecord<PatchInfo>()({
 	},
 	'7.3': {
 		date: {
-			[GameEdition.GLOBAL]: 1754380800, // 25/08/05 8:00:00 GMT
+			[GameEdition.GLOBAL]: 1754380800, // 05/08/25 8:00:00 GMT
 			[GameEdition.KOREAN]: 1761638400, // 28/10/25 08:00:00 GMT
 			[GameEdition.CHINESE]: 1757982344, // 16/09/25 08:00:00 GMT
 		},
 	},
 	'7.4': {
 		date: {
-			[GameEdition.GLOBAL]: 1765872000, // 25/12/16 8:00:00 GMT
-			[GameEdition.KOREAN]: 1770105600, // 26/02/03 08:00:00 GMT
+			[GameEdition.GLOBAL]: 1765872000, // 16/12/25 8:00:00 GMT
+			[GameEdition.KOREAN]: 1770105600, // 03/02/26 08:00:00 GMT
 			[GameEdition.CHINESE]: 1765872000, // CN is synced with global as of 7.4
 		},
 	},

--- a/src/parser/jobs/ast/index.tsx
+++ b/src/parser/jobs/ast/index.tsx
@@ -29,7 +29,7 @@ export const ASTROLOGIAN = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/blm/index.tsx
+++ b/src/parser/jobs/blm/index.tsx
@@ -13,7 +13,7 @@ export const BLACK_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/blu/index.tsx
+++ b/src/parser/jobs/blu/index.tsx
@@ -19,7 +19,7 @@ export const BLUE_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/brd/index.tsx
+++ b/src/parser/jobs/brd/index.tsx
@@ -23,7 +23,7 @@ export const BARD = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/dnc/index.tsx
+++ b/src/parser/jobs/dnc/index.tsx
@@ -25,7 +25,7 @@ export const DANCER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/drg/index.tsx
+++ b/src/parser/jobs/drg/index.tsx
@@ -15,7 +15,7 @@ export const DRAGOON = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/drk/index.tsx
+++ b/src/parser/jobs/drk/index.tsx
@@ -19,7 +19,7 @@ export const DARK_KNIGHT = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/gnb/index.tsx
+++ b/src/parser/jobs/gnb/index.tsx
@@ -21,7 +21,7 @@ export const GUNBREAKER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/mch/index.tsx
+++ b/src/parser/jobs/mch/index.tsx
@@ -24,7 +24,7 @@ export const MACHINIST = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/mnk/index.tsx
+++ b/src/parser/jobs/mnk/index.tsx
@@ -19,7 +19,7 @@ export const MONK = new Meta({
 
 	supportedPatches: {
 		from: '7.01',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/nin/index.tsx
+++ b/src/parser/jobs/nin/index.tsx
@@ -16,7 +16,7 @@ export const NINJA = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/pct/index.tsx
+++ b/src/parser/jobs/pct/index.tsx
@@ -19,7 +19,7 @@ export const PICTOMANCER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/pld/index.tsx
+++ b/src/parser/jobs/pld/index.tsx
@@ -19,7 +19,7 @@ export const PALADIN = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/rdm/index.tsx
+++ b/src/parser/jobs/rdm/index.tsx
@@ -15,7 +15,7 @@ export const RED_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sch/index.tsx
+++ b/src/parser/jobs/sch/index.tsx
@@ -17,7 +17,7 @@ export const SCHOLAR = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sge/index.tsx
+++ b/src/parser/jobs/sge/index.tsx
@@ -17,7 +17,7 @@ export const SAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/vpr/index.tsx
+++ b/src/parser/jobs/vpr/index.tsx
@@ -17,7 +17,7 @@ export const VIPER = new Meta({
 
 	supportedPatches: {
 		from: '7.05',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/whm/index.tsx
+++ b/src/parser/jobs/whm/index.tsx
@@ -20,7 +20,7 @@ export const WHITE_MAGE = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

Adding patch 7.5 definition and dates. KR is now synced with global.
Also marking BLU as supported pre-emptively since it's not receiving any updates this expansion :(

## Job Maintenance
- [x] I am active on the xivanalysis Discord ~~and part of the job maintainers group for the job(s) in this PR~~
