### PR TITLE
Ignore buffed instant drips

### DIFF
--- a/src/parser/jobs/pct/changelog.tsx
+++ b/src/parser/jobs/pct/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2026-07-06'),
+		Changes: () => <>Filter Rainbow Drips that were instant cast due to Rainbow Bright out of the Swiftcast Actions display.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2025-08-08'),
 		Changes: () => <>Return <DataLink showIcon={false} action="STRIKING_MUSE" /> to the cooldowns checklist requirement and update <DataLink showIcon={false} action="STARRY_MUSE" /> window analysis to once again expect all three Hammer GCDs.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/pct/modules/Swiftcast.tsx
+++ b/src/parser/jobs/pct/modules/Swiftcast.tsx
@@ -1,10 +1,25 @@
 import {Trans} from '@lingui/react/macro'
 import {DataLink} from 'components/ui/DbLink'
+import {Action} from 'data/ACTIONS'
+import {dependency} from 'parser/core/Injectable'
+import {Actors} from 'parser/core/modules/Actors'
 import {Swiftcast as CoreSwiftcast} from 'parser/core/modules/Swiftcast'
 import {DISPLAY_ORDER} from './DISPLAY_ORDER'
 
 export class Swiftcast extends CoreSwiftcast {
+	@dependency private actors!: Actors
+
 	static override displayOrder = DISPLAY_ORDER.SWIFTCAST
 
 	override suggestionContent = <Trans id="pct.swiftcast.missed.suggestion.content">Cast a spell with <DataLink action="SWIFTCAST" /> before it expires. This allows you to cast spells that have cast times instantly, such as using <DataLink showIcon={false} status="SWIFTCAST" />a motif for a long movement or weaving window, or <DataLink action="RAINBOW_DRIP" /> right before a boss dies or becomes untargetable.</Trans>
+
+	protected override considerSwiftAction(action: Action): boolean {
+		// Rainbow Drip is the only thing that can be instant not because of Swiftcast, always consider all other actions
+		if (action.id !== this.data.actions.RAINBOW_DRIP.id) {
+			return true
+		}
+
+		// Ignore Rainbow Drips that were used under Rainbow Bright, it takes precedence over Swiftcast
+		return !this.actors.current.hasStatus(this.data.statuses.RAINBOW_BRIGHT.id)
+	}
 }


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] This is in response to a GitHub issue: https://github.com/xivanalysis/xivanalysis/issues/2313
- [x] The goal of this PR is detailed below:

PCT's Swiftcast override was displaying Rainbow Drips that didn't consume Swiftcast in the Swiftcast actions table. Rainbow Bright (the buff you get after finishing all 5 Hyperphantasia casts) makes Rainbow Drip instant and takes precedence over Swiftcast

Now, the override will only consider Rainbow Drips cast without Rainbow Bright active.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
  - https://xivanalysis.com/fflogs/frA9mJkHWQ1jyhRP/14/10

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
