### PR TITLE
Patch 7.5 remaining bumps

### DIFF
--- a/src/parser/jobs/rpr/index.tsx
+++ b/src/parser/jobs/rpr/index.tsx
@@ -16,7 +16,7 @@ export const REAPER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/sam/index.tsx
+++ b/src/parser/jobs/sam/index.tsx
@@ -13,7 +13,7 @@ export const SAMURAI = new Meta({
 
 	supportedPatches: {
 		from: '7.05',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/smn/index.tsx
+++ b/src/parser/jobs/smn/index.tsx
@@ -21,7 +21,7 @@ export const SUMMONER = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [

--- a/src/parser/jobs/smn/modules/MultiHitSkills.ts
+++ b/src/parser/jobs/smn/modules/MultiHitSkills.ts
@@ -24,7 +24,7 @@ export class AoeChecker extends AoEUsages {
 		{
 			aoeAction: this.data.actions.PAINFLARE,
 			stActions: [this.data.actions.NECROTIZE],
-			minTargets: (!this.parser.patch.before('7.2')) ? PF_BP_71 : PF_BP_72,
+			minTargets: this.getPainflareMinTargets(),
 		},
 		{
 			aoeAction: this.data.actions.ASTRAL_FLARE,
@@ -57,4 +57,17 @@ export class AoeChecker extends AoEUsages {
 			minTargets: 3,
 		},
 	]
+
+	private getPainflareMinTargets() {
+		// Prior to patch 7.2, Painflare required 3 targets to pull ahead
+		if (this.parser.patch.before('7.2')) {
+			return PF_BP_71
+		}
+		// Potency changes in patch 7.2 made Painflare require 4 targets
+		if (this.parser.patch.before('7.5')) {
+			return PF_BP_72
+		}
+		// Patch 7.5's potency changes to both Painflare and Necrotize returned it to a 3 target threshold
+		return PF_BP_71
+	}
 }

--- a/src/parser/jobs/war/index.tsx
+++ b/src/parser/jobs/war/index.tsx
@@ -16,7 +16,7 @@ export const WARRIOR = new Meta({
 
 	supportedPatches: {
 		from: '7.0',
-		to: '7.4',
+		to: '7.5',
 	},
 
 	contributors: [


### PR DESCRIPTION
## Pull request type

- [x] This is a patch bump

## Pull request details

- SAM and WAR had potency changes that do not affect their analysis
  - Potency is not tracked in our data for the actions that changed
- RPR sort of had a change, in that it is now situationally viable to skip Communio.
  - However, the constraints for this, and the gain involved, are such that it's being deemed advanced tech and is not expected to be part of our analysis.
  - The specific potency changes are to actions we don't track in our data
- SMN had it's Painflare/Necrotize AoE threshold change (again) due to it's potency changes

## Testing / Validation

Pick your favorite log(s) if you want to test the SMN change

## Job Maintenance
- [x] I am active on the xivanalysis Discord
