### PR TITLE
[BLM] Enforce gauge event ordering

### DIFF
--- a/src/parser/jobs/blm/changelog.tsx
+++ b/src/parser/jobs/blm/changelog.tsx
@@ -8,6 +8,11 @@ export const changelog = [
 	// 	contributors: [CONTRIBUTORS.YOU],
 	// },
 	{
+		date: new Date('2026-09-06'),
+		Changes: () => <>Ensure gauge update events process in the correct order when a spell updates gauge on both cast and damage events.</>,
+		contributors: [CONTRIBUTORS.AKAIRYU],
+	},
+	{
 		date: new Date('2026-01-11'),
 		Changes: () => <>Include High Thunder II in DoT uptime analysis, and small bugfix for instant cast availability in Hot Blizzard III information.</>,
 		contributors: [CONTRIBUTORS.AKAIRYU],

--- a/src/parser/jobs/blm/modules/Gauge.tsx
+++ b/src/parser/jobs/blm/modules/Gauge.tsx
@@ -230,6 +230,7 @@ export class Gauge extends CoreGauge {
 	}))
 
 	private previousGaugeState: BLMGaugeState = this.getGaugeState(this.parser.pull.timestamp)
+	private previousGaugeEventTimestamp: number = 0
 
 	override initialise() {
 		super.initialise()
@@ -419,9 +420,11 @@ export class Gauge extends CoreGauge {
 			// Queue event to tell other analysers about the change
 			this.parser.queueEvent({
 				type: 'blmgauge',
-				timestamp: this.parser.currentEpochTimestamp,
+				timestamp: this.parser.currentEpochTimestamp + (this.parser.currentEpochTimestamp === this.previousGaugeEventTimestamp ? 1: 0),
 				gaugeState: {...this.previousGaugeState},
 			})
+
+			this.previousGaugeEventTimestamp = this.parser.currentEpochTimestamp
 		}
 	}
 


### PR DESCRIPTION
## Pull request type

- [x] This is a bugfix to existing functionality

## Pull request details

- [x] The goal of this PR is detailed below:

A user in The Balance was asking for feedback on one of their logs, and I noted that one of their Astral Fire cycles was being dinged due to Fire IVs being cast prior to Astral Fire III being attained, despite them being preceded by a Flare cast, which sets Astral Fire to III
<img width="1575" height="585" alt="image" src="https://github.com/user-attachments/assets/8187bffb-7296-4283-99fe-1ff7fdb127dc" />

Since Flare consumes Umbral Hearts on cast, and updates the Astral Fire and Astral Soul gauges on damage, it produces two blmgauge update events. The issue in this log is that those events happened at the same timestamp, and the code in the RotationWatchdog that figures out when the player reached Astral Fire III ended up with the wrong timestamp, and so it assumed the first Fire IV of that phase was cast below AF3.

To work around this, we'll check to see if the new blmgauge event we're about to add is at the same timestamp as the previous event, and add a 1ms jitter to the second event, to make sure they get processed in the real order they occurred.

## Testing / Validation

- [x] I used the log(s) listed below to develop and test this bugfix:
  - https://xivanalysis.com/fflogs/banTvjHy1c2M6CL7/13/114
    - The 5:28 rotation should now be dinging for missing a Despair, instead of the "F4 not in AF3" error noted above

## Job Maintenance
- [x] I am active on the xivanalysis Discord and part of the job maintainers group for the job(s) in this PR
