### PR TITLE
Patch 7.5 Core support

### DIFF
--- a/src/generated/unableToActStatusIds.ts
+++ b/src/generated/unableToActStatusIds.ts
@@ -272,8 +272,11 @@ export const UNABLE_TO_ACT_STATUS_IDS = [
 	4578, // Fetters (lockActions, lockControl)
 	4618, // Standing Firm (lockActions, lockControl)
 	4619, //  (lockActions, lockControl)
+	4973, // In Event (lockActions, lockControl)
 	5043, // Stun (lockActions)
+	5047, // Bubble Gaol (lockActions, lockControl)
 	5058, // Stone Curse (lockActions)
 	5110, //  (lockActions, lockControl)
 	5174, // Forced March (lockActions)
+	5407, // Strung Up (lockControl)
 ]

--- a/src/parser/core/index.tsx
+++ b/src/parser/core/index.tsx
@@ -15,7 +15,7 @@ export const CORE = new Meta({
 	// Read `docs/patch-checklist.md` before editing the following values.
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 })
 


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

Updated uta status ids for new patch
Thankfully, neither this EX trial nor any of the 24 man fights appear have any weird invuln behaviors like Doomtrain did... Bumped core support to 7.5

## Testing / Validation

Pick your favorite 24 man and/or EX logs.

## Job Maintenance
- [x] I am active on the xivanalysis Discord
