### PR TITLE
Add generic module expanded modal view and implement for timeline + action window modules

### DIFF
--- a/locale/de/messages.json
+++ b/locale/de/messages.json
@@ -312,6 +312,8 @@
   "core.always-cast.info-header": "",
   "core.always-cast.timestamp-header": "Zeit",
   "core.always-cast.title": "Mach immer etwas",
+  "core.analyse.collapse-module": "",
+  "core.analyse.expand-module": "",
   "core.analyse.see-more": "Siehe mehr",
   "core.aoeusages.aoe-ability": "AoE-Aktionen benutzt",
   "core.aoeusages.min-targets": "Minimale Ziele",

--- a/locale/en/messages.json
+++ b/locale/en/messages.json
@@ -312,6 +312,8 @@
   "core.always-cast.info-header": "Info",
   "core.always-cast.timestamp-header": "Time",
   "core.always-cast.title": "Always be casting",
+  "core.analyse.collapse-module": "Collapse module",
+  "core.analyse.expand-module": "Expand module",
   "core.analyse.see-more": "See more",
   "core.aoeusages.aoe-ability": "AoE Action Used",
   "core.aoeusages.min-targets": "Minimum Targets",

--- a/locale/fr/messages.json
+++ b/locale/fr/messages.json
@@ -312,6 +312,8 @@
   "core.always-cast.info-header": "Info",
   "core.always-cast.timestamp-header": "Temps",
   "core.always-cast.title": "Soyez toujours en train de lançer vos sorts",
+  "core.analyse.collapse-module": "",
+  "core.analyse.expand-module": "",
   "core.analyse.see-more": "Voir plus",
   "core.aoeusages.aoe-ability": "Action AoE Utilisée",
   "core.aoeusages.min-targets": "Cibles Minimum Recommandées",

--- a/locale/ja/messages.json
+++ b/locale/ja/messages.json
@@ -312,6 +312,8 @@
   "core.always-cast.info-header": "情報",
   "core.always-cast.timestamp-header": "タイム",
   "core.always-cast.title": "常に回しましょう",
+  "core.analyse.collapse-module": "",
+  "core.analyse.expand-module": "",
   "core.analyse.see-more": "もっと見る",
   "core.aoeusages.aoe-ability": "範囲攻撃使用数",
   "core.aoeusages.min-targets": "最低ターゲット数",

--- a/locale/ko/messages.json
+++ b/locale/ko/messages.json
@@ -312,6 +312,8 @@
   "core.always-cast.info-header": "",
   "core.always-cast.timestamp-header": "시간",
   "core.always-cast.title": "항상 캐스팅을 하기",
+  "core.analyse.collapse-module": "",
+  "core.analyse.expand-module": "",
   "core.analyse.see-more": "더 보기",
   "core.aoeusages.aoe-ability": "광역기 사용",
   "core.aoeusages.min-targets": "최소 개체 수",

--- a/locale/zh/messages.json
+++ b/locale/zh/messages.json
@@ -312,6 +312,8 @@
   "core.always-cast.info-header": "详细",
   "core.always-cast.timestamp-header": "时间",
   "core.always-cast.title": "保持使用技能",
+  "core.analyse.collapse-module": "",
+  "core.analyse.expand-module": "",
   "core.analyse.see-more": "查看更多",
   "core.aoeusages.aoe-ability": "AoE技能使用",
   "core.aoeusages.min-targets": "最少目标",

--- a/src/akkd/Segment/ExpandableSegment.tsx
+++ b/src/akkd/Segment/ExpandableSegment.tsx
@@ -1,10 +1,13 @@
 import classNames from 'classnames'
