### PR TITLE
Fix #2188: Remove extraneous onComplete event hook from Divination.

### DIFF
--- a/src/parser/jobs/ast/changelog.tsx
+++ b/src/parser/jobs/ast/changelog.tsx
@@ -3,6 +3,11 @@ import {CONTRIBUTORS} from 'data/CONTRIBUTORS'
 
 export const changelog = [
 	{
+		date: new Date('2026-09-06'),
+		Changes: () => <>Fixed duplicated Divination window suggestions.</>,
+		contributors: [CONTRIBUTORS.ANTHONY]
+	},
+	{
 		date: new Date('2025-12-18'),
 		Changes: () => <>Removed the non-mit, non-heal portion of <DataLink status="COLLECTIVE_UNCONSCIOUS" /> from overhealing.</>,
 		contributors: [CONTRIBUTORS.OTOCEPHALY],

--- a/src/parser/jobs/ast/changelog.tsx
+++ b/src/parser/jobs/ast/changelog.tsx
@@ -5,7 +5,7 @@ export const changelog = [
 	{
 		date: new Date('2026-09-06'),
 		Changes: () => <>Fixed duplicated Divination window suggestions.</>,
-		contributors: [CONTRIBUTORS.ANTHONY]
+		contributors: [CONTRIBUTORS.ANTHONY],
 	},
 	{
 		date: new Date('2025-12-18'),

--- a/src/parser/jobs/ast/modules/Divination.tsx
+++ b/src/parser/jobs/ast/modules/Divination.tsx
@@ -81,8 +81,6 @@ export class Divination extends RaidBuffWindow {
 				.target(oneOf(teamMembers)),
 			this.offCard)
 
-		this.addEventHook('complete', this.onComplete)
-
 		this.addEvaluator(new ExpectedGcdCountEvaluator({
 			expectedGcds: BASE_GCDS_PER_WINDOW,
 			globalCooldown: this.globalCooldown,


### PR DESCRIPTION
This hook is already added in the superclass ActionWindow. This was causing evaluators to be run multiple times.


[ActionWindow.tsx:178](https://github.com/xivanalysis/xivanalysis/blob/dawntrail/src/parser/core/modules/ActionWindow/windows/ActionWindow.tsx#L178)
```
	override initialise() {
		this.addEventHook('complete', this.onComplete)
	}
```

And here's a part of a stack trace I captured.
```
initialise @ ActionWindow.tsx:179
initialise @ BuffWindow.ts:68
initialise @ RaidBuffWindow.ts:41
initialise @ Divination.tsx:63
```


## Pull request type

- [ ] This is new functionality or an addition to existing functionality
- [X] This is a bugfix to existing functionality
- [ ] This is a patch bump

## Pull request details

<!-- If this PR is for new functionality or a bugfix, please complete the section below.  For a patch bump, delete this comment and the section below.  The context for your change is important to help the reviewer understand what the change is supposed to do - please provide an appropriate link or description to help the review process. -->
- [X] This is in response to a GitHub issue: #2188 
- [ ] This is in response to a discussion or thread on Discord: *[Link to thread or start of discussion]*
- [ ] The goal of this PR is detailed below:

## Testing / Validation

<!-- If this PR contains any new functionality or bugfixes, please include log links that reviewers can use to help verify your changes.  Reviewers may also find additional logs to check your PR with, but having initial logs is important to speed the review process, especially for corner cases or hard to trigger analysis flags.  If this PR is a patch bump with no changes or potency only changes, you can delete this section. -->
- [ ] The changes being implemented with this bugfix include comments that contain example log(s) to test with
- [ ] I have submitted the example log(s) to the xivanalysis static on FFLogs for record keeping
- [X] I used the log(s) listed below to develop and test this bugfix:

   https://xivanalysis.com/fflogs/PHZTyNqGvQ4AgbRr/8/116
   Before: 

<img width="3454" height="1212" alt="image" src="https://github.com/user-attachments/assets/f5f3dd74-974f-4538-927d-5505e1d9536a" />

After:
<img width="3454" height="1064" alt="image" src="https://github.com/user-attachments/assets/d33c59bc-a444-4e01-85ce-0a3b85a79de2" />

## Job Maintenance
- [ ] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
- [ ] I have collaborated with one or more job maintainers for the job(s) in this PR while developing it
- [ ] I prefer to receive any communications through GitHub only
