### PR TITLE
[SAM] Update Guren/Senei breakpoint for 7.4

### DIFF
--- a/src/parser/jobs/sam/changelog.tsx
+++ b/src/parser/jobs/sam/changelog.tsx
@@ -3,6 +3,11 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2026-06-23'),
+		Changes: () => <>Updated SAM AoE to reflect 7.4's potency change that reduced the <DataLink action="HISSATSU_GUREN"/> breakpoint from 3 to 2.</>,
+		contributors: [CONTRIBUTORS.RYAN],
+	},
+	{
 		date: new Date('2025-03-24'),
 		Changes: () => <>SAM 7.2 Support added. <DataLink action="HISSATSU_GUREN"/> breakpoint increased to 3 from 2.</>,
 		contributors: [CONTRIBUTORS.RYAN],

--- a/src/parser/jobs/sam/modules/AoeChecker.ts
+++ b/src/parser/jobs/sam/modules/AoeChecker.ts
@@ -12,6 +12,9 @@ const AOE_FINISHERS = [
 	ACTIONS.OKA.id,
 ]
 
+const GUREN_SENEI_BREAKPOINT = 3
+const PATCH74_GUREN_SENEI_BREAKPOINT = 2
+
 export class AoeChecker extends AoEUsages {
 	@dependency private actors!: Actors
 
@@ -21,7 +24,7 @@ export class AoeChecker extends AoEUsages {
 		{
 			aoeAction: ACTIONS.HISSATSU_GUREN,
 			stActions: [ACTIONS.HISSATSU_SENEI],
-			minTargets: 3,
+			minTargets: this.parser.patch.after('7.4') ? PATCH74_GUREN_SENEI_BREAKPOINT : GUREN_SENEI_BREAKPOINT,
 		},
 
 		{

--- a/src/parser/jobs/sam/modules/AoeChecker.ts
+++ b/src/parser/jobs/sam/modules/AoeChecker.ts
@@ -24,7 +24,7 @@ export class AoeChecker extends AoEUsages {
 		{
 			aoeAction: ACTIONS.HISSATSU_GUREN,
 			stActions: [ACTIONS.HISSATSU_SENEI],
-			minTargets: this.parser.patch.after('7.4') ? PATCH74_GUREN_SENEI_BREAKPOINT : GUREN_SENEI_BREAKPOINT,
+			minTargets: this.parser.patch.before('7.4') ? GUREN_SENEI_BREAKPOINT : PATCH74_GUREN_SENEI_BREAKPOINT,
 		},
 
 		{


### PR DESCRIPTION
## Pull request type

- [ x] This is new functionality or an addition to existing functionality


## Pull request details

- [x ] This is in response to a discussion or thread on Discord: https://discord.com/channels/441414116914233364/1518296287349444699/1518296287349444699

Since 7.4, Hissatsu: Guren is neutral at 2 targets (you can also argue that multitargeting might give you more chance to crit, so might be better) and worth at 3 targets. 


## Testing / Validation

- [x ] I used the log(s) listed below to develop and test this bugfix:

log link : https://www.fflogs.com/reports/a:b1TGpFcxhfgPamrC?fight=26
xiva link : https://xivanalysis.com/fflogs/a:b1TGpFcxhfgPamrC/26/2

## Job Maintenance
- [ x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