-import {createRef, CSSProperties, PureComponent, ReactNode, RefObject} from 'react'
+import {createRef, CSSProperties, MouseEventHandler, PureComponent, ReactNode, RefObject} from 'react'
 import styles from './Segment.module.css'
 
 interface Props {
+	className?: string
+	onClick?: MouseEventHandler<HTMLDivElement>
 	seeMore?: ReactNode
 	collapsed?: boolean
+	forceExpanded?: boolean
 	maxHeight?: number
 	leeway?: number
 	children?: ReactNode
@@ -81,7 +84,10 @@ export class ExpandableSegment extends PureComponent<Props, State> {
 
 	override render() {
 		const {
+			className,
+			onClick,
 			seeMore,
+			forceExpanded,
 			maxHeight: propHeight,
 			children,
 		} = this.props
@@ -91,10 +97,12 @@ export class ExpandableSegment extends PureComponent<Props, State> {
 			maxHeight: stateHeight,
 		} = this.state
 
-		const maxHeight = collapsed? propHeight : stateHeight
+		const isCollapsed = collapsed && !forceExpanded
+		const maxHeight = isCollapsed? propHeight : stateHeight
+		const shouldClip = maxHeight && overflowing && !forceExpanded
 
 		const style: CSSProperties = {}
-		if (maxHeight && overflowing) {
+		if (shouldClip) {
 			style.maxHeight = maxHeight
 		}
 
@@ -103,12 +111,14 @@ export class ExpandableSegment extends PureComponent<Props, State> {
 				ref={this.ref}
 				className={classNames(
 					styles.segment,
-					maxHeight && styles.expandable,
+					className,
+					shouldClip && styles.expandable,
 				)}
+				onClick={onClick}
 				style={style}
 			>
 				{children}
-				{overflowing && collapsed && (
+				{overflowing && isCollapsed && (
 					<div className={styles.expand} onClick={this.expand}>
 						<span className={styles.expandMarker}>{seeMore || 'See more'}</span>
 					</div>

--- a/src/akkd/Segment/Segment.tsx
+++ b/src/akkd/Segment/Segment.tsx
@@ -1,8 +1,11 @@
-import {PureComponent, ReactNode} from 'react'
+import classNames from 'classnames'
+import {MouseEventHandler, PureComponent, ReactNode} from 'react'
 import {ExpandableSegment} from './ExpandableSegment'
 import styles from './Segment.module.css'
 
 interface SegmentProps {
+	className?: string
+	onClick?: MouseEventHandler<HTMLDivElement>
 	children?: ReactNode
 }
 
@@ -10,7 +13,7 @@ export class Segment extends PureComponent<SegmentProps> {
 	static Expandable = ExpandableSegment
 
 	override render() {
-		const {children} = this.props
-		return <div className={styles.segment}>{children}</div>
+		const {children, className, onClick} = this.props
+		return <div className={classNames(styles.segment, className)} onClick={onClick}>{children}</div>
 	}
 }

--- a/src/components/ReportFlow/Analyse/Analyse.module.css
+++ b/src/components/ReportFlow/Analyse/Analyse.module.css
@@ -84,6 +84,15 @@
 	margin-left: auto;
 }
 
+.moduleExpandButton {
+}
+
+.expandedModuleExpandButton {
+}
+
+.moduleHeaderActionsExpandOnly {
+}
+
 @media (max-width: 767px) {
 	.moduleHeader {
 		flex-wrap: wrap;
@@ -101,6 +110,14 @@
 
 	.moduleHeaderActions > :only-child {
 		margin-left: auto;
+	}
+
+	.moduleExpandButton.moduleExpandButton:not(.expandedModuleExpandButton) {
+		display: none;
+	}
+
+	.moduleHeaderActionsExpandOnly {
+		display: none;
 	}
 }
 

--- a/src/components/ReportFlow/Analyse/Analyse.module.css
+++ b/src/components/ReportFlow/Analyse/Analyse.module.css
@@ -1,3 +1,5 @@
+@value gutter, themeBackground, themeInverse from "theme.module.css";
+
 .header {
 	display: flex;
 }
@@ -16,4 +18,78 @@
 
 .seeMore {
 	margin: 0 5px;
+}
+
+.moduleExpansionFrame {
+	display: block;
+	margin: gutter 0;
+}
+
+.moduleExpansionFrame:first-child {
+	margin-top: 0;
+}
+
+.moduleExpansionFrame:last-child {
+	margin-bottom: 0;
+}
+
+.moduleExpansionFrame.expanded {
+	position: fixed;
+	inset: 0;
+	z-index: 1004;
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin: 0;
+	padding: gutter;
+	background: rgba(0, 0, 0, 0.5);
+	overflow: auto;
+}
+
+.moduleSegment {
+	margin: 0;
+	max-width: 100%;
+}
+
+.expandedSegment.expandedSegment {
+	box-sizing: border-box;
+	width: fit-content;
+	max-height: 100%;
+	max-width: 100%;
+	box-shadow: 0 2px 12px color(themeInverse a(30%));
+	overflow: auto;
+}
+
+.moduleHeader {
+	display: flex;
+	align-items: flex-start;
+	gap: calc(gutter / 2);
+	margin-bottom: 1em;
+}
+
+.moduleTitle {
+	flex: 1 1 auto;
+	margin: 0 !important;
+	min-width: 0;
+}
+
+.moduleHeaderActions {
+	display: flex;
+	flex: 0 1 auto;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: flex-end;
+	gap: calc(gutter / 2);
+	margin-left: auto;
+}
+
+.expandedSegment .moduleHeader {
+	position: sticky;
+	top: calc(-1 * gutter);
+	z-index: 1;
+	align-items: center;
+	margin: calc(-1 * gutter) calc(-1 * gutter) gutter;
+	padding: gutter;
+	background: themeBackground;
 }

--- a/src/components/ReportFlow/Analyse/Analyse.module.css
+++ b/src/components/ReportFlow/Analyse/Analyse.module.css
@@ -87,7 +87,7 @@
 .expandedSegment .moduleHeader {
 	position: sticky;
 	top: calc(-1 * gutter);
-	z-index: 1;
+	z-index: 10;
 	align-items: center;
 	margin: calc(-1 * gutter) calc(-1 * gutter) gutter;
 	padding: gutter;

--- a/src/components/ReportFlow/Analyse/Analyse.module.css
+++ b/src/components/ReportFlow/Analyse/Analyse.module.css
@@ -84,6 +84,26 @@
 	margin-left: auto;
 }
 
+@media (max-width: 767px) {
+	.moduleHeader {
+		flex-wrap: wrap;
+	}
+
+	.moduleTitle {
+		flex-basis: 100%;
+	}
+
+	.moduleHeaderActions {
+		flex: 1 1 100%;
+		justify-content: space-between;
+		margin-left: 0;
+	}
+
+	.moduleHeaderActions > :only-child {
+		margin-left: auto;
+	}
+}
+
 .expandedSegment .moduleHeader {
 	position: sticky;
 	top: calc(-1 * gutter);

--- a/src/components/ReportFlow/Analyse/Analyse.module.css.d.ts
+++ b/src/components/ReportFlow/Analyse/Analyse.module.css.d.ts
@@ -3,12 +3,15 @@
 declare namespace AnalyseModuleCssNamespace {
   export interface IAnalyseModuleCss {
     expanded: string;
+    expandedModuleExpandButton: string;
     expandedSegment: string;
     gutter: string;
     header: string;
+    moduleExpandButton: string;
     moduleExpansionFrame: string;
     moduleHeader: string;
     moduleHeaderActions: string;
+    moduleHeaderActionsExpandOnly: string;
     moduleSegment: string;
     moduleTitle: string;
     resultsContainer: string;

--- a/src/components/ReportFlow/Analyse/Analyse.module.css.d.ts
+++ b/src/components/ReportFlow/Analyse/Analyse.module.css.d.ts
@@ -2,9 +2,19 @@
 /* eslint-disable */
 declare namespace AnalyseModuleCssNamespace {
   export interface IAnalyseModuleCss {
+    expanded: string;
+    expandedSegment: string;
+    gutter: string;
     header: string;
+    moduleExpansionFrame: string;
+    moduleHeader: string;
+    moduleHeaderActions: string;
+    moduleSegment: string;
+    moduleTitle: string;
     resultsContainer: string;
     seeMore: string;
+    themeBackground: string;
+    themeInverse: string;
   }
 }
 

--- a/src/components/ReportFlow/Analyse/ModuleExpansionContext.ts
+++ b/src/components/ReportFlow/Analyse/ModuleExpansionContext.ts
@@ -1,0 +1,13 @@
+import {createContext, useContext} from 'react'
+
+export interface ModuleExpansionContextValue {
+	expanded: boolean
+}
+
+const ModuleExpansionContext = createContext<ModuleExpansionContextValue>({
+	expanded: false,
+})
+
+export const ModuleExpansionProvider = ModuleExpansionContext.Provider
+export const ModuleExpansionConsumer = ModuleExpansionContext.Consumer
+export const useModuleExpansion = () => useContext(ModuleExpansionContext)

--- a/src/components/ReportFlow/Analyse/ResultSegment.tsx
+++ b/src/components/ReportFlow/Analyse/ResultSegment.tsx
@@ -1,13 +1,16 @@
-import {Trans} from '@lingui/react/macro'
+import {msg} from '@lingui/core/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 import {Segment} from 'akkd'
+import classNames from 'classnames'
 import {NormalisedMessage} from 'components/ui/NormalisedMessage'
 import {DisplayMode} from 'parser/core/Analyser'
 import {Result} from 'parser/core/Parser'
-import {PureComponent} from 'react'
+import {MouseEvent, PureComponent, ReactNode} from 'react'
 import ReactDOM from 'react-dom'
-import {Header, Icon} from 'semantic-ui-react'
+import {Button, Header, Icon} from 'semantic-ui-react'
 import {gutter} from 'theme'
 import styles from './Analyse.module.css'
+import {ModuleExpansionProvider} from './ModuleExpansionContext'
 import {Consumer, Context, Scrollable} from './SegmentPositionContext'
 
 interface Props {
@@ -17,11 +20,37 @@ interface Props {
 
 interface State {
 	collapsed?: boolean
+	expanded: boolean
 }
 
 export const OFFSET_FROM_VIEWPORT_TOP = gutter
 const MODULE_HEIGHT_MAX = 400
 const MODULE_HEIGHT_LEEWAY = 200
+
+const expandModuleLabel = msg({id: 'core.analyse.expand-module', message: 'Expand module'})
+const collapseModuleLabel = msg({id: 'core.analyse.collapse-module', message: 'Collapse module'})
+
+function ExpansionButton({
+	expanded,
+	onClick,
+}: {
+	expanded: boolean
+	onClick(event: MouseEvent): void
+}) {
+	const {i18n} = useLingui()
+	const label = i18n._(expanded ? collapseModuleLabel : expandModuleLabel)
+
+	return <Button
+		aria-label={label}
+		aria-pressed={expanded}
+		circular
+		compact
+		icon={expanded ? 'compress' : 'expand'}
+		onClick={onClick}
+		size="mini"
+		title={label}
+	/>
+}
 
 export class ResultSegment extends PureComponent<Props, State> implements Scrollable {
 	private static instances = new Map<string, ResultSegment>()
@@ -37,13 +66,14 @@ export class ResultSegment extends PureComponent<Props, State> implements Scroll
 	})
 	private ref: HTMLElement|null = null
 	private positionContext!: Context
+	private previousBodyOverflow?: string
 
 	constructor(props: Props) {
 		super(props)
 
 		this.scrollIntoView.bind(this)
 
-		const state: State = {}
+		const state: State = {expanded: false}
 		if (props.result.mode === DisplayMode.FULL) {
 			state.collapsed = false
 		}
@@ -63,7 +93,7 @@ export class ResultSegment extends PureComponent<Props, State> implements Scroll
 		}
 	}
 
-	override componentDidUpdate(prevProps: Readonly<Props>) {
+	override componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<State>) {
 		if (this.props.index !== prevProps.index) {
 			this.positionContext.unregister(prevProps.index)
 		}
@@ -78,6 +108,10 @@ export class ResultSegment extends PureComponent<Props, State> implements Scroll
 			this.ref = ref
 			this.observer.observe(ref)
 		}
+
+		if (this.state.expanded !== prevState.expanded) {
+			this.syncExpansionSideEffects()
+		}
 	}
 
 	override componentWillUnmount() {
@@ -87,6 +121,7 @@ export class ResultSegment extends PureComponent<Props, State> implements Scroll
 
 		this.observer.disconnect()
 		this.positionContext.unregister(this.props.index)
+		this.clearExpansionSideEffects()
 	}
 
 	override render() {
@@ -98,23 +133,22 @@ export class ResultSegment extends PureComponent<Props, State> implements Scroll
 
 	private renderContent = () => {
 		const {result} = this.props
+		const {expanded} = this.state
 
 		if (result.mode === DisplayMode.RAW) {
 			return <div>{result.markup}</div>
 		}
 
-		const contents = <>
-			<Header>
-				{result.name != null
-					? <NormalisedMessage message={result.name}/>
-					: result.handle
-				}
-			</Header>
-			<div>{result.markup}</div>
-		</>
+		const titleId = `module-${result.handle}-title`
+		const contents = this.renderModuleContents(titleId)
 
 		if (result.mode === DisplayMode.FULL) {
-			return <Segment>{contents}</Segment>
+			return this.renderExpansionFrame(
+				titleId,
+				<Segment className={this.segmentClassName} onClick={expanded ? this.stopExpansionClickPropagation : undefined}>
+					{contents}
+				</Segment>,
+			)
 		}
 
 		const {collapsed} = this.state
@@ -127,14 +161,82 @@ export class ResultSegment extends PureComponent<Props, State> implements Scroll
 		</>
 
 		return (
-			<Segment.Expandable
-				collapsed={collapsed}
-				maxHeight={MODULE_HEIGHT_MAX}
-				leeway={MODULE_HEIGHT_LEEWAY}
-				seeMore={seeMore}
+			this.renderExpansionFrame(
+				titleId,
+				<Segment.Expandable
+					className={this.segmentClassName}
+					collapsed={collapsed}
+					forceExpanded={expanded}
+					maxHeight={MODULE_HEIGHT_MAX}
+					leeway={MODULE_HEIGHT_LEEWAY}
+					onClick={expanded ? this.stopExpansionClickPropagation : undefined}
+					seeMore={seeMore}
+				>
+					{contents}
+				</Segment.Expandable>,
+			)
+		)
+	}
+
+	private get segmentClassName() {
+		return classNames(
+			styles.moduleSegment,
+			this.state.expanded && styles.expandedSegment,
+		)
+	}
+
+	private renderExpansionFrame(titleId: string, contents: ReactNode) {
+		const {expanded} = this.state
+
+		return (
+			<div
+				aria-labelledby={expanded ? titleId : undefined}
+				aria-modal={expanded || undefined}
+				className={classNames(
+					styles.moduleExpansionFrame,
+					expanded && styles.expanded,
+				)}
+				onClick={expanded ? this.collapseExpanded : undefined}
+				role={expanded ? 'dialog' : undefined}
 			>
-				{contents}
-			</Segment.Expandable>
+				<ModuleExpansionProvider value={{expanded}}>
+					{contents}
+				</ModuleExpansionProvider>
+			</div>
+		)
+	}
+
+	private renderModuleContents(titleId: string) {
+		const {result} = this.props
+
+		return <>
+			<div className={styles.moduleHeader}>
+				<Header id={titleId} className={styles.moduleTitle}>
+					{result.name != null
+						? <NormalisedMessage message={result.name}/>
+						: result.handle
+					}
+				</Header>
+				{this.renderHeaderActions()}
+			</div>
+			<div>{result.markup}</div>
+		</>
+	}
+
+	private renderHeaderActions() {
+		const {result} = this.props
+		if (!result.expandable && result.headerActions == null) { return null }
+
+		return (
+			<div className={styles.moduleHeaderActions}>
+				{result.headerActions}
+				{result.expandable && (
+					<ExpansionButton
+						expanded={this.state.expanded}
+						onClick={this.handleExpansionButtonClick}
+					/>
+				)}
+			</div>
 		)
 	}
 
@@ -142,6 +244,49 @@ export class ResultSegment extends PureComponent<Props, State> implements Scroll
 		for (const entry of entries) {
 			const active = entry.boundingClientRect.bottom > OFFSET_FROM_VIEWPORT_TOP
 			this.positionContext.register(this, this.props.index, active)
+		}
+	}
+
+	private toggleExpanded = () => {
+		this.setState(({expanded}) => ({expanded: !expanded}))
+	}
+
+	private handleExpansionButtonClick = (event: MouseEvent) => {
+		event.stopPropagation()
+		this.toggleExpanded()
+	}
+
+	private stopExpansionClickPropagation = (event: MouseEvent) => {
+		event.stopPropagation()
+	}
+
+	private collapseExpanded = () => {
+		this.setState({expanded: false})
+	}
+
+	private handleKeyDown = (event: KeyboardEvent) => {
+		if (event.key === 'Escape') {
+			this.collapseExpanded()
+		}
+	}
+
+	private syncExpansionSideEffects() {
+		if (this.state.expanded) {
+			this.previousBodyOverflow = document.body.style.overflow
+			document.body.style.overflow = 'hidden'
+			window.addEventListener('keydown', this.handleKeyDown)
+			return
+		}
+
+		this.clearExpansionSideEffects()
+	}
+
+	private clearExpansionSideEffects() {
+		window.removeEventListener('keydown', this.handleKeyDown)
+
+		if (this.previousBodyOverflow != null) {
+			document.body.style.overflow = this.previousBodyOverflow
+			this.previousBodyOverflow = undefined
 		}
 	}
 

--- a/src/components/ReportFlow/Analyse/ResultSegment.tsx
+++ b/src/components/ReportFlow/Analyse/ResultSegment.tsx
@@ -44,6 +44,10 @@ function ExpansionButton({
 		aria-label={label}
 		aria-pressed={expanded}
 		circular
+		className={classNames(
+			styles.moduleExpandButton,
+			expanded && styles.expandedModuleExpandButton,
+		)}
 		compact
 		icon={expanded ? 'compress' : 'expand'}
 		onClick={onClick}
@@ -226,9 +230,13 @@ export class ResultSegment extends PureComponent<Props, State> implements Scroll
 	private renderHeaderActions() {
 		const {result} = this.props
 		if (!result.expandable && result.headerActions == null) { return null }
+		const isExpandOnly = result.expandable && result.headerActions == null && !this.state.expanded
 
 		return (
-			<div className={styles.moduleHeaderActions}>
+			<div className={classNames(
+				styles.moduleHeaderActions,
+				isExpandOnly && styles.moduleHeaderActionsExpandOnly,
+			)}>
 				{result.headerActions}
 				{result.expandable && (
 					<ExpansionButton

--- a/src/components/ReportFlow/Analyse/index.ts
+++ b/src/components/ReportFlow/Analyse/index.ts
@@ -1,2 +1,4 @@
 export {Analyse} from './Analyse'
+export {ModuleExpansionConsumer, ModuleExpansionProvider, useModuleExpansion} from './ModuleExpansionContext'
 export type {AnalyseProps} from './Analyse'
+export type {ModuleExpansionContextValue} from './ModuleExpansionContext'

--- a/src/parser/core/Analyser.ts
+++ b/src/parser/core/Analyser.ts
@@ -53,6 +53,8 @@ export type AnalyserOptions = ConstructorParameters<typeof Analyser>
 export class Analyser extends Injectable {
 	/** Title displayed above analysis output, and in the sidebar. */
 	static title?: MessageDescriptor
+	/** Extra content displayed beside the module title in the result header. */
+	static headerActions?: ReactNode
 
 	/**
 	 * Value used to control the order in which output is displayed in the results
@@ -62,6 +64,8 @@ export class Analyser extends Injectable {
 	static displayOrder = DEFAULT_DISPLAY_ORDER
 	/** The style of the wrapper that analysis output should be rendered in. */
 	static displayMode = DisplayMode.COLLAPSIBLE
+	/** Whether the module can be expanded into a modal-style view. */
+	static expandable = false
 
 	/** The parser for the current analysis. */
 	protected readonly parser: Parser

--- a/src/parser/core/Parser.tsx
+++ b/src/parser/core/Parser.tsx
@@ -20,8 +20,10 @@ const LS_KEY_LAST_FAILING_VERSION = 'xiva.lastFailingVersion'
 export interface Result {
 	handle: string
 	name?: MessageDescriptor
+	headerActions?: ReactNode
 	mode: DisplayMode
 	order: number
+	expandable: boolean
 	markup: ReactNode
 }
 
@@ -378,9 +380,11 @@ export class Parser {
 			const constructor = injectable.constructor as typeof Analyser
 			return {
 				name: constructor.title,
+				headerActions: constructor.headerActions,
 				handle: constructor.handle,
 				mode: constructor.displayMode,
 				order: constructor.displayOrder,
+				expandable: constructor.expandable,
 				markup: null,
 			}
 		}

--- a/src/parser/core/changelog.tsx
+++ b/src/parser/core/changelog.tsx
@@ -9,6 +9,11 @@ export const changelog: ChangelogEntry[] = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2026-06-13'),
+		Changes: () => <>Add "Expand module" buttons to the Timeline and Action Window modules.</>,
+		contributors: [CONTRIBUTORS.HINT],
+	},
+	{
 		date: new Date('2026-03-15'),
 		Changes: () => <>Update Always be Casting GCD Delay calculation to better handle longer than normal GCD recasts, such as PCT's Motif spells.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
+++ b/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx
@@ -20,6 +20,7 @@ export type HistoryEntryPredicate = (e: HistoryEntry<EvaluatedAction[]>) => bool
  * By default, all actions cast during a window will be included.
  */
 export abstract class ActionWindow extends Analyser {
+	static override expandable = true
 
 	@dependency protected data!: Data
 	@dependency protected suggestions!: Suggestions

--- a/src/parser/core/modules/ResourceGraphs/ResourceGraphs.module.css
+++ b/src/parser/core/modules/ResourceGraphs/ResourceGraphs.module.css
@@ -22,6 +22,7 @@
 
 .markerTooltip {
 	position: fixed;
+	z-index: 1900;
 	border: 1px solid black;
 	padding: 5px;
 	transform: translate(-50%, calc(-100% - markerPointerSize));

--- a/src/parser/core/modules/Timeline/Timeline.module.css
+++ b/src/parser/core/modules/Timeline/Timeline.module.css
@@ -4,10 +4,11 @@
 	font-style: italic;
 }
 
-@media (min-width: 992px) {
-	.helpText {
-		position: absolute;
-		top: gutter;
-		right: gutter;
-	}
+.timelineWrapper {
+	display: block;
+}
+
+.timelineWrapper.expanded {
+	width: calc(100vw - 4 * gutter);
+	max-width: 100%;
 }

--- a/src/parser/core/modules/Timeline/Timeline.module.css.d.ts
+++ b/src/parser/core/modules/Timeline/Timeline.module.css.d.ts
@@ -2,8 +2,10 @@
 /* eslint-disable */
 declare namespace TimelineModuleCssNamespace {
   export interface ITimelineModuleCss {
+    expanded: string;
     gutter: string;
     helpText: string;
+    timelineWrapper: string;
   }
 }
 

--- a/src/parser/core/modules/Timeline/Timeline.tsx
+++ b/src/parser/core/modules/Timeline/Timeline.tsx
@@ -1,5 +1,6 @@
 import {msg} from '@lingui/core/macro'
 import {Trans} from '@lingui/react/macro'
+import {useModuleExpansion} from 'components/ReportFlow/Analyse/ModuleExpansionContext'
 import {Analyser, DisplayMode} from 'parser/core/Analyser'
 import {DISPLAY_ORDER} from '../DISPLAY_ORDER'
 import {
@@ -18,11 +19,46 @@ const INITIAL_END = 60000 // One minute
 
 const MINIMUM_ZOOM = 10000 // 10 seconds (~4 gcds)
 
+interface TimelineOutputProps {
+	rows: RowConfig[]
+	items: ItemConfig[]
+	duration: number
+	exposeSetView(handler: SetViewFn): void
+}
+
+function TimelineOutput({
+	rows,
+	items,
+	duration,
+	exposeSetView,
+}: TimelineOutputProps) {
+	const {expanded} = useModuleExpansion()
+
+	return <div className={expanded ? `${styles.timelineWrapper} ${styles.expanded}` : styles.timelineWrapper}>
+		<TimelineComponent
+			rows={rows}
+			items={items}
+
+			min={0}
+			max={duration}
+			end={Math.min(duration, INITIAL_END)}
+			zoomMin={MINIMUM_ZOOM}
+			exposeSetView={exposeSetView}
+		/>
+	</div>
+}
+
 export class Timeline extends Analyser {
 	static override handle = 'timeline'
 	static override displayOrder = DISPLAY_ORDER.TIMELINE
 	static override displayMode = DisplayMode.FULL
 	static override title = msg({id: 'core.timeline.title', message: 'Timeline'})
+	static override expandable = true
+	static override headerActions = <span className={styles.helpText}>
+		<Trans id="core.timeline.help-text">
+			Scroll or click+drag to pan, ctrl+scroll or pinch to zoom.
+		</Trans>
+	</span>
 
 	private setView?: SetViewFn
 
@@ -69,22 +105,11 @@ export class Timeline extends Analyser {
 	}
 
 	override output() {
-		return <>
-			<span className={styles.helpText}>
-				<Trans id="core.timeline.help-text">
-					Scroll or click+drag to pan, ctrl+scroll or pinch to zoom.
-				</Trans>
-			</span>
-			<TimelineComponent
-				rows={this.rows}
-				items={this.items}
-
-				min={0}
-				max={this.parser.currentDuration}
-				end={Math.min(this.parser.currentDuration, INITIAL_END)}
-				zoomMin={MINIMUM_ZOOM}
-				exposeSetView={this.exposeSetView}
-			/>
-		</>
+		return <TimelineOutput
+			rows={this.rows}
+			items={this.items}
+			duration={this.parser.currentDuration}
+			exposeSetView={this.exposeSetView}
+		/>
 	}
 }


### PR DESCRIPTION
## Pull request type

- [x] This is new functionality or an addition to existing functionality

## Pull request details

- [x] The goal of this PR is detailed below:

This PR adds a generic expanded view for modules. Modules can opt in via static analyser metadata, and this will render an expand/compress button that moves the existing mounted module content into an expanded modal.

The Timeline module opts in and moves its help text into shared header actions. ActionWindow modules also opt in through the ActionWindow base class.

Expanded modules preserve their mounted React state, close via Escape, the compress button, or clicking outside the modal, and lock body scrolling while open. Collapsible modules render unclipped while expanded without changing their normal in-flow collapsed state.

On mobile widths there's no extra screen width to consume, so the expand button is hidden.

Impact for future development:
- Modules can opt in with `static expandable = true`.
- Modules can add header content generically with `static headerActions`.
- Modules can read `ModuleExpansionContext` to render differently while expanded (e.g. a compact view in-flow and a more expansive/detailed one when expanded).

## Screenshots

### Timeline

<img width="2631" height="1491" alt="image" src="https://github.com/user-attachments/assets/df7aaf11-d716-44ca-8538-14a3167864c6" />

<img width="2646" height="1505" alt="image" src="https://github.com/user-attachments/assets/18369c84-55b5-4761-a15c-84c3b54b4e72" />

### Bard's burst window

<img width="2630" height="1491" alt="image" src="https://github.com/user-attachments/assets/1d8d9ebd-d86d-4803-9a5e-7de81ffb7361" />

<img width="2632" height="1493" alt="image" src="https://github.com/user-attachments/assets/4316fa46-5466-4fd1-a16d-cdd590ab0a17" />

### Mobile

<img width="574" height="1216" alt="image" src="https://github.com/user-attachments/assets/42dc82ef-f092-4b79-8734-415fbc4c6c7c" />


## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:

http://127.0.0.1:3000/fflogs/LPCNRQx1B8kz9A6G/12/3

Manual checks covered:

- Timeline expands without remounting or resetting pan/zoom state.
- Timeline help text and expand/compress button align correctly in-flow and expanded.
- Resource hover tooltip remains visible above the expanded module.
- Compress button remains clickable while the expanded timeline is scrolled.
- ActionWindow modules show the expansion control and expand correctly.
- Escape, compress button, and outside-click close the expanded view.
- Existing sidebar/module navigation remains usable after closing.
- Expansion affordance is hidden on mobile.
- The regular non-expanded module flow appears as expected.
- Mobile layout appears as expected.

## Job Maintenance

- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR